### PR TITLE
fix(gateway): apply per-app config (policy, opt-out, kill-switch) on /v1/chat/completions

### DIFF
--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -401,4 +401,4 @@ async function handleChat(req, res) {
   });
 }
 
-module.exports = { handleChat, resolveRoute, invokeWithFallback };
+module.exports = { handleChat, resolveRoute, invokeWithFallback, getAppConfig };

--- a/server/src/gateway/openaiCompat.js
+++ b/server/src/gateway/openaiCompat.js
@@ -5,7 +5,7 @@
 const { v4: uuidv4 } = require("uuid");
 const { getRouter } = require("../providers/router");
 const { extractFinishReason } = require("../providers/llm-router");
-const { resolveRoute, invokeWithFallback } = require("./handler");
+const { resolveRoute, invokeWithFallback, getAppConfig } = require("./handler");
 const capEngine = require("../routing/capEngine");
 const pricing = require("../pricing/registry");
 const logger = require("../logging/logger");
@@ -308,6 +308,19 @@ async function handleOpenAICompat(req, res) {
   const normalized = { ...body, maxTokens: body.max_tokens };
   const modelRequested = (body.model || "auto").trim();
 
+  // Per-application config (kill switch, modelOptOut, generated aiPolicyAssignments). Without this
+  // the app's own policy + allowed-models opt-out are ignored and routing falls back to the global
+  // policy / default — exactly the /v1/chat path's behavior. (parity with handleChat)
+  const appCfg = await getAppConfig(meta.application);
+  if (appCfg?.killSwitchEnabled) {
+    return res.status(503).json({
+      error: {
+        message: appCfg.killSwitchMessage || `Application "${meta.application}" is temporarily disabled.`,
+        type: "server_error", code: "app_kill_switch",
+      },
+    });
+  }
+
   const appConfig = {
     allowedModels: req.apiKey?.allowedModels || [],
     defaultModel: req.apiKey?.defaultModel || null,
@@ -315,7 +328,7 @@ async function handleOpenAICompat(req, res) {
   let served, routingDecision, taskType, classifiedBy, difficulty, confidence;
   try {
     ({ served, routingDecision, taskType, classifiedBy, difficulty, confidence } =
-      await resolveRoute(normalized, { router, eff, application: meta.application, workflow: meta.workflow, appConfig }));
+      await resolveRoute(normalized, { router, eff, application: meta.application, workflow: meta.workflow, appConfig, appDbConfig: appCfg }));
   } catch (err) {
     if (err.code === "model_not_allowed") {
       return res.status(403).json({ error: { message: err.message, type: "invalid_request_error", code: "model_not_allowed" } });


### PR DESCRIPTION
## Bug

On `chat.gyde.ai`, an app's **generated AI policy is ignored** and its **allowed-models opt-out isn't enforced**. Reproduced: an `auto` request classified `coding` was served the **default** `us.deepseek.r1-v1:0` with routing **`passthrough`** — not the app policy's `nova-micro`.

## Root cause

`chat.gyde.ai` calls `/v1/chat/completions` (`handleOpenAICompat`). That handler builds `appConfig` from the **API key only** and calls `resolveRoute` **without `appDbConfig`** — so the application's `ApplicationConfig` is never loaded. Consequences on that path:
- per-app `aiPolicyAssignments` ignored → routing falls back to the **global** policy / default;
- per-app `modelOptOut` (the "Allowed models" opt-out) **not enforced** at the gateway;
- per-application **kill switch** silently inert.

`/v1/chat` (`handleChat`) already loads it (`getAppConfig`) and passes `appDbConfig`. This was simply never wired on the OpenAI-compat path.

## Fix (parity with handleChat)

- Export `getAppConfig` from `handler.js`.
- In `handleOpenAICompat`: fetch `getAppConfig(meta.application)`, add the kill-switch 503 check, and pass `appDbConfig: appCfg` to `resolveRoute`.

No new require cycle (`openaiCompat` already imports `handler`). `resolveRoute` already consumes `appDbConfig` for both the AI-policy lookup and `modelOptOut` enforcement, so this one wiring fix restores all three behaviors.

## Testing

- `node --check` on both gateway files; grep confirms both paths now pass `appDbConfig`.
- Not unit-testable locally (needs DB); this is a faithful mirror of the working `handleChat` path.

## Verify on deploy

With an app that has a generated policy (e.g. `gyde-chat-client`, coding → nova-micro): an `auto` coding request should now route **`ai` → nova-micro** (not `passthrough` → default). A deselected model should be blocked/fallback. The per-app kill switch should now return 503 on `/v1/chat/completions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
