### PR TITLE
feat(caching): capture + price provider prompt-cache tokens, surface savings

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dev": "concurrently -n server,web -c blue,green \"npm run server:dev\" \"npm run web\"",
     "smoke:router": "node server/scripts/smoke-router.js",
     "smoke:classify": "node server/scripts/classify-smoke.js",
+    "smoke:cache": "node server/scripts/cache-smoke.js",
     "lint": "eslint server/src",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",

--- a/server/scripts/cache-smoke.js
+++ b/server/scripts/cache-smoke.js
@@ -1,0 +1,44 @@
+// Pure-logic smoke test for cache-token usage extraction (no DB / no provider keys).
+// Run: npm run smoke:cache
+const { extractUsage } = require("../src/providers/llm-router");
+
+let pass = 0, fail = 0;
+const eq = (got, exp, msg) => {
+  if (got === exp) { pass++; } else { fail++; console.log(`FAIL: ${msg} — got ${got}, expected ${exp}`); }
+};
+
+// 1. OpenAI via LangChain: input_tokens is TOTAL (incl. cached); detail carries cache_read.
+let u = extractUsage({ usage_metadata: { input_tokens: 1000, output_tokens: 50, total_tokens: 1050,
+  input_token_details: { cache_read: 800 } } });
+eq(u.inputTokens, 1000, "OpenAI/LC inputTokens");
+eq(u.cachedReadTokens, 800, "OpenAI/LC cachedRead");
+eq(u.cacheWriteTokens, 0, "OpenAI/LC cacheWrite");
+
+// 2. Anthropic via LangChain: cache_read + cache_creation in details.
+u = extractUsage({ usage_metadata: { input_tokens: 1200, output_tokens: 40, total_tokens: 1240,
+  input_token_details: { cache_read: 900, cache_creation: 100 } } });
+eq(u.inputTokens, 1200, "Anthropic/LC inputTokens (total)");
+eq(u.cachedReadTokens, 900, "Anthropic/LC cachedRead");
+eq(u.cacheWriteTokens, 100, "Anthropic/LC cacheWrite");
+
+// 3. Raw OpenAI fallback (no usage_metadata): prompt_tokens incl. cached.
+u = extractUsage({ response_metadata: { usage: { prompt_tokens: 500, completion_tokens: 20, total_tokens: 520,
+  prompt_tokens_details: { cached_tokens: 300 } } } });
+eq(u.inputTokens, 500, "OpenAI raw inputTokens");
+eq(u.cachedReadTokens, 300, "OpenAI raw cachedRead");
+
+// 4. Raw Anthropic fallback: input_tokens EXCLUDES cache → must be added back to a total.
+u = extractUsage({ response_metadata: { usage: { input_tokens: 200, output_tokens: 10,
+  cache_read_input_tokens: 700, cache_creation_input_tokens: 50 } } });
+eq(u.inputTokens, 950, "Anthropic raw inputTokens (200+700+50)");
+eq(u.cachedReadTokens, 700, "Anthropic raw cachedRead");
+eq(u.cacheWriteTokens, 50, "Anthropic raw cacheWrite");
+
+// 5. No cache info → zeros, input preserved.
+u = extractUsage({ usage_metadata: { input_tokens: 100, output_tokens: 10, total_tokens: 110 } });
+eq(u.inputTokens, 100, "no-cache inputTokens");
+eq(u.cachedReadTokens, 0, "no-cache cachedRead = 0");
+eq(u.cacheWriteTokens, 0, "no-cache cacheWrite = 0");
+
+console.log(`${pass}/${pass + fail} passed`);
+process.exit(fail ? 1 : 0);

--- a/server/src/analytics/aggregate.js
+++ b/server/src/analytics/aggregate.js
@@ -28,11 +28,15 @@ async function overview(filter) {
         avgLatency: { $avg: "$latencyMs" },
         totalTokens: { $sum: "$totalTokens" },
         failures: { $sum: { $cond: [{ $eq: ["$status", "failure"] }, 1, 0] } },
+        cacheHits: { $sum: { $cond: ["$cacheHit", 1, 0] } },
+        cachedReadTokens: { $sum: "$cachedReadTokens" },
+        cacheSavingUsd: { $sum: "$cacheSavingUsd" },
       },
     },
   ]);
   const totalRequests = row?.totalRequests || 0;
   const totalCost = row?.totalCost || 0;
+  const cacheHits = row?.cacheHits || 0;
   return {
     totalRequests,
     totalCost,
@@ -40,6 +44,11 @@ async function overview(filter) {
     avgLatency: row?.avgLatency || 0,
     totalTokens: row?.totalTokens || 0,
     failures: row?.failures || 0,
+    // Caching observability: response-cache hit rate + provider prompt-cache reuse and savings.
+    cacheHits,
+    cacheHitRate: totalRequests ? cacheHits / totalRequests : 0,
+    cachedReadTokens: row?.cachedReadTokens || 0,
+    cacheSavingUsd: row?.cacheSavingUsd || 0,
   };
 }
 

--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -392,6 +392,8 @@ async function handleChat(req, res) {
       promptTokens: result.usage?.inputTokens || 0,
       completionTokens: result.usage?.outputTokens || 0,
       totalTokens: result.usage?.totalTokens || 0,
+      cachedReadTokens: result.usage?.cachedReadTokens || 0,
+      cacheWriteTokens: result.usage?.cacheWriteTokens || 0,
       latencyMs: result.latencyMs, status: "success",
       routingDecision, cacheHit: false,
       knownPricing: served.knownPricing,

--- a/server/src/gateway/openaiCompat.js
+++ b/server/src/gateway/openaiCompat.js
@@ -205,6 +205,7 @@ async function proxyOpenAICompat(ctx) {
       promptTokens: u.prompt_tokens || 0,
       completionTokens: u.completion_tokens || 0,
       totalTokens: u.total_tokens || (u.prompt_tokens || 0) + (u.completion_tokens || 0),
+      cachedReadTokens: (u.prompt_tokens_details && u.prompt_tokens_details.cached_tokens) || 0,
       latencyMs, status: "success",
     });
     return;
@@ -218,7 +219,7 @@ async function proxyOpenAICompat(ctx) {
     "X-Accel-Buffering": "no",
   });
   res.flushHeaders(); // send headers immediately so the client/proxy knows it's SSE
-  let promptTokens = 0, completionTokens = 0;
+  let promptTokens = 0, completionTokens = 0, cachedReadTokens = 0;
   try {
     if (!upstream.ok || !upstream.body) {
       const errText = await upstream.text().catch(() => "");
@@ -244,6 +245,7 @@ async function proxyOpenAICompat(ctx) {
           if (j.usage) {
             promptTokens = j.usage.prompt_tokens || promptTokens;
             completionTokens = j.usage.completion_tokens || completionTokens;
+            cachedReadTokens = (j.usage.prompt_tokens_details && j.usage.prompt_tokens_details.cached_tokens) || cachedReadTokens;
           }
         } catch { /* partial/non-JSON keepalive line */ }
       }
@@ -251,6 +253,7 @@ async function proxyOpenAICompat(ctx) {
     res.end();
     logRecord({
       promptTokens, completionTokens, totalTokens: promptTokens + completionTokens,
+      cachedReadTokens,
       latencyMs: Date.now() - start, status: "success",
     });
   } catch (err) {
@@ -419,6 +422,9 @@ async function handleOpenAICompat(req, res) {
       const promptTokens = um.input_tokens || 0;
       const completionTokens = um.output_tokens || 0;
       const totalTokens = um.total_tokens || (promptTokens + completionTokens);
+      const _utd = um.input_token_details || {};
+      const cachedReadTokens = _utd.cache_read || 0;
+      const cacheWriteTokens = _utd.cache_creation || 0;
 
       if (body.stream) {
         // Emit result as SSE so streaming clients receive the turn in OpenAI chunk format.
@@ -494,7 +500,7 @@ async function handleOpenAICompat(req, res) {
           requestId, timestamp, ...meta,
           provider: served.provider, model: served.model, modelRequested,
           taskType, classifiedBy, difficulty, confidence,
-          promptTokens, completionTokens, totalTokens,
+          promptTokens, completionTokens, totalTokens, cachedReadTokens, cacheWriteTokens,
           latencyMs: Date.now() - start, status: "success", routingDecision, cacheHit: false,
           knownPricing: served.knownPricing,
         })
@@ -575,6 +581,8 @@ async function handleOpenAICompat(req, res) {
     const promptTokens = result.usage?.inputTokens || 0;
     const completionTokens = result.usage?.outputTokens || 0;
     const totalTokens = result.usage?.totalTokens || (promptTokens + completionTokens);
+    const cachedReadTokens = result.usage?.cachedReadTokens || 0;
+    const cacheWriteTokens = result.usage?.cacheWriteTokens || 0;
 
     // Role delta on the first chunk (OpenAI protocol).
     res.write(`data: ${JSON.stringify({
@@ -609,7 +617,7 @@ async function handleOpenAICompat(req, res) {
         requestId, timestamp, ...meta,
         provider: result.providerId, model: result.modelId, modelRequested,
         taskType, classifiedBy, difficulty, confidence,
-        promptTokens, completionTokens, totalTokens,
+        promptTokens, completionTokens, totalTokens, cachedReadTokens, cacheWriteTokens,
         latencyMs: Date.now() - start, status: "success", routingDecision, cacheHit: false,
         knownPricing: served.knownPricing,
       })
@@ -671,6 +679,8 @@ async function handleOpenAICompat(req, res) {
       promptTokens:     result.usage?.inputTokens  || 0,
       completionTokens: result.usage?.outputTokens || 0,
       totalTokens:      result.usage?.totalTokens  || 0,
+      cachedReadTokens: result.usage?.cachedReadTokens || 0,
+      cacheWriteTokens: result.usage?.cacheWriteTokens || 0,
       latencyMs: result.latencyMs, status: "success", routingDecision, cacheHit: false,
       knownPricing: served.knownPricing,
     })

--- a/server/src/litellm/sync.js
+++ b/server/src/litellm/sync.js
@@ -48,6 +48,12 @@ function normalizeProvider(prefix) {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
+// Per-token cost (USD) → per-1M rate, or null when absent/non-positive.
+function per1M(costPerToken) {
+  const c = parseFloat(costPerToken);
+  return isFinite(c) && c > 0 ? +(c * 1_000_000).toFixed(4) : null;
+}
+
 function deriveTier(inputPer1M, outputPer1M) {
   const avg = (inputPer1M + outputPer1M) / 2;
   if (avg >= 8)   return "premium";
@@ -173,6 +179,8 @@ async function run() {
       label:         toLabel(id),
       inputPer1M,
       outputPer1M,
+      cacheReadPer1M:  per1M(ltEntry.cache_read_input_token_cost),
+      cacheWritePer1M: per1M(ltEntry.cache_creation_input_token_cost),
       tier:          deriveTier(inputPer1M, outputPer1M),
       builtIn:       false,
       enabled:       true,
@@ -221,6 +229,10 @@ async function run() {
     const outputCost = parseFloat(ltEntry.output_cost_per_token);
     if (isFinite(inputCost)  && inputCost  > 0) update.inputPer1M  = +(inputCost  * 1_000_000).toFixed(4);
     if (isFinite(outputCost) && outputCost > 0) update.outputPer1M = +(outputCost * 1_000_000).toFixed(4);
+    const cacheRead  = per1M(ltEntry.cache_read_input_token_cost);
+    const cacheWrite = per1M(ltEntry.cache_creation_input_token_cost);
+    if (cacheRead  !== null) update.cacheReadPer1M  = cacheRead;
+    if (cacheWrite !== null) update.cacheWritePer1M = cacheWrite;
 
     const maxIn = parseInt(ltEntry.max_input_tokens, 10);
     if (isFinite(maxIn) && maxIn > 0) update.contextWindow = maxIn;

--- a/server/src/logging/logger.js
+++ b/server/src/logging/logger.js
@@ -18,9 +18,17 @@ async function write(record) {
     const promptTokens = record.promptTokens || 0;
     const completionTokens = record.completionTokens || 0;
     const totalTokens = record.totalTokens || promptTokens + completionTokens;
+    const cachedReadTokens = record.cachedReadTokens || 0;
+    const cacheWriteTokens = record.cacheWriteTokens || 0;
     const { inputCost, outputCost, totalCost } = record.knownPricing === false
       ? { inputCost: 0, outputCost: 0, totalCost: 0 }
-      : costFor(record.model, promptTokens, completionTokens);
+      : costFor(record.model, promptTokens, completionTokens, { cachedReadTokens, cacheWriteTokens });
+    // Estimated $ saved by cached reads vs paying full input rate for them.
+    let cacheSavingUsd = 0;
+    if (record.knownPricing !== false && cachedReadTokens > 0) {
+      const full = costFor(record.model, promptTokens, completionTokens);
+      cacheSavingUsd = Math.max(0, full.totalCost - totalCost);
+    }
 
     // PII masking: check setting lazily (cached by Settings.get's singleton pattern).
     // Only applied to the logged copy — the model already received the original text.
@@ -36,6 +44,9 @@ async function write(record) {
       promptTokens,
       completionTokens,
       totalTokens,
+      cachedReadTokens,
+      cacheWriteTokens,
+      cacheSavingUsd,
       inputCost,
       outputCost,
       totalCost,

--- a/server/src/models/ModelEntry.js
+++ b/server/src/models/ModelEntry.js
@@ -7,6 +7,11 @@ const modelEntrySchema = new mongoose.Schema(
     label:        { type: String, default: "" },
     inputPer1M:   { type: Number, required: true, min: 0 },
     outputPer1M:  { type: Number, required: true, min: 0 },
+    // Per-1M rates for provider prompt caching. null = unknown (cost falls back to inputPer1M).
+    // cacheRead = billing for tokens served from the provider's prompt cache (much cheaper);
+    // cacheWrite = billing to populate the cache (Anthropic charges a premium for this).
+    cacheReadPer1M:  { type: Number, default: null },
+    cacheWritePer1M: { type: Number, default: null },
     tier:         { type: String, enum: ["light", "mid", "premium"], required: true },
     builtIn:       { type: Boolean, default: false },
     enabled:       { type: Boolean, default: true },

--- a/server/src/models/RequestRecord.js
+++ b/server/src/models/RequestRecord.js
@@ -21,9 +21,14 @@ const requestRecordSchema = new mongoose.Schema(
     taskType: { type: String, index: true },
 
     // usage
-    promptTokens: { type: Number, default: 0 },
+    promptTokens: { type: Number, default: 0 },      // TOTAL input, including any cached tokens
     completionTokens: { type: Number, default: 0 },
     totalTokens: { type: Number, default: 0 },
+    // Provider prompt-cache breakdown (subset of promptTokens) + the $ saved on cached reads
+    // vs paying full input rate. Lets analytics show cache hit-rate and cache ROI.
+    cachedReadTokens: { type: Number, default: 0 },
+    cacheWriteTokens: { type: Number, default: 0 },
+    cacheSavingUsd: { type: Number, default: 0 },
 
     // cost (USD)
     inputCost: { type: Number, default: 0 },

--- a/server/src/pricing/registry.js
+++ b/server/src/pricing/registry.js
@@ -83,10 +83,20 @@ function isCheapTask(taskType) {
   return CHEAP_TASK_TYPES.has(String(taskType || "").toLowerCase());
 }
 
-function costFor(modelId, promptTokens = 0, completionTokens = 0) {
+// promptTokens is TOTAL input (including any cached tokens). `cache` optionally splits out
+// cached-read and cache-write tokens so they bill at the provider's cache rates. Omitting cache
+// (or a model with no cache rates) prices everything at inputPer1M — identical to before.
+function costFor(modelId, promptTokens = 0, completionTokens = 0, cache = {}) {
   const m = _cache[modelId];
   if (!m) return { inputCost: 0, outputCost: 0, totalCost: 0 };
-  const inputCost  = (Number(promptTokens)    / 1e6) * m.inputPer1M;
+  const cachedRead = Number(cache.cachedReadTokens) || 0;
+  const cacheWrite = Number(cache.cacheWriteTokens) || 0;
+  const uncached   = Math.max(0, Number(promptTokens) - cachedRead - cacheWrite);
+  const readRate   = m.cacheReadPer1M  != null ? m.cacheReadPer1M  : m.inputPer1M;
+  const writeRate  = m.cacheWritePer1M != null ? m.cacheWritePer1M : m.inputPer1M;
+  const inputCost  = (uncached / 1e6) * m.inputPer1M
+                   + (cachedRead / 1e6) * readRate
+                   + (cacheWrite / 1e6) * writeRate;
   const outputCost = (Number(completionTokens) / 1e6) * m.outputPer1M;
   return { inputCost, outputCost, totalCost: inputCost + outputCost };
 }

--- a/server/src/providers/llm-router/index.js
+++ b/server/src/providers/llm-router/index.js
@@ -211,12 +211,35 @@ function extractText(response) {
 }
 
 function extractUsage(response) {
-  const meta = (response && (response.usage_metadata
-    || (response.response_metadata && response.response_metadata.usage))) || {};
+  const um = (response && response.usage_metadata) || {};
+  const rm = (response && response.response_metadata && response.response_metadata.usage) || {};
+  const d  = um.input_token_details || {};
+
+  // Provider prompt-cache tokens. LangChain standardizes them into input_token_details;
+  // fall back to raw provider fields (Anthropic cache_read/creation_input_tokens, OpenAI
+  // prompt_tokens_details.cached_tokens). `??` so a real 0 is kept, not skipped.
+  const cachedReadTokens =
+    d.cache_read
+    ?? rm.cache_read_input_tokens
+    ?? (rm.prompt_tokens_details && rm.prompt_tokens_details.cached_tokens)
+    ?? 0;
+  const cacheWriteTokens = d.cache_creation ?? rm.cache_creation_input_tokens ?? 0;
+
+  // LangChain's input_tokens is TOTAL input (incl. cached). Raw OpenAI prompt_tokens is too.
+  // Raw Anthropic input_tokens EXCLUDES cache, so add it back to keep a consistent total.
+  let inputTokens = um.input_tokens ?? um.inputTokens ?? rm.prompt_tokens;
+  if (inputTokens == null && rm.input_tokens != null) {
+    inputTokens = rm.input_tokens + (Number(cachedReadTokens) || 0) + (Number(cacheWriteTokens) || 0);
+  }
+  const outputTokens = um.output_tokens ?? um.outputTokens ?? rm.completion_tokens ?? rm.output_tokens;
+  const totalTokens  = um.total_tokens  ?? um.totalTokens  ?? rm.total_tokens;
+
   return {
-    inputTokens:  meta.input_tokens  || meta.inputTokens  || meta.prompt_tokens     || undefined,
-    outputTokens: meta.output_tokens || meta.outputTokens || meta.completion_tokens || undefined,
-    totalTokens:  meta.total_tokens  || meta.totalTokens                            || undefined,
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    cachedReadTokens: Number(cachedReadTokens) || 0,
+    cacheWriteTokens: Number(cacheWriteTokens) || 0,
   };
 }
 
@@ -238,4 +261,4 @@ function extractFinishReason(response) {
   return "stop";
 }
 
-module.exports = { createRouter, SUPPORTED_PROVIDERS, extractFinishReason };
+module.exports = { createRouter, SUPPORTED_PROVIDERS, extractFinishReason, extractUsage };

--- a/web/src/pages/Overview.jsx
+++ b/web/src/pages/Overview.jsx
@@ -34,6 +34,12 @@ function Summary() {
         <Stat label="Avg latency" value={fmt.ms(data.avgLatency)} />
       </div>
 
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <Stat label="Cache hit rate" value={`${((data.cacheHitRate || 0) * 100).toFixed(1)}%`} />
+        <Stat label="Cached tokens" value={fmt.num(data.cachedReadTokens)} />
+        <Stat label="Cache savings" value={fmt.usd(data.cacheSavingUsd)} />
+      </div>
+
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         <Card title="Spend by provider">
           <Table


### PR DESCRIPTION
## Why

Borrowing the "better caching" lever from the practice we reviewed (their cache hit rate went 5%→60%). Arbr's weakest area: the gateway logged only `input/output/total` tokens and **dropped every provider prompt-cache signal**. Two consequences:
- **Cost was wrong** wherever provider caching was active — `costFor` priced all input at full `inputPer1M`, but cached reads bill at ~0.1x (Anthropic) / ~0.5x (OpenAI). Reported cost was overstated.
- **Caching was invisible** — the `cacheHit` boolean was never aggregated and provider cache tokens weren't stored.

This makes caching **measurable and cost-correct**. It does not change routing or enable caching (those are separate follow-on slices); behavior is otherwise identical.

## What changed

- **Capture** `cachedReadTokens`/`cacheWriteTokens` across all paths — `extractUsage` (LangChain `input_token_details` + raw provider fallback), the OpenAI-compat proxy (non-stream + streaming `prompt_tokens_details.cached_tokens`), and the native-tool path. Normalized so `promptTokens` is **total input incl. cached** (raw Anthropic `input_tokens` excludes cache, so it's added back).
- **Price** — `ModelEntry` gains `cacheReadPer1M`/`cacheWritePer1M`, populated by the LiteLLM sync from `cache_read_input_token_cost`/`cache_creation_input_token_cost` (insert + refresh). `costFor()` takes an optional cache split and bills cached reads/writes at those rates. **Backward-compatible**: no cache args (or a model without cache rates) → identical to today.
- **Store** — `RequestRecord` adds `cachedReadTokens`/`cacheWriteTokens`/`cacheSavingUsd`; `logger` computes the saving vs full input rate.
- **Surface** — `overview()` exposes `cacheHitRate`, `cachedReadTokens`, `cacheSavingUsd`; the Overview page shows a caching stat row.

## Testing

- `npm run smoke:cache` — **14/14** assertions for per-provider usage normalization (OpenAI & Anthropic, LangChain & raw, no-cache).
- `node --check` on all 9 server files; esbuild-validated `Overview.jsx`.
- Local full build not possible (old local Node); runtime exercised on the Node 20 image.

## Verify on deploy

Send the same long system-prefix prompt twice to an Anthropic or OpenAI model via the gateway; confirm the 2nd record has `cachedReadTokens > 0` and a lower `totalCost` than uncached, and that the Overview caching row shows a non-zero hit rate + savings.

## Out of scope (follow-ons, already mapped)
- **Enable** provider prompt caching on native paths (Anthropic `cache_control`, Gemini implicit).
- **Cache-aware routing**; per-user spend + realised-savings views; cheap-default posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
