### PR TITLE
fix(gateway): stop truncating completions at 1024 tokens; report real finish_reason

### DIFF
--- a/server/src/gateway/openaiCompat.js
+++ b/server/src/gateway/openaiCompat.js
@@ -4,6 +4,7 @@
 // Streaming (stream: true) uses SSE: "data: {...}\n\n" chunks, ending with "data: [DONE]\n\n".
 const { v4: uuidv4 } = require("uuid");
 const { getRouter } = require("../providers/router");
+const { extractFinishReason } = require("../providers/llm-router");
 const { resolveRoute, invokeWithFallback } = require("./handler");
 const capEngine = require("../routing/capEngine");
 const pricing = require("../pricing/registry");
@@ -413,7 +414,7 @@ async function handleOpenAICompat(req, res) {
       const aiMsg = await boundModel.invoke(lcMessages);
       // Only parse tool_calls on turn 1; turn 2 always produces a text answer.
       const toolCalls = hasTurnTools ? translateToolCalls(aiMsg.tool_calls) : undefined;
-      const finishReason = toolCalls?.length ? "tool_calls" : "stop";
+      const finishReason = toolCalls?.length ? "tool_calls" : (extractFinishReason(aiMsg) || "stop");
       const um = aiMsg.usage_metadata || {};
       const promptTokens = um.input_tokens || 0;
       const completionTokens = um.output_tokens || 0;
@@ -596,7 +597,7 @@ async function handleOpenAICompat(req, res) {
       id: `chatcmpl-${requestId}`,
       object: "chat.completion.chunk",
       model: result.modelId,
-      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      choices: [{ index: 0, delta: {}, finish_reason: result.finishReason || "stop" }],
       usage: { prompt_tokens: promptTokens, completion_tokens: completionTokens, total_tokens: totalTokens },
     })}\n\n`);
 
@@ -653,7 +654,7 @@ async function handleOpenAICompat(req, res) {
     choices: [{
       index: 0,
       message: { role: "assistant", content: result.text },
-      finish_reason: "stop",
+      finish_reason: result.finishReason || "stop",
     }],
     usage: {
       prompt_tokens:     result.usage?.inputTokens  || 0,

--- a/server/src/providers/llm-router/index.js
+++ b/server/src/providers/llm-router/index.js
@@ -14,6 +14,14 @@
 
 const SUPPORTED_PROVIDERS = ["gemini", "bedrock-nova", "openai", "anthropic", "deepseek", "moonshot", "xai", "groq", "litellm"];
 
+// Output cap applied ONLY when neither the caller nor the provider config specifies
+// max_tokens. The old default of 1024 silently truncated normal completions mid-sentence
+// (providers reported stop_reason "max_tokens", which the gateway then masked as "stop").
+// Kept high so a missing client max_tokens does not cut answers short; clients should still
+// pass their own value, and the global maxTokensGuardrail setting clamps the ceiling.
+// Override with ARBR_DEFAULT_MAX_TOKENS.
+const DEFAULT_MAX_TOKENS = Number(process.env.ARBR_DEFAULT_MAX_TOKENS) || 4096;
+
 function createRouter(options) {
   if (!options || typeof options !== "object") {
     throw new Error("createRouter: options is required");
@@ -73,6 +81,7 @@ function createRouter(options) {
           modelId: cfg.model,
           latencyMs,
           usage: extractUsage(response),
+          finishReason: extractFinishReason(response),
         };
         if (onTrace) {
           try { onTrace({ ...result, ok: true }); } catch { /* swallow trace errors */ }
@@ -113,7 +122,7 @@ function rejectsSamplingParams(modelId) {
 
 function loadProviderModel(providerId, cfg, { temperature, maxTokens }) {
   const t = temperature != null ? temperature : (cfg.temperature != null ? cfg.temperature : 0.3);
-  const mx = maxTokens != null ? maxTokens : (cfg.maxTokens != null ? cfg.maxTokens : 1024);
+  const mx = maxTokens != null ? maxTokens : (cfg.maxTokens != null ? cfg.maxTokens : DEFAULT_MAX_TOKENS);
   if (providerId === "gemini") {
     const { ChatGoogleGenerativeAI } = require("@langchain/google-genai");
     return new ChatGoogleGenerativeAI({
@@ -211,4 +220,22 @@ function extractUsage(response) {
   };
 }
 
-module.exports = { createRouter, SUPPORTED_PROVIDERS };
+// Normalize a provider's native stop/finish reason into an OpenAI finish_reason value
+// ("stop" | "length" | "tool_calls" | "content_filter"). Each SDK names the field
+// differently: Bedrock Converse → stopReason, Anthropic → stop_reason, OpenAI →
+// finish_reason, Gemini → finishReason. Returns undefined when none is present so callers
+// can fall back to their own default.
+function extractFinishReason(response) {
+  const rm = (response && response.response_metadata) || {};
+  const ak = (response && response.additional_kwargs) || {};
+  const raw = rm.stopReason || rm.stop_reason || rm.finishReason || rm.finish_reason || ak.stop_reason;
+  if (!raw) return undefined;
+  const s = String(raw).toLowerCase();
+  if (s === "max_tokens" || s === "length" || s === "model_length" || s === "max_output_tokens") return "length";
+  if (s.includes("tool") || s.includes("function")) return "tool_calls";
+  if (s.includes("content") || s === "safety" || s === "recitation" || s === "blocklist") return "content_filter";
+  // end_turn, stop, stop_sequence, eos, complete, etc. → normal completion.
+  return "stop";
+}
+
+module.exports = { createRouter, SUPPORTED_PROVIDERS, extractFinishReason };


### PR DESCRIPTION
## Problem

Long answers from `gyde-chat-client` (and any client) were getting cut off mid-sentence. Root-caused on the live instance to two gateway defects:

1. **Hardcoded 1024-token default.** When a client omits `max_tokens`, `llm-router` applied a `1024` default (`loadProviderModel`), truncating normal completions. Confirmed live: nova-lite with no `max_tokens` returned Bedrock `stopReason: "max_tokens"` at exactly **1024** output tokens (cut mid-sentence); with a higher cap it returned `end_turn` and completed cleanly (1364 tokens).

2. **Real stop reason discarded.** The gateway hardcoded `finish_reason: "stop"` on every response. A length-truncated answer was reported to clients as a clean stop, so the client could neither detect the cut nor auto-continue.

## Changes

- `DEFAULT_MAX_TOKENS` constant (4096, override via `ARBR_DEFAULT_MAX_TOKENS`) replaces the `1024` literal. Clients still control their own `max_tokens`; the existing `maxTokensGuardrail` setting clamps the ceiling.
- `extractFinishReason()` normalizes each provider's native field (Bedrock `stopReason`, Anthropic `stop_reason`, Gemini `finishReason`, OpenAI `finish_reason`) into the OpenAI value (`stop` / `length` / `tool_calls` / `content_filter`), wired through the streaming, native-tool, and non-streaming paths.

## Testing

- `extractFinishReason` covered by 11 unit cases across all four providers (truncated / complete / tool / safety / fallback / absent).
- Syntax-checked; module loads and exports verified.
- Live repro confirmed the 1024 truncation and that a higher cap resolves it.

## Note (possible second layer)

The original screenshot stopped at 83 tokens, below 1024, so for that specific request the chat client likely sent its own small `max_tokens`. This PR fixes the Arbr-side default and the masked stop reason; if the client is also sending a low `max_tokens`, that is a separate change on `gyde-chat-client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
