### PR TITLE
chore: prepare repo for open-source release under project-arbr

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # CODEOWNERS — auto-requests review from owners on every PR touching these paths.
 # Format: pattern  @github-username
 
-*               @shubham-gyde
-server/src/     @shubham-gyde
-web/src/        @shubham-gyde
-clients/        @shubham-gyde
-docs/           @shubham-gyde
+*               @project-arbr/maintainers
+server/src/     @project-arbr/maintainers
+web/src/        @project-arbr/maintainers
+clients/        @project-arbr/maintainers
+docs/           @project-arbr/maintainers

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,52 @@
+name: Bug report
+description: Report something that isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please do **not** include API keys,
+        `.env` values, or other secrets in this report.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps, request body, or code to reproduce the behavior.
+      placeholder: |
+        1. Send POST /v1/chat/completions with ...
+        2. Observe ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      description: Release tag or git commit you are running.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Gateway (/v1/chat, OpenAI-compat)
+        - Routing / policy
+        - Dashboard (web)
+        - SDK (JS or Python)
+        - Deployment / config
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste any relevant logs or error output (secrets removed).
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/project-arbr/arbr-control-plane/security/advisories/new
+    about: Please report security issues privately via GitHub Security Advisories, not public issues.
+  - name: Questions & discussion
+    url: https://github.com/project-arbr/arbr-control-plane/discussions
+    about: Ask questions, share ideas, and get help from the community.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature request
+description: Suggest an idea or enhancement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem are you trying to solve? Why does it matter?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see? Describe the behavior or API.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you've thought about, if any.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  # Server (root) npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
+
+  # Dashboard npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
+
+  # JS SDK npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/clients/js"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
+
+  # Python SDK dependencies
+  - package-ecosystem: "pip"
+    directory: "/clients/python"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels: ["ci"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: Build & lint
+    name: Build & test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,5 +27,26 @@ jobs:
       - name: Build dashboard
         run: npm run web:build
 
+      - name: JS SDK unit tests
+        run: npm --prefix clients/js test
+
       - name: Docker build (smoke test)
         run: docker build -t arbr-control-plane:ci .
+
+  python-sdk:
+    name: Python SDK tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python SDK with dev extras
+        run: pip install -e ".[dev,langchain]"
+        working-directory: clients/python
+
+      - name: Run tests
+        run: python -m pytest -q
+        working-directory: clients/python

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules/
 .env
+# Internal / environment-specific deploy overrides — never commit to the public repo.
+docker-compose.gcp.yml
+docker-compose.*.local.yml
 .DS_Store
 dist/
 *.log

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,59 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a
+harassment-free experience for everyone, regardless of age, body size, visible or
+invisible disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal appearance,
+race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse,
+inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and
+  learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without
+  their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional
+  setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in response to
+any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an
+individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to
+the community leaders responsible for enforcement at **conduct@projectarbr.org**.
+All complaints will be reviewed and investigated promptly and fairly. All community
+leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1,
+available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,4 +66,4 @@ For security vulnerabilities, use
 ## License
 
 By contributing, you agree your contributions are licensed under the
-[Apache License 2.0](LICENSE).
+[MIT License](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,183 +1,21 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2026 Project Arbr Contributors
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship made available under
-      the License, as indicated by a copyright notice that is included in
-      or attached to the work (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean, as submitted to the Licensor for inclusion
-      in the Work by the copyright owner or by an individual or Legal Entity
-      authorized to submit on behalf of the copyright owner. For the purposes
-      of this definition, "submitted" means any form of electronic, verbal,
-      or written communication sent to the Licensor or its representatives,
-      including but not limited to communication on electronic mailing lists,
-      source code control systems, and issue tracking systems that are managed
-      by, or on behalf of, the Licensor for the purpose of discussing and
-      improving the Work, but excluding communication that is conspicuously
-      marked or designated in writing by the copyright owner as "Not a
-      Contribution."
-
-      "Contributor" shall mean Licensor and any Legal Entity on behalf of
-      whom a Contribution has been received by the Licensor and subsequently
-      incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a cross-claim
-      or counterclaim in a lawsuit) alleging that the Work or any
-      Contribution incorporated within the Work constitutes direct or
-      contributory patent infringement, then any patent licenses granted to
-      You under this License for that Work shall terminate as of the date
-      such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or Derivative
-          Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, You must include a readable copy of the
-          attribution notices contained within such NOTICE file, in
-          at least one of the following places: within a NOTICE text file
-          distributed as part of the Derivative Works; within the Source
-          form or documentation, if provided along with the Derivative
-          Works; or, within a display generated by the Derivative Works,
-          if and wherever such third-party notices normally appear. The
-          contents of the NOTICE file are for informational purposes only
-          and do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own license statement for Your modifications and
-      may provide additional grant of rights to use, copy, modify, merge,
-      publish, distribute, sublicense, and/or sell copies of Your
-      modifications, or for such Derivative Works as a whole, under terms
-      of Your choice, provided Your use, reproduction, and distribution of
-      the Work otherwise complies with the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or reproducing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or exemplary damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (even if such Contributor has been advised of the possibility
-      of such damages).
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may offer only
-      conditions that are consistent of Your own responsibility and not on
-      behalf of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability incurred
-      by, or claims asserted against, such Contributor by reason of your
-      accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   Copyright 2026 Project Arbr Contributors
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ work out of the box. Adding a provider key unlocks live gateway calls.
 ### Option A — Docker (one command)
 
 ```sh
-git clone https://github.com/shubham-gyde/arbr-ai-control-plane.git && cd arbr-ai-control-plane
+git clone https://github.com/project-arbr/arbr-control-plane.git && cd arbr-control-plane
 cp .env.example .env          # ready to run; no keys needed for the demo
 docker compose up             # Mongo + seeded app, dashboard at http://localhost:4100
 ```
@@ -437,13 +437,12 @@ control-plane/
 │   ├── recommend/engine.js     premium-overuse recommendation
 │   ├── api/routes.js           dashboard / admin API (incl. /api/models CRUD)
 │   └── index.js                boot: mongoose → registry.init() → express
-└── web/                        React + Vite + Tailwind dashboard (Gyde theme)
+└── web/                        React + Vite + Tailwind dashboard
                                 Settings → Models tab: add / edit / delete model entries
 ```
 
-This service is **standalone** — it has no dependency on the rest of the Arbr monorepo.
-The provider router is vendored under `server/src/providers/llm-router/` (originally from
-`@gyde/llm-router`), so the folder can be lifted into its own repo as-is.
+This service is **standalone**. The provider router is vendored under
+`server/src/providers/llm-router/`, so the folder can be lifted into its own repo as-is.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please **do not** open public issues for security vulnerabilities.
+
+Report them privately through GitHub Security Advisories:
+[Report a vulnerability](https://github.com/project-arbr/arbr-control-plane/security/advisories/new).
+
+We aim to acknowledge reports within 3 business days and to provide a remediation
+timeline after triage. Please give us a reasonable window to release a fix before any
+public disclosure (coordinated disclosure).
+
+When reporting, include where possible:
+
+- A description of the issue and its impact
+- Steps to reproduce (proof-of-concept if available)
+- Affected version / commit
+- Any suggested remediation
+
+## Scope
+
+This project is an LLM gateway and control plane. Areas of particular interest:
+
+- The admin API and dashboard authentication (`ARBR_ADMIN_KEY`)
+- Encryption of provider credentials at rest (`ARBR_ENCRYPTION_KEY`)
+- The OpenAI-compatible and native gateway endpoints
+- Any path that could leak stored provider keys
+
+## Supported versions
+
+This project is pre-1.0 and moves quickly. Security fixes are applied to the latest
+release on `main`. Pin a released version for production and upgrade promptly when
+advisories are published.
+
+## Deployment hardening
+
+`ARBR_ENCRYPTION_KEY` **must** be set in production — the server refuses to boot with
+`NODE_ENV=production` if it is missing, because the development fallback key is public.
+See `.env.example` and the deployment docs for the full production checklist.

--- a/clients/js/LICENSE
+++ b/clients/js/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Gyde
+Copyright (c) 2026 Project Arbr Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/clients/js/README.md
+++ b/clients/js/README.md
@@ -161,7 +161,7 @@ Because the response is OpenAI-compatible, it also works directly via the OpenAI
 
 ```js
 import OpenAI from "openai";
-const openai = new OpenAI({ apiKey: "ab_…", baseURL: "https://arbr.gyde.ai/v1" });
+const openai = new OpenAI({ apiKey: "ab_…", baseURL: "https://your-control-plane.example.com/v1" });
 const list = await openai.models.list();
 list.data.forEach(m => console.log(m.id));
 ```

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -2,7 +2,7 @@
   "name": "arbr-client",
   "version": "0.3.1",
   "description": "Official JS client for the Arbr AI control-plane gateway — one function to route, observe, and govern every LLM call.",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "main": "./src/index.js",
   "types": "./index.d.ts",
   "exports": {
@@ -41,5 +41,9 @@
     "type": "git",
     "url": "git+https://github.com/project-arbr/arbr-control-plane.git",
     "directory": "clients/js"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/project-arbr/arbr-control-plane/issues"
+  },
+  "homepage": "https://github.com/project-arbr/arbr-control-plane/tree/main/clients/js#readme"
 }

--- a/clients/python/LICENSE
+++ b/clients/python/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Gyde
+Copyright (c) 2026 Project Arbr Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -8,8 +8,8 @@ version = "0.3.1"
 description = "Official Python client for the Arbr AI control-plane gateway — one function to route, observe, and govern every LLM call."
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "Apache-2.0" }
-authors = [{ name = "Gyde" }]
+license = { text = "MIT" }
+authors = [{ name = "Project Arbr Contributors" }]
 keywords = [
   "llm", "ai", "gateway", "routing", "control-plane",
   "openai", "anthropic", "gemini", "bedrock", "cost",
@@ -25,6 +25,11 @@ classifiers = [
 ]
 # Zero runtime dependencies — stdlib only (urllib + asyncio).
 dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/project-arbr/arbr-control-plane/tree/main/clients/python#readme"
+Repository = "https://github.com/project-arbr/arbr-control-plane"
+Issues = "https://github.com/project-arbr/arbr-control-plane/issues"
 
 [project.optional-dependencies]
 # Optional LangChain integration (arbr_client.langchain.ArbrChatModel).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       ARBR_ENCRYPTION_KEY: ${ARBR_ENCRYPTION_KEY:-}
       # Provider keys (optional) — pass through from your .env if set.
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
-      # Redirect the OpenAI-compatible provider at a proxy/LiteLLM endpoint (e.g. Gyde LiteLLM).
+      # Redirect the OpenAI-compatible provider at a proxy/LiteLLM endpoint.
       OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -13,7 +13,7 @@ export default defineConfig({
       { text: 'Docs', link: '/quickstart' },
       { text: 'SDKs', link: '/sdk/js' },
       { text: 'API Reference', link: '/api-reference' },
-      { text: 'GitHub', link: 'https://github.com/gyde-ai/arbr' },
+      { text: 'GitHub', link: 'https://github.com/project-arbr/arbr-control-plane' },
     ],
 
     sidebar: [
@@ -74,7 +74,7 @@ export default defineConfig({
     ],
 
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/gyde-ai/arbr' }
+      { icon: 'github', link: 'https://github.com/project-arbr/arbr-control-plane' }
     ],
 
     search: {
@@ -83,11 +83,11 @@ export default defineConfig({
 
     footer: {
       message: 'Released under the MIT License.',
-      copyright: 'Copyright © 2024 Gyde AI'
+      copyright: 'Copyright © 2026 Project Arbr Contributors'
     },
 
     editLink: {
-      pattern: 'https://github.com/gyde-ai/arbr/edit/main/control-plane/docs/:path',
+      pattern: 'https://github.com/project-arbr/arbr-control-plane/edit/main/docs/:path',
       text: 'Edit this page on GitHub'
     }
   }

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,4 +1,4 @@
-/* Gyde brand colors — applied to VitePress brand slots */
+/* Arbr brand colors — applied to VitePress brand slots */
 :root {
   --vp-c-brand-1: #698200;
   --vp-c-brand-2: #7a9700;

--- a/docs/deployment-gcp.md
+++ b/docs/deployment-gcp.md
@@ -39,8 +39,8 @@ sudo apt install -y nginx certbot python3-certbot-nginx
 ## Step 5 — Clone the repo and configure
 
 ```sh
-git clone https://github.com/shubham-gyde/arbr-ai-control-plane.git
-cd arbr-ai-control-plane
+git clone https://github.com/project-arbr/arbr-control-plane.git
+cd arbr-control-plane
 cp .env.example .env
 nano .env
 ```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -32,8 +32,8 @@ Everything on **one port** (default 4100): the gateway (`/v1/chat`), the admin A
 ## Single-VM deployment (recommended)
 
 ```sh
-git clone https://github.com/gyde-ai/arbr
-cd arbr/control-plane
+git clone https://github.com/project-arbr/arbr-control-plane
+cd arbr-control-plane
 cp .env.example .env
 # Set in .env:
 #   ARBR_ADMIN_KEY=<generate with the command below>

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ hero:
       link: /quickstart
     - theme: alt
       text: View on GitHub
-      link: https://github.com/gyde-ai/arbr
+      link: https://github.com/project-arbr/arbr-control-plane
 
 features:
   - icon: 🔍

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,15 +12,15 @@ Get Arbr running and make your first routed AI call in under five minutes.
 ::: code-group
 
 ```sh [Docker (recommended)]
-git clone https://github.com/gyde-ai/arbr
-cd arbr/control-plane
+git clone https://github.com/project-arbr/arbr-control-plane
+cd arbr-control-plane
 cp .env.example .env
 docker compose up
 ```
 
 ```sh [Local — Node + MongoDB]
-git clone https://github.com/gyde-ai/arbr
-cd arbr/control-plane
+git clone https://github.com/project-arbr/arbr-control-plane
+cd arbr-control-plane
 npm run setup   # install deps + seed built-in models + demo request records
 npm run dev     # server on :4100, dashboard on :5173
 ```

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": false,
   "description": "Arbr Control Plane — open source AI gateway. A single REST endpoint that routes requests across LLM providers, tracks spend, enforces budgets, and applies human-approved routing rules.",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/project-arbr/arbr-control-plane.git"

--- a/server/src/providers/llm-router/index.js
+++ b/server/src/providers/llm-router/index.js
@@ -1,9 +1,7 @@
 // Vendored LLM router — a thin LangChain factory unifying providers.
 //
-// ORIGIN: copied from @gyde/llm-router (Arbr/packages/llm-router/js) and made
-// standalone for the Arbr Control Plane so this service has no monorepo
-// dependency. Change from the original: added a direct "anthropic" (Claude)
-// adapter alongside gemini / bedrock-nova / openai; added generic OpenAI-compat
+// Standalone module for the Arbr Control Plane: a direct "anthropic" (Claude)
+// adapter alongside gemini / bedrock-nova / openai, plus a generic OpenAI-compat
 // handler for deepseek / moonshot / xai / groq (any provider with a baseURL).
 //
 // Design notes:

--- a/server/src/security/secrets.js
+++ b/server/src/security/secrets.js
@@ -1,22 +1,35 @@
 // Encrypt provider API keys at rest (AES-256-GCM). Keys entered via the dashboard
 // are stored encrypted; they are never returned to the browser.
 //
-// The encryption key comes from ARBR_ENCRYPTION_KEY. If unset, a dev fallback is
-// used so the demo still runs — but a warning is printed, because storing keys
-// under a known dev secret is not safe for production. Set ARBR_ENCRYPTION_KEY
-// (any strong string) in real deployments.
+// The encryption key comes from ARBR_ENCRYPTION_KEY. Outside production, an insecure
+// dev fallback is used so the demo runs key-free — with a warning. In production the
+// fallback is refused: booting without ARBR_ENCRYPTION_KEY throws, because this is an
+// open-source project and the fallback value is public, so storing provider keys under
+// it would make them trivially decryptable by anyone. Set ARBR_ENCRYPTION_KEY (any
+// strong string) in real deployments.
 const crypto = require("crypto");
 
+// Public, intentionally-insecure constant: safe to ship only because it is refused in production.
 const DEV_FALLBACK = "arbr-dev-insecure-encryption-key-change-me";
 let warned = false;
 
 function secret() {
   const s = process.env.ARBR_ENCRYPTION_KEY;
   if (s && s.trim()) return s.trim();
+
+  // Never silently fall back to the public dev key in production — fail loud and early.
+  if (process.env.NODE_ENV === "production") {
+    throw new Error(
+      "[secrets] ARBR_ENCRYPTION_KEY is required in production. Without it, stored " +
+        "provider keys would be encrypted under a public, well-known dev key. Set " +
+        "ARBR_ENCRYPTION_KEY to a strong random string and restart."
+    );
+  }
+
   if (!warned) {
     console.warn(
       "[secrets] ARBR_ENCRYPTION_KEY is not set — using an insecure dev key for " +
-        "stored provider keys. Set ARBR_ENCRYPTION_KEY before production."
+        "stored provider keys. This is refused in production; set ARBR_ENCRYPTION_KEY there."
     );
     warned = true;
   }

--- a/web/src/components/Layout.jsx
+++ b/web/src/components/Layout.jsx
@@ -24,7 +24,7 @@ const FOOTER_LINK = { to: "/docs", label: "Docs" };
 function navClass({ isActive }) {
   return `mx-1 my-0.5 flex items-center rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
     isActive
-      ? "bg-gyde-green-600 text-white"
+      ? "bg-arbr-green-600 text-white"
       : "text-gray-400 hover:bg-white/8 hover:text-white"
   }`;
 }
@@ -33,7 +33,7 @@ function Wordmark() {
   return (
     <div className="flex items-baseline gap-0.5">
       <span className="text-xl font-bold tracking-tight text-white">ARBR</span>
-      <span className="text-xl font-bold text-gyde-green-400">.</span>
+      <span className="text-xl font-bold text-arbr-green-400">.</span>
     </div>
   );
 }
@@ -41,7 +41,7 @@ function Wordmark() {
 export default function Layout({ status, onSignOut, children }) {
   return (
     <div className="flex min-h-full">
-      <aside className="sticky top-0 flex h-screen w-56 flex-col bg-gyde-charcoal">
+      <aside className="sticky top-0 flex h-screen w-56 flex-col bg-arbr-charcoal">
         <div className="px-5 py-5">
           <Wordmark />
           <div className="mt-1 text-[11px] text-gray-500">Control Plane · Phase 1</div>
@@ -88,7 +88,7 @@ export default function Layout({ status, onSignOut, children }) {
                 Demo mode — no provider keys
               </span>
             ) : (
-              <span className="inline-flex items-center rounded-md border border-gyde-green-200 bg-gyde-green-50 px-2.5 py-1 text-xs font-medium text-gyde-green-700">
+              <span className="inline-flex items-center rounded-md border border-arbr-green-200 bg-arbr-green-50 px-2.5 py-1 text-xs font-medium text-arbr-green-700">
                 Live · {(status?.liveProviders || []).join(", ")}
               </span>
             )}

--- a/web/src/components/RequestsTable.jsx
+++ b/web/src/components/RequestsTable.jsx
@@ -31,7 +31,7 @@ function StatCard({ label, value, sub, highlight }) {
   return (
     <div className={`card px-5 py-4 ${highlight ? "border-red-200 bg-red-50" : ""}`}>
       <div className="label">{label}</div>
-      <div className={`mt-1 text-2xl font-bold ${highlight ? "text-red-600" : "text-gyde-charcoal"}`}>{value}</div>
+      <div className={`mt-1 text-2xl font-bold ${highlight ? "text-red-600" : "text-arbr-charcoal"}`}>{value}</div>
       {sub && <div className="mt-0.5 text-xs text-gray-400">{sub}</div>}
     </div>
   );
@@ -121,7 +121,7 @@ export default function RequestsTable({ fixedFilters = {}, hiddenFilterKeys = []
               key={p.label}
               onClick={() => { setPage(1); setActivePeriod(i); }}
               className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-                activePeriod === i ? "bg-white text-gyde-charcoal shadow-sm border border-gray-200" : "text-gray-500 hover:text-gyde-charcoal"
+                activePeriod === i ? "bg-white text-arbr-charcoal shadow-sm border border-gray-200" : "text-gray-500 hover:text-arbr-charcoal"
               }`}
             >
               {p.label}

--- a/web/src/components/ui.jsx
+++ b/web/src/components/ui.jsx
@@ -11,8 +11,8 @@ export function Tabs({ tabs, active, onChange }) {
           onClick={() => onChange(k)}
           className={`-mb-px border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
             active === k
-              ? "border-gyde-green-600 text-gyde-charcoal"
-              : "border-transparent text-gray-500 hover:text-gyde-charcoal"
+              ? "border-arbr-green-600 text-arbr-charcoal"
+              : "border-transparent text-gray-500 hover:text-arbr-charcoal"
           }`}
         >
           {label}
@@ -44,7 +44,7 @@ export function Card({ title, action, children, className = "" }) {
     <div className={`card p-6 ${className}`}>
       {(title || action) && (
         <div className="mb-4 flex items-center justify-between">
-          {title && <h3 className="text-base font-semibold text-gyde-charcoal">{title}</h3>}
+          {title && <h3 className="text-base font-semibold text-arbr-charcoal">{title}</h3>}
           {action}
         </div>
       )}
@@ -57,15 +57,15 @@ export function Stat({ label, value, sub }) {
   return (
     <div className="card p-6">
       <div className="label">{label}</div>
-      <div className="mt-2 text-3xl font-bold text-gyde-charcoal">{value}</div>
+      <div className="mt-2 text-3xl font-bold text-arbr-charcoal">{value}</div>
       {sub && <div className="mt-1 text-sm text-gray-500">{sub}</div>}
     </div>
   );
 }
 
 const BADGE_TONES = {
-  green: "bg-gyde-green-50 text-gyde-green-700 border-gyde-green-200",
-  charcoal: "bg-gray-100 text-gyde-charcoal border-gray-200",
+  green: "bg-arbr-green-50 text-arbr-green-700 border-arbr-green-200",
+  charcoal: "bg-gray-100 text-arbr-charcoal border-gray-200",
   amber: "bg-amber-50 text-amber-700 border-amber-200",
   indigo: "bg-indigo-50 text-indigo-700 border-indigo-200",
   violet: "bg-violet-50 text-violet-700 border-violet-200",
@@ -89,7 +89,7 @@ export function Table({ columns, rows, empty = "No data." }) {
         <thead>
           <tr className="border-b border-gray-200 text-left">
             {columns.map((c) => (
-              <th key={c.key} className="bg-gray-50 px-3 py-2 font-semibold text-gyde-charcoal first:rounded-tl-lg last:rounded-tr-lg">
+              <th key={c.key} className="bg-gray-50 px-3 py-2 font-semibold text-arbr-charcoal first:rounded-tl-lg last:rounded-tr-lg">
                 {c.header}
               </th>
             ))}
@@ -100,7 +100,7 @@ export function Table({ columns, rows, empty = "No data." }) {
             <tr><td colSpan={columns.length} className="px-3 py-8 text-center text-gray-400">{empty}</td></tr>
           ) : (
             rows.map((row, i) => (
-              <tr key={i} className="border-b border-gray-100 hover:bg-gyde-green-50">
+              <tr key={i} className="border-b border-gray-100 hover:bg-arbr-green-50">
                 {columns.map((c) => (
                   <td key={c.key} className="px-3 py-2 text-gray-700">
                     {c.render ? c.render(row) : row[c.key]}
@@ -120,7 +120,7 @@ export function Toggle({ checked, onChange, label }) {
     <button
       type="button"
       onClick={() => onChange(!checked)}
-      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${checked ? "bg-gyde-green-600" : "bg-gray-300"}`}
+      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${checked ? "bg-arbr-green-600" : "bg-gray-300"}`}
       aria-pressed={checked}
       aria-label={label}
     >
@@ -137,7 +137,7 @@ export function ConfirmDialog({ title, message, confirmLabel = "Confirm", onConf
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
       <div className="w-full max-w-sm rounded-xl border border-gray-200 bg-white p-6 shadow-xl">
-        <h3 className="text-base font-semibold text-gyde-charcoal">{title}</h3>
+        <h3 className="text-base font-semibold text-arbr-charcoal">{title}</h3>
         {message && <p className="mt-2 text-sm text-gray-500">{message}</p>}
         <div className="mt-5 flex justify-end gap-3">
           <button className="btn-ghost text-sm" onClick={onCancel}>Cancel</button>
@@ -159,7 +159,7 @@ export function CodeBlock({ code, lang }) {
       {lang && <span className="absolute left-3 top-2 text-[10px] uppercase tracking-wide text-gray-400">{lang}</span>}
       <button
         onClick={copy}
-        className="absolute right-2 top-2 rounded-md border border-gray-200 bg-white px-2 py-0.5 text-xs text-gray-500 hover:border-gyde-green-600 hover:text-gyde-charcoal"
+        className="absolute right-2 top-2 rounded-md border border-gray-200 bg-white px-2 py-0.5 text-xs text-gray-500 hover:border-arbr-green-600 hover:text-arbr-charcoal"
       >
         {copied ? "Copied" : "Copy"}
       </button>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -7,7 +7,7 @@
     height: 100%;
   }
   body {
-    @apply bg-gray-50 text-gyde-charcoal font-sans antialiased;
+    @apply bg-gray-50 text-arbr-charcoal font-sans antialiased;
   }
 }
 
@@ -19,21 +19,21 @@
     @apply inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium transition-colors;
   }
   .btn-primary {
-    @apply btn bg-gyde-charcoal text-white hover:bg-gyde-ink;
+    @apply btn bg-arbr-charcoal text-white hover:bg-arbr-ink;
   }
   .btn-secondary {
-    @apply btn bg-gyde-green-600 text-white hover:bg-gyde-green-700;
+    @apply btn bg-arbr-green-600 text-white hover:bg-arbr-green-700;
   }
   .btn-outline {
-    @apply btn border border-gray-200 text-gyde-charcoal hover:border-gyde-green-600 hover:bg-gyde-green-50;
+    @apply btn border border-gray-200 text-arbr-charcoal hover:border-arbr-green-600 hover:bg-arbr-green-50;
   }
   .btn-ghost {
-    @apply btn text-gray-500 hover:bg-gyde-green-50 hover:text-gyde-charcoal;
+    @apply btn text-gray-500 hover:bg-arbr-green-50 hover:text-arbr-charcoal;
   }
   .label {
     @apply text-xs font-medium uppercase tracking-wide text-gray-500;
   }
   .input {
-    @apply rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-gyde-green-600 focus:outline-none focus:ring-2 focus:ring-gyde-green-600/15;
+    @apply rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-arbr-green-600 focus:outline-none focus:ring-2 focus:ring-arbr-green-600/15;
   }
 }

--- a/web/src/pages/ApplicationDetail.jsx
+++ b/web/src/pages/ApplicationDetail.jsx
@@ -97,7 +97,7 @@ function ModelPicker({ models, excluded, onChange }) {
                     className={`flex cursor-pointer items-center gap-3 py-1.5 pr-3 pl-9 transition-colors hover:bg-gray-50 ${!included ? "opacity-40" : ""}`}
                   >
                     <input type="checkbox" checked={included} onChange={() => toggle(m.id)} className="rounded shrink-0" />
-                    <span className="flex-1 font-mono text-xs text-gyde-charcoal truncate">{m.id}</span>
+                    <span className="flex-1 font-mono text-xs text-arbr-charcoal truncate">{m.id}</span>
                     <Badge tone={TIER_TONE[m.tier] || "gray"}>{m.tier}</Badge>
                   </label>
                 );
@@ -246,7 +246,7 @@ function RoutingPolicyTab({ appName, initialAssignments, initialModelOptOut, mod
                   >
                     <div className="flex items-center gap-3">
                       <Badge tone={badge}>{label}</Badge>
-                      <span className="text-sm font-medium text-gyde-charcoal">{tasks.length} tasks</span>
+                      <span className="text-sm font-medium text-arbr-charcoal">{tasks.length} tasks</span>
                       <span className="hidden text-xs text-gray-400 sm:inline">{desc}</span>
                     </div>
                     <div className="flex items-center gap-3">
@@ -267,7 +267,7 @@ function RoutingPolicyTab({ appName, initialAssignments, initialModelOptOut, mod
                         <tbody>
                           {tasks.map((task) => (
                             <tr key={task.id} className="border-t border-gray-100">
-                              <td className="px-4 py-2 font-medium text-gyde-charcoal">{task.label}</td>
+                              <td className="px-4 py-2 font-medium text-arbr-charcoal">{task.label}</td>
                               <td className="px-4 py-2 text-xs text-gray-500">{task.description}</td>
                               <td className="px-4 py-2">
                                 <select
@@ -303,7 +303,7 @@ function RoutingPolicyTab({ appName, initialAssignments, initialModelOptOut, mod
               >
                 <div className="flex items-center gap-3">
                   <Badge tone="charcoal">Custom</Badge>
-                  <span className="text-sm font-medium text-gyde-charcoal">{globalPol.customTaskTypes.length} tasks</span>
+                  <span className="text-sm font-medium text-arbr-charcoal">{globalPol.customTaskTypes.length} tasks</span>
                   <span className="hidden text-xs text-gray-400 sm:inline">Task types seen in traffic, not in built-in catalog</span>
                 </div>
                 <Chevron open={expanded.custom} />
@@ -320,7 +320,7 @@ function RoutingPolicyTab({ appName, initialAssignments, initialModelOptOut, mod
                     <tbody>
                       {globalPol.customTaskTypes.map((taskId) => (
                         <tr key={taskId} className="border-t border-gray-100">
-                          <td className="px-4 py-2 font-mono text-sm font-medium text-gyde-charcoal">{taskId}</td>
+                          <td className="px-4 py-2 font-mono text-sm font-medium text-arbr-charcoal">{taskId}</td>
                           <td className="px-4 py-2">
                             <select
                               className="input w-full"
@@ -379,7 +379,7 @@ function AppOverview({ appName }) {
       {cards.map(({ label, value, sub, highlight }) => (
         <div key={label} className={`card px-5 py-4 ${highlight ? "border-red-200 bg-red-50" : ""}`}>
           <div className="label">{label}</div>
-          <div className={`mt-1 text-2xl font-bold ${highlight ? "text-red-600" : "text-gyde-charcoal"}`}>{value}</div>
+          <div className={`mt-1 text-2xl font-bold ${highlight ? "text-red-600" : "text-arbr-charcoal"}`}>{value}</div>
           {sub && <div className="mt-0.5 text-xs text-gray-400">{sub}</div>}
         </div>
       ))}
@@ -434,13 +434,13 @@ export default function ApplicationDetail() {
       {/* Breadcrumb + header */}
       <div>
         <div className="text-xs text-gray-400 mb-1">
-          <Link to="/applications" className="hover:text-gyde-charcoal">Applications</Link>
+          <Link to="/applications" className="hover:text-arbr-charcoal">Applications</Link>
           <span className="mx-1">/</span>
           <span>{appName}</span>
         </div>
         <div className="flex items-center justify-between gap-4">
           <div>
-            <h1 className="text-2xl font-bold text-gyde-charcoal">{appName}</h1>
+            <h1 className="text-2xl font-bold text-arbr-charcoal">{appName}</h1>
             {isKilled && (
               <span className="mt-1 inline-flex items-center rounded text-xs font-medium text-red-600 bg-red-100 px-2 py-0.5">
                 Disconnected — all requests blocked

--- a/web/src/pages/Applications.jsx
+++ b/web/src/pages/Applications.jsx
@@ -14,7 +14,7 @@ function AppCard({ app, stats, config, onToggleKill }) {
     <div className={`card flex flex-col gap-4 p-5 transition-all ${isKilled ? "border-red-200 bg-red-50/30" : ""}`}>
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
-          <Link to={`/applications/${encodeURIComponent(app)}`} className="text-base font-semibold text-gyde-charcoal hover:text-gyde-green-700 hover:underline truncate block">
+          <Link to={`/applications/${encodeURIComponent(app)}`} className="text-base font-semibold text-arbr-charcoal hover:text-arbr-green-700 hover:underline truncate block">
             {app}
           </Link>
           {isKilled ? (
@@ -22,8 +22,8 @@ function AppCard({ app, stats, config, onToggleKill }) {
               Disconnected
             </span>
           ) : (
-            <span className="mt-1 inline-flex items-center gap-1 text-xs font-medium text-gyde-green-700">
-              <span className="h-1.5 w-1.5 rounded-full bg-gyde-green-600 inline-block" />
+            <span className="mt-1 inline-flex items-center gap-1 text-xs font-medium text-arbr-green-700">
+              <span className="h-1.5 w-1.5 rounded-full bg-arbr-green-600 inline-block" />
               Active
             </span>
           )}
@@ -38,25 +38,25 @@ function AppCard({ app, stats, config, onToggleKill }) {
       <div className="grid grid-cols-2 gap-3 text-sm">
         <div>
           <div className="label">Requests</div>
-          <div className="font-semibold text-gyde-charcoal">{stats ? fmt.num(stats.requests) : "—"}</div>
+          <div className="font-semibold text-arbr-charcoal">{stats ? fmt.num(stats.requests) : "—"}</div>
         </div>
         <div>
           <div className="label">Cost</div>
-          <div className="font-semibold text-gyde-charcoal">{stats ? fmt.usd(stats.cost) : "—"}</div>
+          <div className="font-semibold text-arbr-charcoal">{stats ? fmt.usd(stats.cost) : "—"}</div>
         </div>
         <div>
           <div className="label">Success</div>
-          <div className={`font-semibold ${stats?.failures > 0 ? "text-red-600" : "text-gyde-charcoal"}`}>{successRate}</div>
+          <div className={`font-semibold ${stats?.failures > 0 ? "text-red-600" : "text-arbr-charcoal"}`}>{successRate}</div>
         </div>
         <div>
           <div className="label">Avg latency</div>
-          <div className="font-semibold text-gyde-charcoal">{stats ? fmt.ms(stats.avgLatency) : "—"}</div>
+          <div className="font-semibold text-arbr-charcoal">{stats ? fmt.ms(stats.avgLatency) : "—"}</div>
         </div>
       </div>
 
       <Link
         to={`/applications/${encodeURIComponent(app)}`}
-        className="mt-auto text-xs text-gyde-green-600 hover:underline self-start"
+        className="mt-auto text-xs text-arbr-green-600 hover:underline self-start"
       >
         View details →
       </Link>
@@ -104,7 +104,7 @@ export default function Applications() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-gyde-charcoal">Applications</h1>
+        <h1 className="text-2xl font-bold text-arbr-charcoal">Applications</h1>
         <p className="text-sm text-gray-500">Per-application traffic overview and controls. Apps appear as they generate requests.</p>
       </div>
 

--- a/web/src/pages/Audit.jsx
+++ b/web/src/pages/Audit.jsx
@@ -48,7 +48,7 @@ export default function Audit() {
       render: (r) => (
         <span className="flex items-center gap-2">
           <Badge tone={ENTITY_TONE[r.entity] || "gray"}>{r.entity}</Badge>
-          <span className="text-sm text-gyde-charcoal">{ACTION_LABELS[r.action] || r.action}</span>
+          <span className="text-sm text-arbr-charcoal">{ACTION_LABELS[r.action] || r.action}</span>
         </span>
       ),
     },
@@ -76,7 +76,7 @@ export default function Audit() {
   return (
     <div className="space-y-5">
       <div>
-        <h1 className="text-2xl font-bold text-gyde-charcoal">Audit log</h1>
+        <h1 className="text-2xl font-bold text-arbr-charcoal">Audit log</h1>
         <p className="text-sm text-gray-500">
           Immutable record of every admin action — rule changes, budget edits, key creation/revocation,
           governance settings.

--- a/web/src/pages/Budgets.jsx
+++ b/web/src/pages/Budgets.jsx
@@ -19,7 +19,7 @@ function actionLabel(action) {
 // Inline progress bar: green → amber (>80%) → red (breached).
 function SpendBar({ cap }) {
   const pct = Math.min(cap.pct ?? 0, 100);
-  const color = cap.breached ? "bg-red-500" : pct > 80 ? "bg-amber-400" : "bg-gyde-green-600";
+  const color = cap.breached ? "bg-red-500" : pct > 80 ? "bg-amber-400" : "bg-arbr-green-600";
   return (
     <div className="flex items-center gap-2">
       <div className="relative h-1.5 w-20 overflow-hidden rounded-full bg-gray-200">
@@ -65,11 +65,11 @@ function CapRow({ cap, onRefresh }) {
 
   return (
     <>
-      <tr className={`border-b border-gray-100 ${cap.breached && cap.enabled ? "bg-red-50/40" : "hover:bg-gyde-green-50"}`}>
+      <tr className={`border-b border-gray-100 ${cap.breached && cap.enabled ? "bg-red-50/40" : "hover:bg-arbr-green-50"}`}>
         <td className="px-3 py-2.5">
           <Toggle checked={cap.enabled} onChange={toggle} label="enabled" />
         </td>
-        <td className="px-3 py-2.5 text-sm font-medium text-gyde-charcoal">{scopeLabel(cap)}</td>
+        <td className="px-3 py-2.5 text-sm font-medium text-arbr-charcoal">{scopeLabel(cap)}</td>
         <td className="px-3 py-2.5 text-sm text-gray-600">{cap.period === "day" ? "Daily" : "Monthly"}</td>
         <td className="px-3 py-2.5 text-sm text-gray-600">{fmt.usd(cap.limit)}</td>
         <td className="px-3 py-2.5"><SpendBar cap={cap} /></td>
@@ -295,7 +295,7 @@ export default function Budgets({ onChange }) {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-xl font-bold text-gyde-charcoal">Budgets</h1>
+        <h1 className="text-xl font-bold text-arbr-charcoal">Budgets</h1>
         <p className="mt-1 text-sm text-gray-500">
           Stop or downgrade AI requests once a spending threshold is reached. Spend is measured across all
           requests logged in the current daily or monthly rolling window.
@@ -307,13 +307,13 @@ export default function Budgets({ onChange }) {
         <div className="card px-4 py-3 flex items-center gap-3">
           <div>
             <div className="label">Active constraints</div>
-            <div className="text-2xl font-bold text-gyde-charcoal">{active.length}</div>
+            <div className="text-2xl font-bold text-arbr-charcoal">{active.length}</div>
           </div>
         </div>
         <div className={`card px-4 py-3 flex items-center gap-3 ${breached.length > 0 ? "border-red-200 bg-red-50" : ""}`}>
           <div>
             <div className="label">Breached now</div>
-            <div className={`text-2xl font-bold ${breached.length > 0 ? "text-red-600" : "text-gyde-charcoal"}`}>
+            <div className={`text-2xl font-bold ${breached.length > 0 ? "text-red-600" : "text-arbr-charcoal"}`}>
               {breached.length}
             </div>
           </div>

--- a/web/src/pages/ByDimension.jsx
+++ b/web/src/pages/ByDimension.jsx
@@ -35,7 +35,7 @@ export default function ByDimension({ embedded = false }) {
     <div className="space-y-6">
       {!embedded && (
         <div>
-          <h1 className="text-2xl font-bold text-gyde-charcoal">By dimension</h1>
+          <h1 className="text-2xl font-bold text-arbr-charcoal">By dimension</h1>
           <p className="text-sm text-gray-500">Usage and cost, sliced the ways each audience needs to see them.</p>
         </div>
       )}

--- a/web/src/pages/Docs.jsx
+++ b/web/src/pages/Docs.jsx
@@ -71,7 +71,7 @@ function makeModel(opts) {
   return (
     <div className="max-w-4xl space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-gyde-charcoal">Documentation</h1>
+        <h1 className="text-2xl font-bold text-arbr-charcoal">Documentation</h1>
         <p className="text-sm text-gray-500">
           How to run Arbr, point an app at the gateway, and turn visibility into approved routing.
         </p>

--- a/web/src/pages/Governance.jsx
+++ b/web/src/pages/Governance.jsx
@@ -24,7 +24,7 @@ export default function Governance() {
   return (
     <div className="space-y-5">
       <div>
-        <h1 className="text-2xl font-bold text-gyde-charcoal">Governance</h1>
+        <h1 className="text-2xl font-bold text-arbr-charcoal">Governance</h1>
         <p className="text-sm text-gray-500">
           Safety controls, data lifecycle, and alerting for responsible AI usage.
         </p>
@@ -42,7 +42,7 @@ export default function Governance() {
             <div className="flex flex-col gap-4">
               <div className="flex items-center justify-between">
                 <div>
-                  <div className="text-sm font-medium text-gyde-charcoal">Enable maintenance mode</div>
+                  <div className="text-sm font-medium text-arbr-charcoal">Enable maintenance mode</div>
                   <div className="mt-0.5 text-xs text-gray-500">All gateway calls return 503 while this is on.</div>
                 </div>
                 <Toggle
@@ -125,7 +125,7 @@ export default function Governance() {
             </p>
             <div className="flex items-center justify-between">
               <div>
-                <div className="text-sm font-medium text-gyde-charcoal">Enable PII masking in logs</div>
+                <div className="text-sm font-medium text-arbr-charcoal">Enable PII masking in logs</div>
                 <div className="mt-0.5 text-xs text-gray-500">
                   Applies to: credit card, SSN, Aadhaar, email addresses, phone numbers.
                 </div>
@@ -142,7 +142,7 @@ export default function Governance() {
             <button className="btn-secondary" disabled={saving} onClick={save}>
               {saving ? "Saving…" : "Save"}
             </button>
-            {ok  && <span className="text-sm text-gyde-green-600">Saved.</span>}
+            {ok  && <span className="text-sm text-arbr-green-600">Saved.</span>}
             {err && <span className="text-sm text-red-600">{err}</span>}
           </div>
         </>

--- a/web/src/pages/Login.jsx
+++ b/web/src/pages/Login.jsx
@@ -28,8 +28,8 @@ export default function Login({ onAuthed }) {
     <div className="flex min-h-full items-center justify-center bg-gray-50 px-4">
       <form onSubmit={submit} className="card w-full max-w-sm p-8">
         <div className="flex items-baseline gap-0.5">
-          <span className="text-xl font-bold tracking-tight text-gyde-charcoal">ARBR</span>
-          <span className="text-xl font-bold text-gyde-green-600">.</span>
+          <span className="text-xl font-bold tracking-tight text-arbr-charcoal">ARBR</span>
+          <span className="text-xl font-bold text-arbr-green-600">.</span>
         </div>
         <p className="mt-1 text-sm text-gray-500">This instance requires the admin key.</p>
 

--- a/web/src/pages/Models.jsx
+++ b/web/src/pages/Models.jsx
@@ -62,7 +62,7 @@ function tierTone(tier) {
 
 function StatusDot({ live }) {
   return (
-    <span className={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${live ? "bg-gyde-green-600" : "bg-gray-300"}`} />
+    <span className={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${live ? "bg-arbr-green-600" : "bg-gray-300"}`} />
   );
 }
 
@@ -75,9 +75,9 @@ function Field({ label, children }) {
   );
 }
 
-const INPUT = "w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-gyde-green-600 focus:outline-none focus:ring-1 focus:ring-gyde-green-600";
+const INPUT = "w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-arbr-green-600 focus:outline-none focus:ring-1 focus:ring-arbr-green-600";
 const BTN   = "rounded-md px-3 py-1.5 text-sm font-medium transition-colors";
-const BTN_PRIMARY = `${BTN} bg-gyde-green-600 text-white hover:bg-gyde-green-700`;
+const BTN_PRIMARY = `${BTN} bg-arbr-green-600 text-white hover:bg-arbr-green-700`;
 const BTN_GHOST   = `${BTN} border border-gray-300 text-gray-700 hover:bg-gray-50`;
 const BTN_DANGER  = `${BTN} text-red-600 hover:bg-red-50`;
 
@@ -92,7 +92,7 @@ function BenchmarkBar({ dim, value }) {
       <span className="w-16 text-right text-gray-500 capitalize flex-shrink-0">{dim}</span>
       <div className="flex-1 h-1.5 rounded-full bg-gray-200 overflow-hidden">
         {pct != null && (
-          <div className="h-1.5 rounded-full bg-gyde-green-600 transition-all" style={{ width: `${pct}%` }} />
+          <div className="h-1.5 rounded-full bg-arbr-green-600 transition-all" style={{ width: `${pct}%` }} />
         )}
       </div>
       <span className="w-8 font-mono text-gray-600 flex-shrink-0">{pct != null ? pct : "—"}</span>
@@ -169,7 +169,7 @@ function ModelMetaPanel({ model }) {
         <div className="flex items-center gap-2">
           <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">Capabilities</span>
           {chips.map((c) => (
-            <span key={c} className="rounded-full bg-gyde-green-50 border border-gyde-green-200 px-2 py-0.5 text-xs font-medium text-gyde-green-700">{c}</span>
+            <span key={c} className="rounded-full bg-arbr-green-50 border border-arbr-green-200 px-2 py-0.5 text-xs font-medium text-arbr-green-700">{c}</span>
           ))}
         </div>
       )}
@@ -299,7 +299,7 @@ function ModelRow({ model, onRefresh }) {
         </svg>
 
         <div className="flex-1 min-w-0">
-          <div className="font-medium text-gyde-charcoal truncate">{model.label || model.id}</div>
+          <div className="font-medium text-arbr-charcoal truncate">{model.label || model.id}</div>
           {model.label && <div className="text-xs text-gray-400 truncate font-mono">{model.id}</div>}
         </div>
 
@@ -355,7 +355,7 @@ function ModelRow({ model, onRefresh }) {
           <div className="px-4 py-2.5 bg-gray-50 border-t border-gray-100 flex items-center gap-2">
             <button
               onClick={(e) => { e.stopPropagation(); setShowTest((v) => !v); setDeleting(false); }}
-              className={`${BTN} text-xs ${showTest ? "bg-gyde-green-50 text-gyde-green-700 border border-gyde-green-200" : "text-gray-600 hover:bg-gray-100"}`}
+              className={`${BTN} text-xs ${showTest ? "bg-arbr-green-50 text-arbr-green-700 border border-arbr-green-200" : "text-gray-600 hover:bg-gray-100"}`}
             >
               Test
             </button>
@@ -434,7 +434,7 @@ function AddModelForm({ providerId, models, onSave, onClose }) {
 
   return (
     <form onSubmit={submit} className="border border-gray-200 rounded-lg bg-gray-50 px-4 py-4 space-y-3">
-      <p className="text-sm font-semibold text-gyde-charcoal">Add model</p>
+      <p className="text-sm font-semibold text-arbr-charcoal">Add model</p>
       <div className="grid grid-cols-2 gap-3">
         <Field label="Model ID *">
           <input
@@ -456,7 +456,7 @@ function AddModelForm({ providerId, models, onSave, onClose }) {
               required
             />
             {autoFilled && (
-              <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-gyde-green-600 font-medium">
+              <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-arbr-green-600 font-medium">
                 auto-filled
               </span>
             )}
@@ -594,7 +594,7 @@ function BuiltinProviderDetail({ provider, models, onRefresh }) {
       {/* header */}
       <div className="flex items-start justify-between">
         <div>
-          <h2 className="text-lg font-semibold text-gyde-charcoal">{provider.label}</h2>
+          <h2 className="text-lg font-semibold text-arbr-charcoal">{provider.label}</h2>
           <div className="flex items-center gap-2 mt-1">
             <StatusDot live={isLive} />
             <span className="text-sm text-gray-500">
@@ -626,7 +626,7 @@ function BuiltinProviderDetail({ provider, models, onRefresh }) {
       </div>
 
       {testResult && (
-        <div className={`text-sm rounded-lg px-4 py-3 ${testResult.ok ? "bg-gyde-green-50 text-gyde-green-800 border border-gyde-green-200" : "bg-red-50 text-red-700 border border-red-200"}`}>
+        <div className={`text-sm rounded-lg px-4 py-3 ${testResult.ok ? "bg-arbr-green-50 text-arbr-green-800 border border-arbr-green-200" : "bg-red-50 text-red-700 border border-red-200"}`}>
           {testResult.ok ? `✓ Connected · model: ${testResult.model}${testResult.sample ? ` · "${testResult.sample}"` : ""}` : `✗ ${testResult.message}`}
         </div>
       )}
@@ -696,7 +696,7 @@ function CustomProviderDetail({ provider, models, onRefresh, onDeleted }) {
       <div className="flex items-start justify-between">
         <div>
           <div className="flex items-center gap-2">
-            <h2 className="text-lg font-semibold text-gyde-charcoal">{provider.label}</h2>
+            <h2 className="text-lg font-semibold text-arbr-charcoal">{provider.label}</h2>
             <Badge tone="gray">custom</Badge>
             {!provider.enabled && <Badge tone="amber">disabled</Badge>}
           </div>
@@ -716,7 +716,7 @@ function CustomProviderDetail({ provider, models, onRefresh, onDeleted }) {
       </div>
 
       {testResult && (
-        <div className={`text-sm rounded-lg px-4 py-3 ${testResult.ok ? "bg-gyde-green-50 text-gyde-green-800 border border-gyde-green-200" : "bg-red-50 text-red-700 border border-red-200"}`}>
+        <div className={`text-sm rounded-lg px-4 py-3 ${testResult.ok ? "bg-arbr-green-50 text-arbr-green-800 border border-arbr-green-200" : "bg-red-50 text-red-700 border border-red-200"}`}>
           {testResult.ok ? `✓ Connected · "${testResult.sample}"` : `✗ ${testResult.message}`}
         </div>
       )}
@@ -814,7 +814,7 @@ function CatalogProviderDetail({ provider, models, onRefresh }) {
       <div className="flex items-start justify-between">
         <div>
           <div className="flex items-center gap-2">
-            <h2 className="text-lg font-semibold text-gyde-charcoal">{provider.label}</h2>
+            <h2 className="text-lg font-semibold text-arbr-charcoal">{provider.label}</h2>
             <Badge tone="gray">not connected</Badge>
           </div>
           <p className="mt-1 text-sm text-gray-500">
@@ -840,7 +840,7 @@ function CatalogProviderDetail({ provider, models, onRefresh }) {
           <div className="flex flex-col gap-1 text-sm">
             <label className="font-medium text-gray-700">
               Base URL
-              {info.url && <span className="ml-2 text-xs font-normal text-gyde-green-700">· pre-filled with official endpoint</span>}
+              {info.url && <span className="ml-2 text-xs font-normal text-arbr-green-700">· pre-filled with official endpoint</span>}
               {!info.url && <span className="ml-2 text-xs font-normal text-amber-600">· account-specific, see hint below</span>}
             </label>
             <input
@@ -950,7 +950,7 @@ function ProviderSidebar({ allProviders, selected, onSelect, onRefresh }) {
             onClick={() => onSelect(p)}
             className={`w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-left transition-colors ${
               selected?.provider === p.provider && selected?.type === p.type
-                ? "bg-gyde-green-50 text-gyde-charcoal font-medium"
+                ? "bg-arbr-green-50 text-arbr-charcoal font-medium"
                 : "text-gray-600 hover:bg-gray-50"
             }`}
           >
@@ -1074,7 +1074,7 @@ export default function Models() {
     <div className="space-y-4">
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-xl font-semibold text-gyde-charcoal">Models</h1>
+          <h1 className="text-xl font-semibold text-arbr-charcoal">Models</h1>
           <p className="mt-1 text-sm text-gray-500">
             Manage provider connections and the model registry.
           </p>

--- a/web/src/pages/Overview.jsx
+++ b/web/src/pages/Overview.jsx
@@ -66,7 +66,7 @@ export default function Overview() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-gyde-charcoal">Overview</h1>
+        <h1 className="text-2xl font-bold text-arbr-charcoal">Overview</h1>
         <p className="text-sm text-gray-500">Total AI usage and cost across the organisation.</p>
       </div>
 

--- a/web/src/pages/Recommendations.jsx
+++ b/web/src/pages/Recommendations.jsx
@@ -24,7 +24,7 @@ export default function Recommendations({ embedded = false }) {
     <div className="space-y-6">
       <div className="flex items-start justify-between">
         <div>
-          {!embedded && <h1 className="text-2xl font-bold text-gyde-charcoal">Recommendations</h1>}
+          {!embedded && <h1 className="text-2xl font-bold text-arbr-charcoal">Recommendations</h1>}
           <p className="text-sm text-gray-500">Costed optimisation suggestions. The system proposes; the human decides.</p>
         </div>
         <button className="btn-primary" onClick={recompute} disabled={busy}>
@@ -36,7 +36,7 @@ export default function Recommendations({ embedded = false }) {
       {recs === null ? <Spinner /> : recs.length === 0 ? (
         <Card>
           <div className="py-8 text-center text-gray-400">
-            No recommendations yet. Click <span className="font-medium text-gyde-charcoal">Recompute</span> to analyse the logged data.
+            No recommendations yet. Click <span className="font-medium text-arbr-charcoal">Recompute</span> to analyse the logged data.
           </div>
         </Card>
       ) : (
@@ -46,7 +46,7 @@ export default function Recommendations({ embedded = false }) {
               <div className="flex items-start justify-between gap-4">
                 <div className="min-w-0">
                   <div className="flex items-center gap-2">
-                    <h3 className="text-base font-semibold text-gyde-charcoal">{r.title}</h3>
+                    <h3 className="text-base font-semibold text-arbr-charcoal">{r.title}</h3>
                     {r.status === "accepted" && <Badge tone="green">Accepted</Badge>}
                     {r.status === "dismissed" && <Badge tone="gray">Dismissed</Badge>}
                     {r.status === "pending" && <Badge tone="amber">Pending</Badge>}
@@ -59,7 +59,7 @@ export default function Recommendations({ embedded = false }) {
                 </div>
                 <div className="shrink-0 text-right">
                   <div className="label">Projected saving</div>
-                  <div className="text-2xl font-bold text-gyde-green-600">{fmt.usd(r.projectedSavings)}</div>
+                  <div className="text-2xl font-bold text-arbr-green-600">{fmt.usd(r.projectedSavings)}</div>
                   <div className="text-xs text-gray-500">{fmt.usd(r.currentCost)} → {fmt.usd(r.projectedCost)}</div>
                 </div>
               </div>

--- a/web/src/pages/Routing.jsx
+++ b/web/src/pages/Routing.jsx
@@ -280,7 +280,7 @@ function AiPolicyEditor({ models }) {
               >
                 <div className="flex items-center gap-3">
                   <Badge tone={badge}>{label}</Badge>
-                  <span className="text-sm font-medium text-gyde-charcoal">{tasks.length} tasks</span>
+                  <span className="text-sm font-medium text-arbr-charcoal">{tasks.length} tasks</span>
                   <span className="hidden text-xs text-gray-400 sm:inline">{desc}</span>
                 </div>
                 <div className="flex items-center gap-3">
@@ -302,7 +302,7 @@ function AiPolicyEditor({ models }) {
                     <tbody>
                       {tasks.map((task) => (
                         <tr key={task.id} className="border-t border-gray-100">
-                          <td className="px-4 py-2 font-medium text-gyde-charcoal">{task.label}</td>
+                          <td className="px-4 py-2 font-medium text-arbr-charcoal">{task.label}</td>
                           <td className="px-4 py-2 text-xs text-gray-500">{task.description}</td>
                           <td className="px-4 py-2">
                             <select
@@ -341,7 +341,7 @@ function AiPolicyEditor({ models }) {
             >
               <div className="flex items-center gap-3">
                 <Badge tone="charcoal">Custom</Badge>
-                <span className="text-sm font-medium text-gyde-charcoal">{pol.customTaskTypes.length} tasks</span>
+                <span className="text-sm font-medium text-arbr-charcoal">{pol.customTaskTypes.length} tasks</span>
                 <span className="hidden text-xs text-gray-400 sm:inline">Task types seen in traffic, not in the built-in catalog</span>
               </div>
               <div className="flex items-center gap-3">
@@ -362,7 +362,7 @@ function AiPolicyEditor({ models }) {
                   <tbody>
                     {pol.customTaskTypes.map((taskId) => (
                       <tr key={taskId} className="border-t border-gray-100">
-                        <td className="px-4 py-2 font-mono text-sm font-medium text-gyde-charcoal">{taskId}</td>
+                        <td className="px-4 py-2 font-mono text-sm font-medium text-arbr-charcoal">{taskId}</td>
                         <td className="px-4 py-2 text-xs text-gray-500">
                           {assignments[taskId]
                             ? "AI-evaluated · scored as mid tier"
@@ -421,7 +421,7 @@ export default function Routing({ onChange }) {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-gyde-charcoal">Routing</h1>
+        <h1 className="text-2xl font-bold text-arbr-charcoal">Routing</h1>
         <p className="text-sm text-gray-500">
           How requests are routed. A developer-pinned, connected model is honored as-is. When the model is
           <code className="mx-1 rounded bg-gray-100 px-1">auto</code>/omitted/unavailable, the router decides:
@@ -475,10 +475,10 @@ export default function Routing({ onChange }) {
             </p>
             <div className="space-y-2">
               {MODE_OPTIONS.map(([k, label, desc]) => (
-                <label key={k} className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 ${mode === k ? "border-gyde-green-600 bg-gyde-green-50" : "border-gray-200 hover:border-gray-300"}`}>
+                <label key={k} className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 ${mode === k ? "border-arbr-green-600 bg-arbr-green-50" : "border-gray-200 hover:border-gray-300"}`}>
                   <input type="radio" name="routingMode" className="mt-1" checked={mode === k} onChange={() => changeMode(k)} />
                   <div>
-                    <div className="text-sm font-medium text-gyde-charcoal">{label}</div>
+                    <div className="text-sm font-medium text-arbr-charcoal">{label}</div>
                     <div className="text-xs text-gray-500">{desc}</div>
                   </div>
                 </label>

--- a/web/src/pages/Settings.jsx
+++ b/web/src/pages/Settings.jsx
@@ -22,7 +22,7 @@ function KeyRow({ k, onToggle, onRevoke, onSave }) {
       <td className="py-2">
         {editing
           ? <input className="input w-36" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} />
-          : <span className="text-gyde-charcoal">{k.name}</span>}
+          : <span className="text-arbr-charcoal">{k.name}</span>}
       </td>
       <td className="py-2">
         {editing
@@ -108,8 +108,8 @@ function ApiKeys({ onChange }) {
       </p>
 
       {created && (
-        <div className="rounded-lg border border-gyde-green-200 bg-gyde-green-50 p-4">
-          <div className="text-sm font-medium text-gyde-charcoal">Key created: {created.name}</div>
+        <div className="rounded-lg border border-arbr-green-200 bg-arbr-green-50 p-4">
+          <div className="text-sm font-medium text-arbr-charcoal">Key created: {created.name}</div>
           <div className="mt-1 text-xs text-gray-600">
             Copy it now — <strong>this is the only time it will be shown.</strong>
           </div>
@@ -118,7 +118,7 @@ function ApiKeys({ onChange }) {
             <button className="btn-secondary" onClick={copyKey}>{copied ? "Copied" : "Copy"}</button>
             <button className="btn-ghost" onClick={() => setCreated(null)}>Dismiss</button>
           </div>
-          <div className="mt-4 border-t border-gyde-green-200 pt-4">
+          <div className="mt-4 border-t border-arbr-green-200 pt-4">
             <div className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-2">Share with your developer</div>
             <pre className="rounded bg-white p-3 text-xs leading-relaxed text-gray-700 overflow-x-auto whitespace-pre">{[
               `# .env`,
@@ -249,7 +249,7 @@ export default function Settings({ onChange }) {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-xl font-semibold text-gyde-charcoal">Settings</h1>
+        <h1 className="text-xl font-semibold text-arbr-charcoal">Settings</h1>
         <p className="mt-1 text-sm text-gray-500">Gateway configuration and API key management.</p>
       </div>
 
@@ -261,7 +261,7 @@ export default function Settings({ onChange }) {
             <p className="mb-4 text-sm text-gray-600">
               Used when a request sends <code className="rounded bg-gray-100 px-1">model: "auto"</code> or
               names no model. Configure providers and models in the{" "}
-              <a href="/models" className="text-gyde-green-600 hover:underline">Models</a> page.
+              <a href="/models" className="text-arbr-green-600 hover:underline">Models</a> page.
             </p>
             <div className="flex flex-wrap items-end gap-4">
               <div>
@@ -297,7 +297,7 @@ export default function Settings({ onChange }) {
           <Card title="Security">
             <div className="flex items-center justify-between">
               <div>
-                <div className="text-sm font-medium text-gyde-charcoal">Require API keys</div>
+                <div className="text-sm font-medium text-arbr-charcoal">Require API keys</div>
                 <div className="mt-0.5 text-xs text-gray-500">
                   When on, anonymous gateway calls are rejected (401). Leave off until every integrated app has a key.
                 </div>
@@ -310,19 +310,19 @@ export default function Settings({ onChange }) {
             <dl className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm sm:grid-cols-3">
               <div>
                 <dt className="text-xs font-medium uppercase tracking-wide text-gray-400">Control plane</dt>
-                <dd className="mt-0.5 font-mono text-gyde-charcoal">
+                <dd className="mt-0.5 font-mono text-arbr-charcoal">
                   {about ? `v${about.version}` : "—"}
                 </dd>
               </div>
               <div>
                 <dt className="text-xs font-medium uppercase tracking-wide text-gray-400">JS SDK (npm)</dt>
-                <dd className="mt-0.5 font-mono text-gyde-charcoal">
+                <dd className="mt-0.5 font-mono text-arbr-charcoal">
                   {about ? `arbr-client@${about.sdkJs}` : "—"}
                 </dd>
               </div>
               <div>
                 <dt className="text-xs font-medium uppercase tracking-wide text-gray-400">Python SDK (PyPI)</dt>
-                <dd className="mt-0.5 font-mono text-gyde-charcoal">
+                <dd className="mt-0.5 font-mono text-arbr-charcoal">
                   {about ? `arbr-client@${about.sdkPython}` : "—"}
                 </dd>
               </div>

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,11 +1,11 @@
 /** @type {import('tailwindcss').Config} */
-// Gyde design system, translated from the SIS MUI themes.
+// Arbr design system.
 export default {
   content: ["./index.html", "./src/**/*.{js,jsx}"],
   theme: {
     extend: {
       colors: {
-        gyde: {
+        arbr: {
           green: {
             50: "#f7fee7",
             100: "#e5fe96",


### PR DESCRIPTION
## Why
Preps the repo to go public under `project-arbr`. Closes the gaps a private
internal repo doesn't need but a public OSS one does: secrets exposure,
licensing consistency, identity/branding, and contributor scaffolding.

## What
**Security**
- `secrets.js` now fails to boot in production without `ARBR_ENCRYPTION_KEY`
  instead of silently falling back to a public dev key.
- `docker-compose.gcp.yml` gitignored so internal GCP infra can't be committed.

**Licensing & identity**
- Relicensed to MIT everywhere (was mixed Apache/MIT).
- All URLs, docs, and CODEOWNERS point at `project-arbr/arbr-control-plane`.
- Removed every "Gyde" reference, incl. renaming the `gyde-*` Tailwind token
  namespace to `arbr-*` (styling verified unchanged).

**Community health & CI**
- Added SECURITY.md, CODE_OF_CONDUCT.md, issue templates, dependabot.
- CI now runs JS + Python SDK tests.

## ⚠️ Do not merge yet
This PR *is* the migration. Merge only **after** the `project-arbr/arbr-control-plane`
repo and the `@project-arbr/maintainers` team exist — otherwise the new URLs 404 and
CODEOWNERS can't resolve.

## Verified locally
- Web build green (52 modules, styling unchanged)
- JS SDK tests 18/18; encryption fail-fast behavior confirmed
- No "Gyde"/internal refs remain; pattern secret-scan clean
- Python SDK test job unverified locally → relying on CI