### PR TITLE
feat(classify): capture 1-10 difficulty score (route on tiers, measure-first)

### DIFF
--- a/server/scripts/classify-smoke.js
+++ b/server/scripts/classify-smoke.js
@@ -32,5 +32,31 @@ ok(c.normalizeDifficulty("banana") === null, "normalize junk -> null");
 ok(c.classify({ messages: [{ role: "user", content: "zxcv qwer" }] }).taskType === "content generation",
   "no match -> content generation default");
 
+// ── 1-10 difficulty score ──
+// scoreToTier boundaries (1-3 light, 4-7 mid, 8-10 premium).
+ok(c.scoreToTier(1) === "light" && c.scoreToTier(3) === "light", "scoreToTier 1,3 -> light");
+ok(c.scoreToTier(4) === "mid" && c.scoreToTier(7) === "mid", "scoreToTier 4,7 -> mid");
+ok(c.scoreToTier(8) === "premium" && c.scoreToTier(10) === "premium", "scoreToTier 8,10 -> premium");
+
+// LLM-score normalization: number clamps to 1-10; tier words map; junk -> null.
+ok(c.normalizeDifficultyScore(8) === 8, "normalizeScore 8 -> 8");
+ok(c.normalizeDifficultyScore("12") === 10, "normalizeScore 12 -> clamp 10");
+ok(c.normalizeDifficultyScore(0) === 1, "normalizeScore 0 -> clamp 1");
+ok(c.normalizeDifficultyScore("hard") === 9, "normalizeScore 'hard' -> 9 (premium)");
+ok(c.normalizeDifficultyScore("banana") === null, "normalizeScore junk -> null");
+
+// Keyword score: trivial low, complex high; both within 1-10.
+const easyScore = c.estimateDifficultyScore("rename this var", "coding");
+const hardScore = c.estimateDifficultyScore(
+  "design and implement an end-to-end distributed scheduler, step by step, across multiple services", "coding");
+ok(easyScore >= 1 && easyScore <= 3, `trivial coding score in light band (got ${easyScore})`);
+ok(hardScore >= 8 && hardScore <= 10, `complex coding score in premium band (got ${hardScore})`);
+
+// ROUTING PARITY: scoreToTier(estimateDifficultyScore(...)) == old estimateDifficulty tier.
+for (const [text, tt] of [["rename this var", "coding"], ["design a distributed scheduler step by step across multiple services", "coding"], ["what is 2+2", "faq"]]) {
+  ok(c.scoreToTier(c.estimateDifficultyScore(text, tt)) === c.estimateDifficulty(text, tt),
+    `parity: score buckets to same tier as estimateDifficulty ("${text.slice(0,20)}...")`);
+}
+
 console.log(`${pass}/${pass + fail} passed`);
 process.exit(fail ? 1 : 0);

--- a/server/src/classify/classifier.js
+++ b/server/src/classify/classifier.js
@@ -146,6 +146,34 @@ function estimateDifficulty(text, taskType) {
   return TIER_ORDER[idx];
 }
 
+// ── 1-10 difficulty score ─────────────────────────────────────────────────────
+// The LLM path emits a genuine 1-10 spectrum; the keyword path can only estimate coarsely.
+// Routing still consumes the 3 TIERS — `scoreToTier` is the single place that buckets the score,
+// so `scoreToTier(estimateDifficultyScore(...))` is guaranteed to equal the old tier (routing parity).
+const TIER_BAND = { light: [1, 3], mid: [4, 7], premium: [8, 10] };
+function scoreToTier(score) {
+  const n = Number(score);
+  if (!isFinite(n)) return "mid";
+  if (n <= 3) return "light";
+  if (n <= 7) return "mid";
+  return "premium";
+}
+// Normalize an LLM-provided difficulty into a 1-10 integer. Accepts a number, or a tier word
+// (light/mid/premium and synonyms) mapped to a representative score; null if unrecognized.
+function normalizeDifficultyScore(v) {
+  const n = Number(v);
+  if (isFinite(n)) return Math.max(1, Math.min(10, Math.round(n)));
+  const tier = normalizeDifficulty(v);
+  return tier ? { light: 2, mid: 5, premium: 9 }[tier] : null;
+}
+// Keyword-path score: derive the tier the existing way, then place WITHIN that tier's band by
+// prompt length. Stays inside the band, so it always buckets back to the same tier (parity).
+function estimateDifficultyScore(text, taskType) {
+  const [lo, hi] = TIER_BAND[estimateDifficulty(text, taskType)] || TIER_BAND.mid;
+  const frac = Math.max(0, Math.min(1, (text || "").length / 2000));
+  return Math.round(lo + frac * (hi - lo));
+}
+
 // Last complete {...} JSON block in text. Local copy (a require on aiPolicy would be circular,
 // since aiPolicy imports this module for TASK_TYPES/TASK_CATALOG).
 function parseJsonBlock(text) {
@@ -175,16 +203,18 @@ function pickClassifierModel(eff) {
 // confidence: manual = 1.0, a keyword hit = 0.9, the safe-default fallthrough = 0.3.
 function classify({ taskType, messages }) {
   if (taskType && String(taskType).trim()) {
-    return { taskType: String(taskType).trim().toLowerCase(), source: "manual", confidence: 1.0, difficulty: null };
+    return { taskType: String(taskType).trim().toLowerCase(), source: "manual", confidence: 1.0, difficulty: null, difficultyScore: null };
   }
   const text = lastUserText(messages).toLowerCase();
   for (const [type, keywords] of RULES) {
     if (keywords.some((kw) => text.includes(kw))) {
-      return { taskType: type, source: "auto", confidence: 0.9, difficulty: estimateDifficulty(text, type) };
+      const difficultyScore = estimateDifficultyScore(text, type);
+      return { taskType: type, source: "auto", confidence: 0.9, difficultyScore, difficulty: scoreToTier(difficultyScore) };
     }
   }
   // safe default
-  return { taskType: "content generation", source: "auto", confidence: 0.3, difficulty: estimateDifficulty(text, "content generation") };
+  const difficultyScore = estimateDifficultyScore(text, "content generation");
+  return { taskType: "content generation", source: "auto", confidence: 0.3, difficultyScore, difficulty: scoreToTier(difficultyScore) };
 }
 
 // ── LLM fallback ──────────────────────────────────────────────────────────────
@@ -212,8 +242,8 @@ async function classifyWithLLM({ messages, router, eff }) {
   const prompt =
     `You are a task classifier for an AI gateway. Classify the user request and rate its difficulty.\n` +
     `taskType MUST be EXACTLY ONE of: ${TASK_TYPES.join(", ")}\n` +
-    `difficulty: "light" = trivial/short, "mid" = moderate, "premium" = complex, multi-step, or deep reasoning.\n` +
-    `Return ONLY a JSON object: {"taskType": "...", "difficulty": "light|mid|premium", "confidence": 0-1}\n\n` +
+    `difficulty: an integer 1-10 (1 = trivial/short, 5 = moderate, 10 = very complex, multi-step, or deep reasoning).\n` +
+    `Return ONLY a JSON object: {"taskType": "...", "difficulty": <1-10>, "confidence": <0-1>}\n\n` +
     `Request:\n"""${text}"""`;
   const m = pickClassifierModel(eff);
   const result = await router.complete({
@@ -225,14 +255,15 @@ async function classifyWithLLM({ messages, router, eff }) {
   });
   const parsed = parseJsonBlock(result.text || "");
   let label = parsed ? normalizeLabel(parsed.taskType) : null;
-  const difficulty = parsed ? normalizeDifficulty(parsed.difficulty) : null;
+  const difficultyScore = parsed ? normalizeDifficultyScore(parsed.difficulty) : null;
   const confidence = parsed && parsed.confidence != null && !isNaN(Number(parsed.confidence))
     ? clamp01(parsed.confidence) : null;
   if (!label) label = normalizeLabel(result.text); // fallback: substring scan of raw text
   if (!label) return null;
   return {
     label,
-    difficulty,
+    difficultyScore,
+    difficulty: difficultyScore != null ? scoreToTier(difficultyScore) : null, // tier for routing
     confidence,
     provider: result.providerId || m.provider,
     model: result.modelId || m.model,
@@ -249,16 +280,16 @@ async function classifyWithLLM({ messages, router, eff }) {
 // is off, the keyword heuristic decides.
 async function classifyTask({ taskType, messages, router, eff, useLLM }) {
   if (taskType && String(taskType).trim()) {
-    return { taskType: String(taskType).trim().toLowerCase(), method: "provided", confidence: 1.0, difficulty: null, llm: null };
+    return { taskType: String(taskType).trim().toLowerCase(), method: "provided", confidence: 1.0, difficulty: null, difficultyScore: null, llm: null };
   }
   if (useLLM && router && eff && (eff.liveIds || []).length) {
     const key = cacheKey(messages);
     const hit = _llmCache.get(key);
-    if (hit) return { taskType: hit.taskType, method: "ai", confidence: hit.confidence ?? 0.8, difficulty: hit.difficulty || null, llm: null };
+    if (hit) return { taskType: hit.taskType, method: "ai", confidence: hit.confidence ?? 0.8, difficulty: hit.difficulty || null, difficultyScore: hit.difficultyScore ?? null, llm: null };
     try {
       const r = await classifyWithLLM({ messages, router, eff });
       if (r && r.label) {
-        const entry = { taskType: r.label, difficulty: r.difficulty || null, confidence: r.confidence };
+        const entry = { taskType: r.label, difficulty: r.difficulty || null, difficultyScore: r.difficultyScore ?? null, confidence: r.confidence };
         if (_llmCache.size >= LLM_CACHE_MAX) _llmCache.delete(_llmCache.keys().next().value);
         _llmCache.set(key, entry);
         return {
@@ -266,6 +297,7 @@ async function classifyTask({ taskType, messages, router, eff, useLLM }) {
           method: "ai",
           confidence: r.confidence ?? 0.8,
           difficulty: r.difficulty || null,
+          difficultyScore: r.difficultyScore ?? null,
           llm: { provider: r.provider, model: r.model, usage: r.usage, latencyMs: r.latencyMs },
         };
       }
@@ -274,10 +306,11 @@ async function classifyTask({ taskType, messages, router, eff, useLLM }) {
     }
   }
   const kw = classify({ taskType: null, messages });
-  return { taskType: kw.taskType, method: "keyword", confidence: kw.confidence, difficulty: kw.difficulty || null, llm: null };
+  return { taskType: kw.taskType, method: "keyword", confidence: kw.confidence, difficulty: kw.difficulty || null, difficultyScore: kw.difficultyScore ?? null, llm: null };
 }
 
 module.exports = {
   classify, classifyTask, classifyWithLLM, TASK_TYPES, TASK_CATALOG,
-  firstUserText, lastUserText, estimateDifficulty, normalizeDifficulty, tierForTask,
+  firstUserText, lastUserText, estimateDifficulty, estimateDifficultyScore,
+  normalizeDifficulty, normalizeDifficultyScore, scoreToTier, tierForTask,
 };

--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -107,6 +107,7 @@ async function resolveRoute(body, { router, eff, application, workflow, appConfi
   const taskType = cls.taskType;
   const classifiedBy = cls.method;
   const difficulty = cls.difficulty || null;
+  const difficultyScore = typeof cls.difficultyScore === "number" ? cls.difficultyScore : null;
   const confidence = typeof cls.confidence === "number" ? cls.confidence : null;
 
   let served, routingDecision;
@@ -174,7 +175,7 @@ async function resolveRoute(body, { router, eff, application, workflow, appConfi
     }
   }
 
-  return { served, routingDecision, taskType, classifiedBy, cls, difficulty, confidence };
+  return { served, routingDecision, taskType, classifiedBy, cls, difficulty, difficultyScore, confidence };
 }
 
 async function handleChat(req, res) {
@@ -240,9 +241,9 @@ async function handleChat(req, res) {
     allowedModels: req.apiKey?.allowedModels || [],
     defaultModel: req.apiKey?.defaultModel || null,
   };
-  let served, routingDecision, taskType, classifiedBy, cls, difficulty, confidence;
+  let served, routingDecision, taskType, classifiedBy, cls, difficulty, difficultyScore, confidence;
   try {
-    ({ served, routingDecision, taskType, classifiedBy, cls, difficulty, confidence } =
+    ({ served, routingDecision, taskType, classifiedBy, cls, difficulty, difficultyScore, confidence } =
       await resolveRoute(body, { router, eff, application: meta.application, workflow: meta.workflow, appConfig, appDbConfig: appCfg }));
   } catch (err) {
     if (err.code === "model_not_allowed") {
@@ -320,7 +321,7 @@ async function handleChat(req, res) {
         logger.write({
           requestId, timestamp, ...meta,
           provider: cached.provider, model: cached.model, modelRequested,
-          taskType, classifiedBy, difficulty, confidence,
+          taskType, classifiedBy, difficulty, difficultyScore, confidence,
           promptTokens: cached.usage?.inputTokens || 0,
           completionTokens: cached.usage?.outputTokens || 0,
           totalTokens: cached.usage?.totalTokens || 0,
@@ -388,7 +389,7 @@ async function handleChat(req, res) {
     logger.write({
       requestId, timestamp, ...meta,
       provider: result.providerId, model: result.modelId, modelRequested,
-      taskType, classifiedBy, difficulty, confidence,
+      taskType, classifiedBy, difficulty, difficultyScore, confidence,
       promptTokens: result.usage?.inputTokens || 0,
       completionTokens: result.usage?.outputTokens || 0,
       totalTokens: result.usage?.totalTokens || 0,

--- a/server/src/gateway/openaiCompat.js
+++ b/server/src/gateway/openaiCompat.js
@@ -155,7 +155,7 @@ function translateToolCalls(toolCalls) {
 async function proxyOpenAICompat(ctx) {
   const {
     res, body, served, modelRequested, meta, requestId, timestamp,
-    taskType, classifiedBy, difficulty, confidence, routingDecision, eff, baseURL,
+    taskType, classifiedBy, difficulty, difficultyScore, confidence, routingDecision, eff, baseURL,
   } = ctx;
 
   const apiKey = eff.providers[served.provider]?.credential?.apiKey || "none";
@@ -168,7 +168,7 @@ async function proxyOpenAICompat(ctx) {
       logger.write({
         requestId, timestamp, ...meta,
         provider: served.provider, model: served.model, modelRequested,
-        taskType, classifiedBy, difficulty, confidence, routingDecision, cacheHit: false,
+        taskType, classifiedBy, difficulty, difficultyScore, confidence, routingDecision, cacheHit: false,
         knownPricing: served.knownPricing,
         ...extra,
       })
@@ -325,9 +325,9 @@ async function handleOpenAICompat(req, res) {
     allowedModels: req.apiKey?.allowedModels || [],
     defaultModel: req.apiKey?.defaultModel || null,
   };
-  let served, routingDecision, taskType, classifiedBy, difficulty, confidence;
+  let served, routingDecision, taskType, classifiedBy, difficulty, difficultyScore, confidence;
   try {
-    ({ served, routingDecision, taskType, classifiedBy, difficulty, confidence } =
+    ({ served, routingDecision, taskType, classifiedBy, difficulty, difficultyScore, confidence } =
       await resolveRoute(normalized, { router, eff, application: meta.application, workflow: meta.workflow, appConfig, appDbConfig: appCfg }));
   } catch (err) {
     if (err.code === "model_not_allowed") {
@@ -400,7 +400,7 @@ async function handleOpenAICompat(req, res) {
       routing: routingDecision, taskType });
     return proxyOpenAICompat({
       res, body, served, modelRequested, meta, requestId, timestamp,
-      taskType, classifiedBy, difficulty, confidence, routingDecision, eff, baseURL: compatBaseURL,
+      taskType, classifiedBy, difficulty, difficultyScore, confidence, routingDecision, eff, baseURL: compatBaseURL,
     });
   }
 
@@ -512,7 +512,7 @@ async function handleOpenAICompat(req, res) {
         logger.write({
           requestId, timestamp, ...meta,
           provider: served.provider, model: served.model, modelRequested,
-          taskType, classifiedBy, difficulty, confidence,
+          taskType, classifiedBy, difficulty, difficultyScore, confidence,
           promptTokens, completionTokens, totalTokens, cachedReadTokens, cacheWriteTokens,
           latencyMs: Date.now() - start, status: "success", routingDecision, cacheHit: false,
           knownPricing: served.knownPricing,
@@ -629,7 +629,7 @@ async function handleOpenAICompat(req, res) {
       logger.write({
         requestId, timestamp, ...meta,
         provider: result.providerId, model: result.modelId, modelRequested,
-        taskType, classifiedBy, difficulty, confidence,
+        taskType, classifiedBy, difficulty, difficultyScore, confidence,
         promptTokens, completionTokens, totalTokens, cachedReadTokens, cacheWriteTokens,
         latencyMs: Date.now() - start, status: "success", routingDecision, cacheHit: false,
         knownPricing: served.knownPricing,
@@ -688,7 +688,7 @@ async function handleOpenAICompat(req, res) {
     logger.write({
       requestId, timestamp, ...meta,
       provider: result.providerId, model: result.modelId, modelRequested,
-      taskType, classifiedBy, difficulty, confidence,
+      taskType, classifiedBy, difficulty, difficultyScore, confidence,
       promptTokens:     result.usage?.inputTokens  || 0,
       completionTokens: result.usage?.outputTokens || 0,
       totalTokens:      result.usage?.totalTokens  || 0,

--- a/server/src/models/RequestRecord.js
+++ b/server/src/models/RequestRecord.js
@@ -53,6 +53,9 @@ const requestRecordSchema = new mongoose.Schema(
     // Estimated difficulty of this instance (drives difficulty-aware model selection) and the
     // classifier's confidence (0-1) in the taskType. Null when not estimated (e.g. provided taskType).
     difficulty: { type: String, enum: ["light", "mid", "premium", null], default: null },
+    // Finer 1-10 difficulty estimate (the tier above is derived from it). Captured for analysis;
+    // routing still uses the tier. Null when not estimated.
+    difficultyScore: { type: Number, default: null },
     confidence: { type: Number, default: null },
     cacheHit: { type: Boolean, default: false },
   },


### PR DESCRIPTION
## Why

Follow-up to difficulty-aware routing (#36). We want to know whether a finer difficulty signal (1-10) would improve routing — but acting on it now would be false precision (the estimator is new and model selection is still 3-tier). So this **captures a 1-10 score and logs it, while routing stays on the 3 tiers** ("measure-first"). **No routing behavior change.**

## What changed

- **Classifier emits 1-10.** The LLM prompt now asks for `difficulty` as an integer 1-10; the keyword path computes a 1-10 score within the task's tier band.
- **One bucketing point.** New `scoreToTier` (1-3 light / 4-7 mid / 8-10 premium) derives the tier routing consumes. By construction `scoreToTier(estimateDifficultyScore(...))` equals the old `estimateDifficulty` tier — **routing parity**, asserted in the smoke test.
- `normalizeDifficultyScore` handles number / clamp-to-1-10 / tier-word / junk→null.
- `classifyTask` returns `difficultyScore` alongside the derived `difficulty` tier; LLM cache stores it.
- `RequestRecord.difficultyScore` (Number) added; threaded through both gateway handlers' `resolveRoute` + all log sites, mirroring `difficulty`/`confidence`.

## Testing

- `npm run smoke:classify` — **24/24** (scoreToTier boundaries, score normalization, keyword score bands, and **parity**: score buckets to the same tier as before).
- `node --check` on all changed files.

## Verify on deploy

New `request_records` carry `difficultyScore` (1-10); routing decisions look identical to before (still `ai` → tier-appropriate model). Then we can analyze the score distribution vs `confidence` and served tier to decide whether continuous (frontier) selection is worth building.

## Next (agreed, separate)
Goal-driven policy generation (cost/quality/balanced/latency) + an impact simulator (project a proposed policy's cost over recent traffic, with a capability-index quality proxy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
