### PR TITLE
chore: group dependabot PRs — one PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,40 +1,56 @@
 version: 2
 updates:
-  # Server (root) npm dependencies
+  # Server (root) npm dependencies — all bumps in one PR
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     labels: ["dependencies"]
+    groups:
+      server-deps:
+        patterns: ["*"]
 
-  # Dashboard npm dependencies
+  # Dashboard npm dependencies — all bumps in one PR
   - package-ecosystem: "npm"
     directory: "/web"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     labels: ["dependencies"]
+    groups:
+      web-deps:
+        patterns: ["*"]
 
-  # JS SDK npm dependencies
+  # JS SDK npm dependencies — all bumps in one PR
   - package-ecosystem: "npm"
     directory: "/clients/js"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     labels: ["dependencies"]
+    groups:
+      js-sdk-deps:
+        patterns: ["*"]
 
-  # Python SDK dependencies
+  # Python SDK dependencies — all bumps in one PR
   - package-ecosystem: "pip"
     directory: "/clients/python"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     labels: ["dependencies"]
+    groups:
+      python-sdk-deps:
+        patterns: ["*"]
 
-  # GitHub Actions
+  # GitHub Actions — all bumps in one PR
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 1
     labels: ["ci"]
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
## Problem

After the `dependabot.yml` was merged, Dependabot created **15 separate PRs** on its first run — one per outdated package. This flooded the PR list and made it impossible to review.

## Fix

Add `groups: { "*": patterns: ["*"] }` to each ecosystem entry so Dependabot bundles all bumps for that ecosystem into **one PR per week**:

| Ecosystem | PRs before | PRs after |
|---|---|---|
| npm (server) | N | 1 |
| npm (web) | N | 1 |
| npm (clients/js) | N | 1 |
| pip (clients/python) | N | 1 |
| github-actions | N | 1 |

The 15 existing dependabot PRs were closed manually. The next weekly run will create at most 5 grouped PRs (one per ecosystem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)