### PR TITLE
feat(routing): difficulty-aware classification signal

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "setup": "npm install && npm --prefix web install && npm run seed:models && npm run seed",
     "dev": "concurrently -n server,web -c blue,green \"npm run server:dev\" \"npm run web\"",
     "smoke:router": "node server/scripts/smoke-router.js",
+    "smoke:classify": "node server/scripts/classify-smoke.js",
     "lint": "eslint server/src",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",

--- a/server/scripts/classify-smoke.js
+++ b/server/scripts/classify-smoke.js
@@ -1,0 +1,36 @@
+// Pure-logic smoke test for the classifier (no DB / no provider keys needed).
+// Run: npm run smoke:classify
+const c = require("../src/classify/classifier");
+
+let pass = 0, fail = 0;
+const ok = (cond, msg) => { if (cond) { pass++; } else { fail++; console.log("FAIL:", msg); } };
+
+// Latest user turn drives classification (not the first turn of a conversation).
+const convo = [
+  { role: "user", content: "translate hello to french" },
+  { role: "assistant", content: "bonjour" },
+  { role: "user", content: "now write me a python web scraper for this site" },
+];
+ok(c.lastUserText(convo).includes("python web scraper"), "lastUserText = latest user turn");
+ok(c.firstUserText(convo).includes("translate"), "firstUserText = first turn (unchanged)");
+ok(c.classify({ messages: convo }).taskType === "coding", "classify uses latest turn -> coding");
+
+// Difficulty: easy vs hard instances of the SAME task family route to different tiers.
+ok(c.tierForTask("coding") === "mid", "coding default tier = mid");
+ok(c.estimateDifficulty("rename this var", "coding") === "light", "trivial coding -> light");
+ok(c.estimateDifficulty(
+  "design and implement an end-to-end distributed scheduler, step by step, across multiple services",
+  "coding") === "premium", "complex multi-step coding -> premium");
+
+// Difficulty label normalization.
+ok(c.normalizeDifficulty("HARD") === "premium", "normalize HARD -> premium");
+ok(c.normalizeDifficulty("easy") === "light", "normalize easy -> light");
+ok(c.normalizeDifficulty("medium") === "mid", "normalize medium -> mid");
+ok(c.normalizeDifficulty("banana") === null, "normalize junk -> null");
+
+// No keyword match -> safe default.
+ok(c.classify({ messages: [{ role: "user", content: "zxcv qwer" }] }).taskType === "content generation",
+  "no match -> content generation default");
+
+console.log(`${pass}/${pass + fail} passed`);
+process.exit(fail ? 1 : 0);

--- a/server/src/classify/classifier.js
+++ b/server/src/classify/classifier.js
@@ -89,10 +89,7 @@ const RULES = [
   ["content generation",            ["write a", "draft", "generate a", "compose", "create a post", "blog", "marketing"]],
 ];
 
-function firstUserText(messages) {
-  if (!Array.isArray(messages)) return "";
-  const valid = messages.filter((x) => x != null);
-  const m = valid.find((x) => (x.role || "user").toLowerCase() === "user") || valid[0];
+function messageText(m) {
   if (!m) return "";
   if (typeof m.content === "string") return m.content;
   if (Array.isArray(m.content)) {
@@ -101,28 +98,102 @@ function firstUserText(messages) {
   return String(m.content || "");
 }
 
+function firstUserText(messages) {
+  if (!Array.isArray(messages)) return "";
+  const valid = messages.filter((x) => x != null);
+  const m = valid.find((x) => (x.role || "user").toLowerCase() === "user") || valid[0];
+  return messageText(m);
+}
+
+// The LATEST user turn — what the model is actually being asked right now. Routing must
+// classify this, not the first turn of a long conversation (which is stale by turn 2).
+function lastUserText(messages) {
+  if (!Array.isArray(messages)) return "";
+  const valid = messages.filter((x) => x != null);
+  for (let i = valid.length - 1; i >= 0; i--) {
+    if ((valid[i].role || "user").toLowerCase() === "user") return messageText(valid[i]);
+  }
+  return messageText(valid[valid.length - 1]);
+}
+
+// ── Difficulty signal ───────────────────────────────────────────────────────
+// Each task type has a default tier; an individual request can be easier or harder than
+// that. difficulty lets the router right-size the model (cheap for trivial, strong for hard)
+// instead of routing every instance of a task type to the same model.
+const _TIER_BY_TASK = Object.fromEntries(TASK_CATALOG.map((t) => [t.id, t.tier]));
+function tierForTask(taskType) { return _TIER_BY_TASK[String(taskType || "").toLowerCase()] || null; }
+
+const TIER_ORDER = ["light", "mid", "premium"];
+function normalizeDifficulty(v) {
+  const s = String(v || "").toLowerCase().trim();
+  if (["light", "easy", "low", "simple", "trivial"].includes(s)) return "light";
+  if (["mid", "medium", "moderate", "normal"].includes(s)) return "mid";
+  if (["premium", "hard", "high", "complex", "difficult"].includes(s)) return "premium";
+  return null;
+}
+function clamp01(n) { return Math.max(0, Math.min(1, Number(n))); }
+
+// Cheap heuristic difficulty for the keyword path (no LLM estimate available). Starts at the
+// task's catalog tier and nudges one step by surface signals.
+const HARD_CUES = /\b(step by step|step-by-step|and then|after that|multiple steps|several steps|design|architect|optimi[sz]e|trade-?offs?|edge cases?|end[- ]to[- ]end|across (?:multiple|several)|refactor|migrat|root cause)\b/i;
+function estimateDifficulty(text, taskType) {
+  const t = text || "";
+  let idx = TIER_ORDER.indexOf(tierForTask(taskType) || "mid");
+  if (idx < 0) idx = 1;
+  const codeBlocks = (t.match(/```/g) || []).length;
+  if (t.length < 80 && !HARD_CUES.test(t)) idx = Math.max(0, idx - 1);
+  if (HARD_CUES.test(t) || t.length > 1500 || codeBlocks >= 2) idx = Math.min(2, idx + 1);
+  return TIER_ORDER[idx];
+}
+
+// Last complete {...} JSON block in text. Local copy (a require on aiPolicy would be circular,
+// since aiPolicy imports this module for TASK_TYPES/TASK_CATALOG).
+function parseJsonBlock(text) {
+  let depth = 0, end = -1;
+  for (let i = (text || "").length - 1; i >= 0; i--) {
+    const ch = text[i];
+    if (ch === "}") { if (depth === 0) end = i; depth++; }
+    else if (ch === "{") {
+      depth--;
+      if (depth === 0 && end !== -1) {
+        try { return JSON.parse(text.slice(i, end + 1)); } catch { end = -1; depth = 0; }
+      }
+    }
+  }
+  return null;
+}
+
+// Pick a cheap, fast model for classification instead of the (possibly premium) default.
+function pickClassifierModel(eff) {
+  const pricing = require("../pricing/registry");
+  const light = eff.defaultModel ? pricing.suggestLightTarget(eff.defaultModel) : null;
+  if (light && (eff.liveIds || []).includes(light.provider)) return light;
+  return { provider: eff.defaultProvider, model: eff.defaultModel };
+}
+
 // Returns { taskType, source: "manual" | "auto", confidence }.
 // confidence: manual = 1.0, a keyword hit = 0.9, the safe-default fallthrough = 0.3.
 function classify({ taskType, messages }) {
   if (taskType && String(taskType).trim()) {
-    return { taskType: String(taskType).trim().toLowerCase(), source: "manual", confidence: 1.0 };
+    return { taskType: String(taskType).trim().toLowerCase(), source: "manual", confidence: 1.0, difficulty: null };
   }
-  const text = firstUserText(messages).toLowerCase();
+  const text = lastUserText(messages).toLowerCase();
   for (const [type, keywords] of RULES) {
     if (keywords.some((kw) => text.includes(kw))) {
-      return { taskType: type, source: "auto", confidence: 0.9 };
+      return { taskType: type, source: "auto", confidence: 0.9, difficulty: estimateDifficulty(text, type) };
     }
   }
-  return { taskType: "content generation", source: "auto", confidence: 0.3 }; // safe default
+  // safe default
+  return { taskType: "content generation", source: "auto", confidence: 0.3, difficulty: estimateDifficulty(text, "content generation") };
 }
 
 // ── LLM fallback ──────────────────────────────────────────────────────────────
 
 // Tiny in-memory cache so identical inputs aren't re-classified (bounds cost).
 const LLM_CACHE_MAX = 2000;
-const _llmCache = new Map(); // sha(firstUserText) -> taskType
+const _llmCache = new Map(); // sha(lastUserText) -> { taskType, difficulty, confidence }
 function cacheKey(messages) {
-  return crypto.createHash("sha256").update(firstUserText(messages)).digest("hex");
+  return crypto.createHash("sha256").update(lastUserText(messages)).digest("hex");
 }
 
 function normalizeLabel(text) {
@@ -134,27 +205,37 @@ function normalizeLabel(text) {
   return null;
 }
 
-// One LLM call on the DEFAULT model → a task type from TASK_TYPES, or null.
+// One LLM call on a CHEAP model → { taskType, difficulty, confidence } from TASK_TYPES, or null.
 async function classifyWithLLM({ messages, router, eff }) {
   if (!router || !eff || !eff.defaultProvider) return null;
-  const text = firstUserText(messages).slice(0, 800);
+  const text = lastUserText(messages).slice(0, 800);
   const prompt =
-    `You are a task classifier. Classify the user request into EXACTLY ONE of these task types:\n` +
-    `${TASK_TYPES.join(", ")}\n` +
-    `Respond with only the task type, nothing else.\n\nRequest:\n"""${text}"""`;
+    `You are a task classifier for an AI gateway. Classify the user request and rate its difficulty.\n` +
+    `taskType MUST be EXACTLY ONE of: ${TASK_TYPES.join(", ")}\n` +
+    `difficulty: "light" = trivial/short, "mid" = moderate, "premium" = complex, multi-step, or deep reasoning.\n` +
+    `Return ONLY a JSON object: {"taskType": "...", "difficulty": "light|mid|premium", "confidence": 0-1}\n\n` +
+    `Request:\n"""${text}"""`;
+  const m = pickClassifierModel(eff);
   const result = await router.complete({
     messages: [{ role: "user", content: prompt }],
-    providerOverride: eff.defaultProvider,
-    modelOverride: eff.defaultModel,
+    providerOverride: m.provider,
+    modelOverride: m.model,
     temperature: 0,
     maxTokens: 256, // headroom for "thinking" models (e.g. Gemini 2.5)
   });
-  const label = normalizeLabel(result.text);
+  const parsed = parseJsonBlock(result.text || "");
+  let label = parsed ? normalizeLabel(parsed.taskType) : null;
+  const difficulty = parsed ? normalizeDifficulty(parsed.difficulty) : null;
+  const confidence = parsed && parsed.confidence != null && !isNaN(Number(parsed.confidence))
+    ? clamp01(parsed.confidence) : null;
+  if (!label) label = normalizeLabel(result.text); // fallback: substring scan of raw text
   if (!label) return null;
   return {
     label,
-    provider: result.providerId || eff.defaultProvider,
-    model: result.modelId || eff.defaultModel,
+    difficulty,
+    confidence,
+    provider: result.providerId || m.provider,
+    model: result.modelId || m.model,
     usage: result.usage,
     latencyMs: result.latencyMs,
   };
@@ -168,21 +249,23 @@ async function classifyWithLLM({ messages, router, eff }) {
 // is off, the keyword heuristic decides.
 async function classifyTask({ taskType, messages, router, eff, useLLM }) {
   if (taskType && String(taskType).trim()) {
-    return { taskType: String(taskType).trim().toLowerCase(), method: "provided", confidence: 1.0, llm: null };
+    return { taskType: String(taskType).trim().toLowerCase(), method: "provided", confidence: 1.0, difficulty: null, llm: null };
   }
   if (useLLM && router && eff && (eff.liveIds || []).length) {
     const key = cacheKey(messages);
     const hit = _llmCache.get(key);
-    if (hit) return { taskType: hit, method: "ai", confidence: 0.8, llm: null };
+    if (hit) return { taskType: hit.taskType, method: "ai", confidence: hit.confidence ?? 0.8, difficulty: hit.difficulty || null, llm: null };
     try {
       const r = await classifyWithLLM({ messages, router, eff });
       if (r && r.label) {
+        const entry = { taskType: r.label, difficulty: r.difficulty || null, confidence: r.confidence };
         if (_llmCache.size >= LLM_CACHE_MAX) _llmCache.delete(_llmCache.keys().next().value);
-        _llmCache.set(key, r.label);
+        _llmCache.set(key, entry);
         return {
           taskType: r.label,
           method: "ai",
-          confidence: 0.8,
+          confidence: r.confidence ?? 0.8,
+          difficulty: r.difficulty || null,
           llm: { provider: r.provider, model: r.model, usage: r.usage, latencyMs: r.latencyMs },
         };
       }
@@ -191,7 +274,10 @@ async function classifyTask({ taskType, messages, router, eff, useLLM }) {
     }
   }
   const kw = classify({ taskType: null, messages });
-  return { taskType: kw.taskType, method: "keyword", confidence: kw.confidence, llm: null };
+  return { taskType: kw.taskType, method: "keyword", confidence: kw.confidence, difficulty: kw.difficulty || null, llm: null };
 }
 
-module.exports = { classify, classifyTask, classifyWithLLM, TASK_TYPES, TASK_CATALOG };
+module.exports = {
+  classify, classifyTask, classifyWithLLM, TASK_TYPES, TASK_CATALOG,
+  firstUserText, lastUserText, estimateDifficulty, normalizeDifficulty, tierForTask,
+};

--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -106,6 +106,8 @@ async function resolveRoute(body, { router, eff, application, workflow, appConfi
   });
   const taskType = cls.taskType;
   const classifiedBy = cls.method;
+  const difficulty = cls.difficulty || null;
+  const confidence = typeof cls.confidence === "number" ? cls.confidence : null;
 
   let served, routingDecision;
   if (explicit) {
@@ -129,7 +131,10 @@ async function resolveRoute(body, { router, eff, application, workflow, appConfi
       const aiMap = appDbConfig?.aiPolicyAssignments
         ? appDbConfig.aiPolicyAssignments
         : await aiPolicy.getEffective();
-      const hit = aiPolicy.lookup(aiMap, taskType);
+      // A low-confidence classification shouldn't drive a difficulty-based downgrade;
+      // fall back to the task's default policy pick when we're unsure.
+      const effDifficulty = (confidence == null || confidence >= 0.5) ? difficulty : null;
+      const hit = aiPolicy.resolveModel({ map: aiMap, taskType, difficulty: effDifficulty, eff });
       if (hit && eff.liveIds.includes(hit.provider)) {
         served = { provider: hit.provider, model: hit.model };
         routingDecision = "ai";
@@ -169,7 +174,7 @@ async function resolveRoute(body, { router, eff, application, workflow, appConfi
     }
   }
 
-  return { served, routingDecision, taskType, classifiedBy, cls };
+  return { served, routingDecision, taskType, classifiedBy, cls, difficulty, confidence };
 }
 
 async function handleChat(req, res) {
@@ -235,9 +240,9 @@ async function handleChat(req, res) {
     allowedModels: req.apiKey?.allowedModels || [],
     defaultModel: req.apiKey?.defaultModel || null,
   };
-  let served, routingDecision, taskType, classifiedBy, cls;
+  let served, routingDecision, taskType, classifiedBy, cls, difficulty, confidence;
   try {
-    ({ served, routingDecision, taskType, classifiedBy, cls } =
+    ({ served, routingDecision, taskType, classifiedBy, cls, difficulty, confidence } =
       await resolveRoute(body, { router, eff, application: meta.application, workflow: meta.workflow, appConfig, appDbConfig: appCfg }));
   } catch (err) {
     if (err.code === "model_not_allowed") {
@@ -315,7 +320,7 @@ async function handleChat(req, res) {
         logger.write({
           requestId, timestamp, ...meta,
           provider: cached.provider, model: cached.model, modelRequested,
-          taskType, classifiedBy,
+          taskType, classifiedBy, difficulty, confidence,
           promptTokens: cached.usage?.inputTokens || 0,
           completionTokens: cached.usage?.outputTokens || 0,
           totalTokens: cached.usage?.totalTokens || 0,
@@ -383,7 +388,7 @@ async function handleChat(req, res) {
     logger.write({
       requestId, timestamp, ...meta,
       provider: result.providerId, model: result.modelId, modelRequested,
-      taskType, classifiedBy,
+      taskType, classifiedBy, difficulty, confidence,
       promptTokens: result.usage?.inputTokens || 0,
       completionTokens: result.usage?.outputTokens || 0,
       totalTokens: result.usage?.totalTokens || 0,

--- a/server/src/gateway/openaiCompat.js
+++ b/server/src/gateway/openaiCompat.js
@@ -154,7 +154,7 @@ function translateToolCalls(toolCalls) {
 async function proxyOpenAICompat(ctx) {
   const {
     res, body, served, modelRequested, meta, requestId, timestamp,
-    taskType, classifiedBy, routingDecision, eff, baseURL,
+    taskType, classifiedBy, difficulty, confidence, routingDecision, eff, baseURL,
   } = ctx;
 
   const apiKey = eff.providers[served.provider]?.credential?.apiKey || "none";
@@ -167,7 +167,7 @@ async function proxyOpenAICompat(ctx) {
       logger.write({
         requestId, timestamp, ...meta,
         provider: served.provider, model: served.model, modelRequested,
-        taskType, classifiedBy, routingDecision, cacheHit: false,
+        taskType, classifiedBy, difficulty, confidence, routingDecision, cacheHit: false,
         knownPricing: served.knownPricing,
         ...extra,
       })
@@ -308,9 +308,9 @@ async function handleOpenAICompat(req, res) {
     allowedModels: req.apiKey?.allowedModels || [],
     defaultModel: req.apiKey?.defaultModel || null,
   };
-  let served, routingDecision, taskType, classifiedBy;
+  let served, routingDecision, taskType, classifiedBy, difficulty, confidence;
   try {
-    ({ served, routingDecision, taskType, classifiedBy } =
+    ({ served, routingDecision, taskType, classifiedBy, difficulty, confidence } =
       await resolveRoute(normalized, { router, eff, application: meta.application, workflow: meta.workflow, appConfig }));
   } catch (err) {
     if (err.code === "model_not_allowed") {
@@ -383,7 +383,7 @@ async function handleOpenAICompat(req, res) {
       routing: routingDecision, taskType });
     return proxyOpenAICompat({
       res, body, served, modelRequested, meta, requestId, timestamp,
-      taskType, classifiedBy, routingDecision, eff, baseURL: compatBaseURL,
+      taskType, classifiedBy, difficulty, confidence, routingDecision, eff, baseURL: compatBaseURL,
     });
   }
 
@@ -492,7 +492,7 @@ async function handleOpenAICompat(req, res) {
         logger.write({
           requestId, timestamp, ...meta,
           provider: served.provider, model: served.model, modelRequested,
-          taskType, classifiedBy,
+          taskType, classifiedBy, difficulty, confidence,
           promptTokens, completionTokens, totalTokens,
           latencyMs: Date.now() - start, status: "success", routingDecision, cacheHit: false,
           knownPricing: served.knownPricing,
@@ -607,7 +607,7 @@ async function handleOpenAICompat(req, res) {
       logger.write({
         requestId, timestamp, ...meta,
         provider: result.providerId, model: result.modelId, modelRequested,
-        taskType, classifiedBy,
+        taskType, classifiedBy, difficulty, confidence,
         promptTokens, completionTokens, totalTokens,
         latencyMs: Date.now() - start, status: "success", routingDecision, cacheHit: false,
         knownPricing: served.knownPricing,
@@ -666,7 +666,7 @@ async function handleOpenAICompat(req, res) {
     logger.write({
       requestId, timestamp, ...meta,
       provider: result.providerId, model: result.modelId, modelRequested,
-      taskType, classifiedBy,
+      taskType, classifiedBy, difficulty, confidence,
       promptTokens:     result.usage?.inputTokens  || 0,
       completionTokens: result.usage?.outputTokens || 0,
       totalTokens:      result.usage?.totalTokens  || 0,

--- a/server/src/models/RequestRecord.js
+++ b/server/src/models/RequestRecord.js
@@ -45,6 +45,10 @@ const requestRecordSchema = new mongoose.Schema(
     },
     // How the taskType was determined: app-provided, keyword heuristic, or AI classifier.
     classifiedBy: { type: String, enum: ["provided", "keyword", "ai"], default: "keyword", index: true },
+    // Estimated difficulty of this instance (drives difficulty-aware model selection) and the
+    // classifier's confidence (0-1) in the taskType. Null when not estimated (e.g. provided taskType).
+    difficulty: { type: String, enum: ["light", "mid", "premium", null], default: null },
+    confidence: { type: Number, default: null },
     cacheHit: { type: Boolean, default: false },
   },
   { collection: "request_records" }

--- a/server/src/routing/aiPolicy.js
+++ b/server/src/routing/aiPolicy.js
@@ -148,6 +148,32 @@ function lookup(map, taskType) {
   return m ? { provider: m.provider, model } : null;
 }
 
+// Difficulty-aware resolution. Start from the policy's pick for the task type; if the
+// classifier rated THIS instance easier or harder than the task's default tier, re-pick
+// within that tier using the same scoring engine. Falls back to the base pick on anything
+// unexpected (no difficulty, unknown task, scoring error, or a non-live result).
+function resolveModel({ map, taskType, difficulty, eff }) {
+  const base = lookup(map, taskType);
+  // Only ADJUST an existing policy pick; never invent one for an unmapped task (that stays
+  // passthrough, as before). And no difficulty/eff → unchanged behavior.
+  if (!base || !difficulty || !eff || !eff.liveIds) return base;
+  const tt = String(taskType || "").toLowerCase();
+  const catalogTier = TASK_CATALOG.find((t) => t.id === tt)?.tier || null;
+  if (difficulty === catalogTier) return base;
+  try {
+    const liveIdSet = new Set(eff.liveIds);
+    const liveModels = pricing.listModels()
+      .filter((m) => liveIdSet.has(m.provider))
+      .sort((a, b) => (b.inputPer1M || 0) - (a.inputPer1M || 0));
+    if (!liveModels.length) return base;
+    const catalogMap = Object.fromEntries(TASK_CATALOG.map((t) => [t.id, t]));
+    const id = _scoringFallback(tt, liveModels, catalogMap, eff, difficulty);
+    const m = pricing.getModel(id);
+    if (m && liveIdSet.has(m.provider)) return { provider: m.provider, model: id };
+    return base;
+  } catch { return base; }
+}
+
 // Operator edits — keep only entries whose model is known to the pricing table.
 async function setAssignments(assignments) {
   const clean = {};
@@ -289,7 +315,7 @@ async function _computeAssignments({ router, eff, excludeModels = [] }) {
   return { assignments, generatorModel };
 }
 
-function _scoringFallback(task, liveModels, catalogMap, eff) {
+function _scoringFallback(task, liveModels, catalogMap, eff, tierOverride) {
   const byTier = { light: [], mid: [], premium: [] };
   for (const m of liveModels) { if (byTier[m.tier]) byTier[m.tier].push(m); }
   const hardFallback = liveModels[0].id;
@@ -302,7 +328,7 @@ function _scoringFallback(task, liveModels, catalogMap, eff) {
     return p.length ? p : liveModels;
   }
 
-  const tier     = catalogMap[task]?.tier || "mid";
+  const tier     = tierOverride || catalogMap[task]?.tier || "mid";
   const taskCaps = TASK_CAPABILITIES[task] || { coding:0.3, reasoning:0.3, writing:0.3, analysis:0.3, language:0.1, general:0.5, data:0.2 };
   const pool     = poolFor(tier);
   const cheapest = Math.min(...pool.map((m) => m.inputPer1M || 0.001));
@@ -350,4 +376,4 @@ async function describe() {
   };
 }
 
-module.exports = { getEffective, lookup, setAssignments, regenerate, computeAssignments: _computeAssignments, describe, invalidate, CAPABILITY_VERSION };
+module.exports = { getEffective, lookup, resolveModel, setAssignments, regenerate, computeAssignments: _computeAssignments, describe, invalidate, CAPABILITY_VERSION };


### PR DESCRIPTION
## Why

Today routing classifies a request to one `taskType` and the AI policy maps that single label to one model. Two ceilings:
- the label captures task *type*, not *difficulty*, so "rename this variable" and "design a distributed scheduler" (both `coding`) route to the **same** model;
- it classifies the **first** user message only (stale on multi-turn chats), and the `confidence` it computes is thrown away.

This enriches the routing **signal** without changing Arbr's nature: it stays a transparent 1:1 gateway. No new endpoint, no judge, no extra answer calls. (Cascades and full task decomposition are deliberate follow-ons.)

## What changed

- **Classify the latest user turn.** New `lastUserText` (mirrors `firstUserText`), used by the keyword path, the LLM prompt, and the cache key. Fixes stale classification mid-conversation.
- **Richer output `{ taskType, difficulty, confidence }`.** The LLM classifier now requests structured JSON and runs on a **cheap** model via `pricing.suggestLightTarget(eff.defaultModel)` instead of the premium default; the keyword path derives a coarse difficulty from cheap heuristics (length, multi-step cues, code blocks).
- **Difficulty-aware routing.** `aiPolicy.resolveModel()` re-picks within the difficulty tier using the existing scoring engine (`_scoringFallback` gained a `tierOverride` param) when an instance is easier/harder than the task's default tier. It only **adjusts** an existing policy pick; unmapped tasks stay passthrough as before.
- **Confidence is used + stored.** Low-confidence classifications (`< 0.5`) don't drive a difficulty-based downgrade. `difficulty` and `confidence` are persisted on `RequestRecord` so quality is measurable.

## Testing

- `npm run smoke:classify` — 11 pure-logic assertions (latest-turn classification, difficulty tiering of easy vs hard same-task instances, label normalization, safe default). No DB/keys needed.
- `node --check` on all changed files; no require cycle (classifier lazily requires pricing; pricing does not import classifier).
- Local full build/load not possible (old local Node + deps); runtime load is exercised on deploy (Node 20 image).

## Verify on deploy

For the same task type, confirm easy instances route to a cheaper model and hard instances to a stronger one (today they route identically), and that `difficulty`/`confidence` now appear on request records.

## Out of scope (follow-ons)
- **Cascades** (cheap model → judge → escalate).
- **Full task decomposition** (planner → sub-task routing → synthesis).
- Optional `Settings.classifierModel` knob (currently auto-picks a cheap model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
