### PR TITLE
feat(routing): goal-driven policy generation + impact simulator

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "smoke:classify": "node server/scripts/classify-smoke.js",
     "smoke:cache": "node server/scripts/cache-smoke.js",
     "smoke:savings": "node server/scripts/savings-smoke.js",
+    "smoke:simulate": "node server/scripts/simulate-smoke.js",
     "lint": "eslint server/src",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",

--- a/server/scripts/simulate-smoke.js
+++ b/server/scripts/simulate-smoke.js
@@ -1,0 +1,40 @@
+// Pure-logic smoke test for the policy impact projector (no DB / no provider keys).
+// Run: npm run smoke:simulate
+const { projectImpact } = require("../src/routing/policySim");
+
+let pass = 0, fail = 0;
+const ok = (cond, msg) => { if (cond) { pass++; } else { fail++; console.log("FAIL:", msg); } };
+const near = (a, b) => Math.abs(a - b) < 1e-9;
+
+// Fake pricing: cost = (prompt+completion)/1e6 * rate; unknown model -> null.
+const RATE = { cheap: 1, mid: 5, premium: 10 };
+const priceOf = (m, p, c) => (RATE[m] != null ? ((p + c) / 1e6) * RATE[m] : null);
+// Fake capability per model.
+const CAP = { cheap: 0.4, mid: 0.7, premium: 0.95 };
+const capOf = (_t, m) => (CAP[m] != null ? CAP[m] : null);
+
+const rows = [
+  { taskType: "coding", servedModel: "premium", requests: 10, promptTokens: 900000, completionTokens: 100000, actualCost: 10 },
+  { taskType: "faq",    servedModel: "mid",     requests: 20, promptTokens: 400000, completionTokens: 0,      actualCost: 2 },
+];
+const r = projectImpact(rows, { coding: "cheap", faq: "cheap" }, priceOf, capOf);
+ok(near(r.current.cost, 12), `current cost = 12 (got ${r.current.cost})`);
+ok(near(r.projected.cost, 1.4), `projected cost = 1.4 at cheap (got ${r.projected.cost})`);
+ok(near(r.current.capabilityIndex, (10 * 0.95 + 20 * 0.7) / 30), "current capability index = traffic-weighted");
+ok(near(r.projected.capabilityIndex, 0.4), "projected capability index = 0.4 (all cheap)");
+ok(r.rows[0].taskType === "coding" && near(r.rows[0].saved, 9), "rows sorted by saved desc (coding saves 9)");
+
+// Unmapped task -> keeps current served model (no change for that slice).
+const r2 = projectImpact([{ taskType: "x", servedModel: "mid", requests: 1, promptTokens: 1000000, completionTokens: 0, actualCost: 5 }], {}, priceOf, capOf);
+ok(near(r2.projected.cost, 5), "unmapped task -> served model, no cost change");
+
+// Unpriceable proposed model -> keep actual cost (don't zero it out).
+const r3 = projectImpact([{ taskType: "y", servedModel: "mid", requests: 1, promptTokens: 1000000, completionTokens: 0, actualCost: 5 }], { y: "ghost" }, priceOf, capOf);
+ok(near(r3.projected.cost, 5), "unpriceable proposed -> keep actual cost");
+
+// Empty input is safe.
+const r4 = projectImpact([], {}, priceOf, capOf);
+ok(r4.current.cost === 0 && r4.projected.cost === 0 && r4.rows.length === 0, "empty -> zeros, no rows");
+
+console.log(`${pass}/${pass + fail} passed`);
+process.exit(fail ? 1 : 0);

--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -627,12 +627,25 @@ router.put("/ai-policy", async (req, res, next) => {
   } catch (e) { res.status(400).json({ error: "bad_request", message: String(e.message || e) }); }
 });
 
-router.post("/ai-policy/regenerate", async (_req, res, next) => {
+router.post("/ai-policy/regenerate", async (req, res, next) => {
   try {
     const { router: r, eff } = await getRouter();
     if (!r) return res.status(503).json({ error: "demo_mode", message: "Add a provider key to generate an AI policy." });
-    await aiPolicy.regenerate({ router: r, eff });
-    res.json(await aiPolicy.describe());
+    const goal = String(req.body?.goal || "balanced");
+    const pol = await aiPolicy.regenerate({ router: r, eff, goal });
+    const simulation = await aiPolicy.simulate({ assignments: pol.assignments, windowDays: Number(req.body?.windowDays) || 14 });
+    res.json({ ...(await aiPolicy.describe()), simulation });
+  } catch (e) { res.status(400).json({ error: "bad_request", message: String(e.message || e) }); }
+});
+
+// Project a proposed policy's cost + capability over recent global traffic (no persist).
+router.post("/ai-policy/simulate", async (req, res, next) => {
+  try {
+    const simulation = await aiPolicy.simulate({
+      assignments: req.body?.assignments || {},
+      windowDays: Number(req.body?.windowDays) || 14,
+    });
+    res.json(simulation);
   } catch (e) { res.status(400).json({ error: "bad_request", message: String(e.message || e) }); }
 });
 
@@ -851,15 +864,29 @@ router.post("/app-configs/:app/generate-policy", async (req, res, next) => {
     const { router: r, eff } = await getRouter();
     if (!r) return res.status(503).json({ error: "no live providers — cannot generate policy" });
     const excludeModels = Array.isArray(req.body?.excludeModels) ? req.body.excludeModels : [];
-    const { assignments, generatorModel } = await aiPolicy.computeAssignments({ router: r, eff, excludeModels });
+    const goal = String(req.body?.goal || "balanced");
+    const { assignments, generatorModel } = await aiPolicy.computeAssignments({ router: r, eff, excludeModels, goal });
     const generatedAt = new Date();
     const cfg = await ApplicationConfig.findOneAndUpdate(
       { applicationName: req.params.app },
       { $set: { aiPolicyAssignments: assignments } },
       { new: true, upsert: true }
     ).lean();
-    setImmediate(() => logAction("appConfig.generatePolicy", "appConfig", req.params.app, { excludeModels }));
-    res.json({ assignments, generatedAt, generatorModel: generatorModel.id, cfg });
+    setImmediate(() => logAction("appConfig.generatePolicy", "appConfig", req.params.app, { excludeModels, goal }));
+    const simulation = await aiPolicy.simulate({ assignments, application: req.params.app, windowDays: Number(req.body?.windowDays) || 14 });
+    res.json({ assignments, generatedAt, generatorModel: generatorModel.id, cfg, simulation });
+  } catch (e) { next(e); }
+});
+
+// Project a proposed policy's cost + capability over this app's recent traffic (no persist).
+router.post("/app-configs/:app/simulate", async (req, res, next) => {
+  try {
+    const simulation = await aiPolicy.simulate({
+      assignments: req.body?.assignments || {},
+      application: req.params.app,
+      windowDays: Number(req.body?.windowDays) || 14,
+    });
+    res.json(simulation);
   } catch (e) { next(e); }
 });
 

--- a/server/src/routing/aiPolicy.js
+++ b/server/src/routing/aiPolicy.js
@@ -5,6 +5,7 @@ const Settings = require("../models/Settings");
 const RequestRecord = require("../models/RequestRecord");
 const pricing = require("../pricing/registry");
 const { TASK_TYPES, TASK_CATALOG } = require("../classify/classifier");
+const { projectImpact } = require("./policySim");
 
 // Increment when MODEL_CAPABILITIES or TASK_CAPABILITIES change.
 // GET /api/ai-policy auto-regenerates if the stored version is behind.
@@ -222,6 +223,14 @@ function parseJsonBlock(text) {
 // For general tasks the gap is small (~0.12) so the cheap model still wins.
 const COST_SENSITIVITY = { light: 0.20, mid: 0.25, premium: 0.10 };
 
+// Goal-driven cost-vs-capability weight. "balanced" (default) keeps today's per-tier behavior;
+// "cost" weights cost heavily (cheapest capable model); "quality" weights capability (best model).
+function goalWeight(goal, tier) {
+  if (goal === "cost") return 0.6;
+  if (goal === "quality") return 0.05;
+  return COST_SENSITIVITY[tier] || 0.25; // "balanced" / unset
+}
+
 // Scoring function: returns weighted capability score and cost efficiency ratio.
 // costScore = cheapestInPool / model.cost  →  cheapest model = 1.0, expensive → near 0.
 function scoreModel(taskCaps, model, cheapestCost) {
@@ -242,7 +251,7 @@ function scoreModel(taskCaps, model, cheapestCost) {
 
 // Core scoring engine — shared by regenerate() and computeAssignments().
 // excludeModels: array of model IDs to exclude from consideration.
-async function _computeAssignments({ router, eff, excludeModels = [] }) {
+async function _computeAssignments({ router, eff, excludeModels = [], goal = "balanced" }) {
   if (!eff) throw new Error("no effective config");
 
   const excludeSet = new Set(excludeModels);
@@ -283,7 +292,13 @@ async function _computeAssignments({ router, eff, excludeModels = [] }) {
       `Rules:\n` +
       `- Use light-tier models for simple/cheap tasks, premium for complex reasoning\n` +
       `- Vary assignments — don't give every task the same model\n` +
-      `- Choose the model best suited for each task's requirements\n\n` +
+      `- Choose the model best suited for each task's requirements\n` +
+      (goal === "cost"
+        ? `- GOAL: minimize cost — prefer the cheapest model that can do each task acceptably\n`
+        : goal === "quality"
+        ? `- GOAL: maximize quality — prefer the most capable model for each task, cost is secondary\n`
+        : `- GOAL: balance capability and cost\n`) +
+      `\n` +
       `Return ONLY a valid JSON object mapping each task ID to one model ID. Example:\n` +
       `{"faq":"model-a","coding":"model-b","translation":"model-c"}`;
 
@@ -301,7 +316,7 @@ async function _computeAssignments({ router, eff, excludeModels = [] }) {
       for (const task of tasks) {
         const assigned = raw[task];
         // accept the LLM's choice only if it picked a valid live model
-        assignments[task] = validIds.has(assigned) ? assigned : _scoringFallback(task, liveModels, catalogMap, eff);
+        assignments[task] = validIds.has(assigned) ? assigned : _scoringFallback(task, liveModels, catalogMap, eff, undefined, goal);
       }
       return { assignments, generatorModel };
     }
@@ -310,12 +325,12 @@ async function _computeAssignments({ router, eff, excludeModels = [] }) {
   // ── Scoring matrix fallback ───────────────────────────────────────────────
   const assignments = {};
   for (const task of tasks) {
-    assignments[task] = _scoringFallback(task, liveModels, catalogMap, eff);
+    assignments[task] = _scoringFallback(task, liveModels, catalogMap, eff, undefined, goal);
   }
   return { assignments, generatorModel };
 }
 
-function _scoringFallback(task, liveModels, catalogMap, eff, tierOverride) {
+function _scoringFallback(task, liveModels, catalogMap, eff, tierOverride, goal) {
   const byTier = { light: [], mid: [], premium: [] };
   for (const m of liveModels) { if (byTier[m.tier]) byTier[m.tier].push(m); }
   const hardFallback = liveModels[0].id;
@@ -332,7 +347,7 @@ function _scoringFallback(task, liveModels, catalogMap, eff, tierOverride) {
   const taskCaps = TASK_CAPABILITIES[task] || { coding:0.3, reasoning:0.3, writing:0.3, analysis:0.3, language:0.1, general:0.5, data:0.2 };
   const pool     = poolFor(tier);
   const cheapest = Math.min(...pool.map((m) => m.inputPer1M || 0.001));
-  const cs       = COST_SENSITIVITY[tier] || 0.25;
+  const cs       = goalWeight(goal, tier);
   let best = pool[0], bestScore = -1;
   for (const m of pool) {
     const { capScore, costScore } = scoreModel(taskCaps, m, cheapest);
@@ -343,14 +358,46 @@ function _scoringFallback(task, liveModels, catalogMap, eff, tierOverride) {
 }
 
 // Policy engine — saves global AI policy to Settings.
-async function regenerate({ router, eff }) {
-  const { assignments, generatorModel } = await _computeAssignments({ router, eff });
+async function regenerate({ router, eff, goal }) {
+  const { assignments, generatorModel } = await _computeAssignments({ router, eff, goal });
   const s = await Settings.get();
   s.aiPolicy = { assignments, generatedAt: new Date(), generatorModel: generatorModel.id, capabilityVersion: CAPABILITY_VERSION };
   s.markModified("aiPolicy");
   await s.save();
   invalidate();
   return s.aiPolicy;
+}
+
+// Project a proposed taskType->model policy over recent traffic. Cost is a real re-pricing of the
+// logged tokens; `capabilityIndex` is a heuristic PROXY (capability scores, not measured quality).
+async function simulate({ assignments = {}, application = null, windowDays = 14 } = {}) {
+  const since = new Date(Date.now() - windowDays * 86400000);
+  const match = { status: "success", timestamp: { $gte: since } };
+  if (application) match.application = application;
+  const agg = await RequestRecord.aggregate([
+    { $match: match },
+    { $group: {
+        _id: { taskType: "$taskType", model: "$model" },
+        requests: { $sum: 1 },
+        promptTokens: { $sum: "$promptTokens" },
+        completionTokens: { $sum: "$completionTokens" },
+        actualCost: { $sum: "$totalCost" },
+      } },
+  ]);
+  const groups = agg.map((r) => ({
+    taskType: r._id.taskType, servedModel: r._id.model, requests: r.requests,
+    promptTokens: r.promptTokens, completionTokens: r.completionTokens, actualCost: r.actualCost,
+  }));
+  const priceOf = (modelId, p, c) =>
+    pricing.getModel(modelId) ? pricing.costFor(modelId, p, c).totalCost : null;
+  const capOf = (taskType, modelId) => {
+    const model = pricing.getModel(modelId);
+    if (!model) return null;
+    const taskCaps = TASK_CAPABILITIES[String(taskType || "").toLowerCase()]
+      || { coding: 0.3, reasoning: 0.3, writing: 0.3, analysis: 0.3, language: 0.1, general: 0.5, data: 0.2 };
+    return scoreModel(taskCaps, model, model.inputPer1M || 0.001).capScore;
+  };
+  return { windowDays, ...projectImpact(groups, assignments, priceOf, capOf) };
 }
 
 // Full view for the editor: assignments + catalogs + what's unmapped/custom.
@@ -376,4 +423,4 @@ async function describe() {
   };
 }
 
-module.exports = { getEffective, lookup, resolveModel, setAssignments, regenerate, computeAssignments: _computeAssignments, describe, invalidate, CAPABILITY_VERSION };
+module.exports = { getEffective, lookup, resolveModel, setAssignments, regenerate, computeAssignments: _computeAssignments, simulate, describe, invalidate, CAPABILITY_VERSION };

--- a/server/src/routing/policySim.js
+++ b/server/src/routing/policySim.js
@@ -1,0 +1,52 @@
+// Pure projection of a proposed taskType->model policy over aggregated traffic. Split out from
+// aiPolicy.js so the math is testable without a DB. No dependencies injected as functions:
+//   rows:        [{ taskType, servedModel, requests, promptTokens, completionTokens, actualCost }]
+//   assignments: { [taskType]: modelId }  (the PROPOSED policy)
+//   priceOf(modelId, promptTokens, completionTokens) -> total cost, or null if unpriceable
+//   capOf(taskType, modelId) -> capability score 0-1, or null if unknown
+//
+// A taskType absent from `assignments` keeps its currently-served model (no change for that slice).
+// Cost is a real re-pricing; the capability index is a heuristic PROXY, not measured quality.
+function projectImpact(rows, assignments, priceOf, capOf) {
+  const perTask = {};
+  let curCost = 0, projCost = 0, wSum = 0, curCapW = 0, projCapW = 0;
+
+  for (const r of rows || []) {
+    const tt = r.taskType;
+    const proposed = (assignments && assignments[tt]) || r.servedModel;
+    const projected = priceOf(proposed, r.promptTokens, r.completionTokens);
+    const projRowCost = projected == null ? (r.actualCost || 0) : projected; // unpriceable -> no change
+    curCost += r.actualCost || 0;
+    projCost += projRowCost;
+
+    const w = r.requests || 0;
+    wSum += w;
+    const curCap = capOf(tt, r.servedModel); if (curCap != null) curCapW += w * curCap;
+    const projCap = capOf(tt, proposed);     if (projCap != null) projCapW += w * projCap;
+
+    const e = perTask[tt] || (perTask[tt] = { taskType: tt, requests: 0, actualCost: 0, projectedCost: 0, proposedModel: proposed, currentModels: {} });
+    e.requests += w;
+    e.actualCost += r.actualCost || 0;
+    e.projectedCost += projRowCost;
+    e.proposedModel = proposed;
+    e.currentModels[r.servedModel] = (e.currentModels[r.servedModel] || 0) + w;
+  }
+
+  const rowsOut = Object.values(perTask).map((e) => ({
+    taskType: e.taskType,
+    requests: e.requests,
+    currentModel: Object.entries(e.currentModels).sort((a, b) => b[1] - a[1])[0]?.[0] || null,
+    proposedModel: e.proposedModel,
+    actualCost: e.actualCost,
+    projectedCost: e.projectedCost,
+    saved: e.actualCost - e.projectedCost,
+  })).sort((a, b) => b.saved - a.saved);
+
+  return {
+    current:   { cost: curCost,  capabilityIndex: wSum ? curCapW / wSum : null },
+    projected: { cost: projCost, capabilityIndex: wSum ? projCapW / wSum : null },
+    rows: rowsOut,
+  };
+}
+
+module.exports = { projectImpact };

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -72,7 +72,8 @@ export const api = {
 
   aiPolicy: () => req("/ai-policy"),
   setAiPolicy: (assignments) => req("/ai-policy", { method: "PUT", body: JSON.stringify({ assignments }) }),
-  regenerateAiPolicy: () => req("/ai-policy/regenerate", { method: "POST" }),
+  regenerateAiPolicy: (goal = "balanced", windowDays) => req("/ai-policy/regenerate", { method: "POST", body: JSON.stringify({ goal, windowDays }) }),
+  simulatePolicy: (assignments, windowDays) => req("/ai-policy/simulate", { method: "POST", body: JSON.stringify({ assignments, windowDays }) }),
 
   syncBenchmarks:   () => req("/benchmarks/sync",  { method: "POST" }),
   benchmarksStatus: () => req("/benchmarks/status"),
@@ -124,7 +125,8 @@ export const api = {
   appConfigs: () => req("/app-configs"),
   appConfig: (app) => req(`/app-configs/${encodeURIComponent(app)}`),
   setAppConfig: (app, body) => req(`/app-configs/${encodeURIComponent(app)}`, { method: "PUT", body: JSON.stringify(body) }),
-  generateAppPolicy: (app, excludeModels = []) => req(`/app-configs/${encodeURIComponent(app)}/generate-policy`, { method: "POST", body: JSON.stringify({ excludeModels }) }),
+  generateAppPolicy: (app, excludeModels = [], goal = "balanced", windowDays) => req(`/app-configs/${encodeURIComponent(app)}/generate-policy`, { method: "POST", body: JSON.stringify({ excludeModels, goal, windowDays }) }),
+  simulateAppPolicy: (app, assignments, windowDays) => req(`/app-configs/${encodeURIComponent(app)}/simulate`, { method: "POST", body: JSON.stringify({ assignments, windowDays }) }),
   setAppDefaultPolicy: (app) => req(`/app-configs/${encodeURIComponent(app)}/set-default-policy`, { method: "POST" }),
 };
 

--- a/web/src/pages/ApplicationDetail.jsx
+++ b/web/src/pages/ApplicationDetail.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { api, fmt } from "../api.js";
-import { Card, Badge, Spinner, Toggle, Tabs, useTabParam, ConfirmDialog } from "../components/ui.jsx";
+import { Card, Badge, Spinner, Toggle, Tabs, useTabParam, ConfirmDialog, Stat, Table } from "../components/ui.jsx";
 import RequestsTable from "../components/RequestsTable.jsx";
 
 const TABS = [
@@ -123,6 +123,8 @@ function RoutingPolicyTab({ appName, initialAssignments, initialModelOptOut, mod
   const [msg, setMsg]                 = useState(null);
   const [allowedMsg, setAllowedMsg]   = useState(null);
   const [confirmGen, setConfirmGen]   = useState(false);
+  const [goal, setGoal]               = useState("balanced"); // cost | balanced | quality
+  const [sim, setSim]                 = useState(null);        // impact simulation result
 
   useEffect(() => { api.aiPolicy().then(setGlobalPol).catch((e) => setMsg(e.message)); }, []);
 
@@ -138,6 +140,16 @@ function RoutingPolicyTab({ appName, initialAssignments, initialModelOptOut, mod
   // True when the allowed-models selection differs from what's persisted.
   const allowedDirty =
     JSON.stringify([...excluded].sort()) !== JSON.stringify([...(initialModelOptOut || [])].sort());
+
+  // Simulator delta labels. Cost is a real projection; capability index is a heuristic proxy.
+  const pctChange = (cur, proj) => (cur > 0 ? Math.round(((proj - cur) / cur) * 100) : 0);
+  const costDeltaLabel = (s) => { const p = pctChange(s.current?.cost || 0, s.projected?.cost || 0); return `${p > 0 ? "+" : ""}${p}% vs current`; };
+  const capLabel = (x) => (x == null ? "—" : Number(x).toFixed(2));
+  const capDeltaLabel = (s) => {
+    const c = s.current?.capabilityIndex, p = s.projected?.capabilityIndex;
+    if (c == null || p == null) return null;
+    const d = p - c; return `${d >= 0 ? "+" : ""}${d.toFixed(2)} vs current`;
+  };
 
   function dominantModel(tier) {
     const counts = {};
@@ -175,17 +187,26 @@ function RoutingPolicyTab({ appName, initialAssignments, initialModelOptOut, mod
     finally { setBusy(false); }
   };
 
-  // Generate uses excluded as the exclusion list automatically.
+  // Generate uses excluded as the exclusion list automatically, optimizing for the chosen goal.
   const generate = async () => {
     setConfirmGen(false);
-    setBusy(true); setMsg("Generating with AI…");
+    setBusy(true); setMsg(`Generating (goal: ${goal})…`); setSim(null);
     try {
-      const result = await api.generateAppPolicy(appName, excluded);
+      const result = await api.generateAppPolicy(appName, excluded, goal);
       setAssignments(result.assignments);
+      setSim(result.simulation || null);
       setMsg(result.generatorModel ? `Done — via ${result.generatorModel}` : "Done");
       setTimeout(() => setMsg(null), 3000);
       onSaved?.();
     } catch (e) { setMsg(e.message); }
+    finally { setBusy(false); }
+  };
+
+  // Re-project impact for the current (possibly hand-edited) assignments over recent traffic.
+  const resimulate = async () => {
+    setBusy(true);
+    try { setSim(await api.simulateAppPolicy(appName, effectiveAssignments)); }
+    catch (e) { setMsg(e.message); }
     finally { setBusy(false); }
   };
 
@@ -230,6 +251,17 @@ function RoutingPolicyTab({ appName, initialAssignments, initialModelOptOut, mod
           />
         )}
         <div className="space-y-4">
+          {/* Goal selector — generation optimizes the cost/capability blend for this goal */}
+          <div className="flex items-center gap-2 text-xs">
+            <span className="text-gray-500">Optimize for:</span>
+            {["cost", "balanced", "quality"].map((g) => (
+              <button key={g} type="button"
+                className={goal === g ? "btn-secondary text-xs" : "btn-outline text-xs"}
+                disabled={busy} onClick={() => setGoal(g)}>
+                {g[0].toUpperCase() + g.slice(1)}
+              </button>
+            ))}
+          </div>
           {/* Action bar */}
           <div className="flex flex-wrap items-center gap-3">
             {usingGlobal ? (
@@ -252,6 +284,37 @@ function RoutingPolicyTab({ appName, initialAssignments, initialModelOptOut, mod
             )}
             {msg && <span className="text-xs text-gray-500">{msg}</span>}
           </div>
+
+          {/* Impact simulator — projected cost (real) + capability index (heuristic proxy) over recent traffic */}
+          {sim && (
+            <div className="space-y-2 rounded-lg border border-gray-200 p-3">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium">
+                  Projected impact{" "}
+                  <span className="text-xs font-normal text-gray-400">
+                    (last {sim.windowDays}d · cost is real, capability is an estimate)
+                  </span>
+                </span>
+                <button className="btn-ghost text-xs" disabled={busy} onClick={resimulate}>Re-simulate</button>
+              </div>
+              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                <Stat label="Projected cost" value={fmt.usd(sim.projected?.cost)} sub={costDeltaLabel(sim)} />
+                <Stat label="Current cost" value={fmt.usd(sim.current?.cost)} />
+                <Stat label="Capability index" value={capLabel(sim.projected?.capabilityIndex)} sub={capDeltaLabel(sim)} />
+              </div>
+              {sim.rows?.length > 0 && (
+                <Table
+                  columns={[
+                    { key: "taskType", header: "Task", render: (r) => r.taskType },
+                    { key: "proposedModel", header: "Model", render: (r) => r.proposedModel || "—" },
+                    { key: "requests", header: "Reqs", render: (r) => fmt.num(r.requests) },
+                    { key: "saved", header: "Saved", render: (r) => fmt.usd(r.saved) },
+                  ]}
+                  rows={sim.rows.slice(0, 8)}
+                />
+              )}
+            </div>
+          )}
 
           {/* Tier accordions */}
           <div className="space-y-2">

--- a/web/src/pages/Routing.jsx
+++ b/web/src/pages/Routing.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
-import { api } from "../api.js";
-import { Card, Table, Toggle, Badge, Spinner, Tabs, useTabParam, ConfirmDialog } from "../components/ui.jsx";
+import { api, fmt } from "../api.js";
+import { Card, Table, Stat, Toggle, Badge, Spinner, Tabs, useTabParam, ConfirmDialog } from "../components/ui.jsx";
 import Recommendations from "./Recommendations.jsx";
 
 const TABS = [
@@ -193,23 +193,34 @@ function AiPolicyEditor({ models }) {
   const [msg, setMsg] = useState(null);
   const [confirmRegen, setConfirmRegen] = useState(false);
   const [expanded, setExpanded] = useState({ light: false, mid: false, premium: false, custom: true });
+  const [goal, setGoal] = useState("balanced"); // cost | balanced | quality
+  const [sim, setSim] = useState(null);
   const load = () => api.aiPolicy().then((p) => { setPol(p); setAssignments({ ...p.assignments }); }).catch((e) => setMsg(e.message));
   useEffect(() => { load(); }, []);
   if (!pol) return <Spinner />;
 
   const regen = async () => {
     setConfirmRegen(false);
-    setBusy(true); setMsg("Generating policy with AI…");
+    setBusy(true); setMsg(`Generating (goal: ${goal})…`); setSim(null);
     try {
-      const p = await api.regenerateAiPolicy();
+      const p = await api.regenerateAiPolicy(goal);
       setPol(p);
       setAssignments({ ...p.assignments });
+      setSim(p.simulation || null);
       setMsg(p.generatorModel ? `Done — via ${p.generatorModel}` : "Done");
       setTimeout(() => setMsg(null), 3000);
     }
     catch (e) { setMsg(e.message); }
     finally { setBusy(false); }
   };
+  const resimulate = async () => {
+    setBusy(true);
+    try { setSim(await api.simulatePolicy(assignments)); }
+    catch (e) { setMsg(e.message); }
+    finally { setBusy(false); }
+  };
+  const costDeltaLabel = (s) => { const c = s.current?.cost || 0, p = s.projected?.cost || 0; const pc = c > 0 ? Math.round(((p - c) / c) * 100) : 0; return `${pc > 0 ? "+" : ""}${pc}% vs current`; };
+  const capDeltaLabel = (s) => { const c = s.current?.capabilityIndex, p = s.projected?.capabilityIndex; if (c == null || p == null) return null; const d = p - c; return `${d >= 0 ? "+" : ""}${d.toFixed(2)} vs current`; };
   const save = async () => {
     setBusy(true); setMsg(null);
     try { const p = await api.setAiPolicy(assignments); setPol(p); setAssignments({ ...p.assignments }); setMsg("Saved"); setTimeout(() => setMsg(null), 1500); }
@@ -248,6 +259,16 @@ function AiPolicyEditor({ models }) {
           onCancel={() => setConfirmRegen(false)}
         />
       )}
+      <div className="flex items-center gap-2 text-xs">
+        <span className="text-gray-500">Optimize for:</span>
+        {["cost", "balanced", "quality"].map((g) => (
+          <button key={g} type="button"
+            className={goal === g ? "btn-secondary text-xs" : "btn-outline text-xs"}
+            disabled={busy} onClick={() => setGoal(g)}>
+            {g[0].toUpperCase() + g.slice(1)}
+          </button>
+        ))}
+      </div>
       <div className="flex flex-wrap items-center gap-3">
         <button className="btn-secondary" disabled={busy} onClick={() => setConfirmRegen(true)}>{busy ? "Generating…" : "Generate with AI"}</button>
         <button className="btn-outline" disabled={busy} onClick={save}>Save edits</button>
@@ -258,6 +279,37 @@ function AiPolicyEditor({ models }) {
         )}
         {msg && <span className="text-xs text-gray-500">{msg}</span>}
       </div>
+
+      {/* Impact simulator — projected cost (real) + capability index (heuristic proxy) over recent traffic */}
+      {sim && (
+        <div className="space-y-2 rounded-lg border border-gray-200 p-3">
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium">
+              Projected impact{" "}
+              <span className="text-xs font-normal text-gray-400">
+                (last {sim.windowDays}d · cost is real, capability is an estimate)
+              </span>
+            </span>
+            <button className="btn-ghost text-xs" disabled={busy} onClick={resimulate}>Re-simulate</button>
+          </div>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+            <Stat label="Projected cost" value={fmt.usd(sim.projected?.cost)} sub={costDeltaLabel(sim)} />
+            <Stat label="Current cost" value={fmt.usd(sim.current?.cost)} />
+            <Stat label="Capability index" value={sim.projected?.capabilityIndex == null ? "—" : Number(sim.projected.capabilityIndex).toFixed(2)} sub={capDeltaLabel(sim)} />
+          </div>
+          {sim.rows?.length > 0 && (
+            <Table
+              columns={[
+                { key: "taskType", header: "Task", render: (r) => r.taskType },
+                { key: "proposedModel", header: "Model", render: (r) => r.proposedModel || "—" },
+                { key: "requests", header: "Reqs", render: (r) => fmt.num(r.requests) },
+                { key: "saved", header: "Saved", render: (r) => fmt.usd(r.saved) },
+              ]}
+              rows={sim.rows.slice(0, 8)}
+            />
+          )}
+        </div>
+      )}
 
       {pol.unmapped.length > 0 && (
         <div className="text-xs text-amber-700">


### PR DESCRIPTION
## Why

Two asks: (1) pick a **goal** before generating an AI routing policy, and (2) see a **simulator** — the projected cost (and a quality proxy) of the proposed policy over recent traffic. Both reuse existing machinery (the `aiPolicy.js` scoring engine + the recommender's re-pricing aggregation), so the change is mostly wiring.

## What changed

**Goal-driven generation**
- `goal` ∈ `cost | balanced | quality` re-weights the existing cost-vs-capability blend at the one scoring injection point (`goalWeight` → `_scoringFallback`) and is added to the LLM-generation prompt. `balanced` = today's per-tier behavior (**default**), so nothing changes unless a goal is chosen. Threaded through `computeAssignments` + `regenerate`.

**Impact simulator**
- `aiPolicy.simulate({assignments, application, windowDays})`: aggregates recent `request_records` by taskType and **re-prices the tokens at the proposed models** (`pricing.costFor`), returning **projected vs current cost** and a traffic-weighted **capability index**. Pure math in `routing/policySim.js`.
- **Honest framing:** cost is a real projection; the capability index is a **heuristic proxy** (capability scores, not measured quality) — labeled in the UI.

**API**
- Generate endpoints (`/ai-policy/regenerate`, `/app-configs/:app/generate-policy`) accept `{goal, windowDays}` and return the `simulation` alongside the proposed policy.
- New `POST /ai-policy/simulate` and `POST /app-configs/:app/simulate` re-project an edited policy (no persist).

**UI** (per-app Routing policy tab + global AI policy editor)
- Goal selector (Cost / Balanced / Quality) and a "Projected impact" panel: projected cost + Δ%, capability index + Δ, and a per-task table. "Re-simulate" after hand-edits.

## Deliberate scope note
Generate still **persists** as before — I kept that to avoid reworking both pages' persist flow on web code I can't build/test locally. The simulator shows impact right after generation and on demand. Strict preview-before-apply (no auto-persist) can be a fast-follow if you want it.

## Deferred (agreed)
**Latency goal** — needs a new scoring dimension + per-(taskType,model) latency aggregation; historical latency is noisy with a cold-start for new models.

## Testing
- `npm run smoke:simulate` — **8/8** (projection math: re-pricing, capability index, unmapped→no-change, unpriceable→keep-actual, sorting, empty-safe).
- `node --check` all changed server files; esbuild-validated both JSX pages.

## Verify on deploy
For an app with traffic: goal=cost → cheaper assignments + a negative cost delta vs the last 14d; goal=quality → stronger models + positive capability delta; "Re-simulate" reflects manual edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
