### PR TITLE
chore: add .editorconfig and pin CI actions to commit SHAs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[*.{py,pyi}]
+indent_size = 4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     name: Build & test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 20
           cache: npm
@@ -40,9 +40,9 @@ jobs:
     name: Python SDK tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
Closes #25
Closes #23

## Changes

### `.editorconfig` (#25)
Adds root `.editorconfig` so any editor that respects it (VS Code, JetBrains, vim, etc.) enforces consistent formatting automatically — no manual config needed per contributor:
- `utf-8` charset, `lf` line endings
- 2-space indent for all files; 4-space for Python; tabs for Makefiles
- Trim trailing whitespace (except `.md` where trailing spaces are meaningful)
- Insert final newline

### Pin GitHub Actions to commit SHAs (#23)
Floating tags like `actions/checkout@v7` can be silently redirected if the tag is moved or hijacked. Pinned to full commit SHAs with `# vN` comments so the version stays human-readable:

| Action | Tag | SHA |
|---|---|---|
| `actions/checkout` | v7 | `9c091bb` |
| `actions/setup-node` | v6 | `48b55a0` |
| `actions/setup-python` | v6 | `ece7cb0` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)