### PR TITLE
feat(web): per-request routing-flow strip in the request drilldown

### DIFF
--- a/web/src/components/RequestsTable.jsx
+++ b/web/src/components/RequestsTable.jsx
@@ -10,6 +10,53 @@ const CLASSIFY = {
   ai:       { tone: "violet", label: "AI" },
 };
 
+// One node in the request-flow strip.
+function FlowNode({ label, value, sub }) {
+  return (
+    <div className="flex shrink-0 flex-col items-center rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-center">
+      <div className="text-[10px] uppercase tracking-wide text-gray-400">{label}</div>
+      <div className="text-sm font-medium text-arbr-charcoal">{value}</div>
+      {sub && <div className="text-[10px] text-gray-400">{sub}</div>}
+    </div>
+  );
+}
+const FlowArrow = () => <span className="shrink-0 text-gray-300">→</span>;
+
+// Visualizes a single request's actual path: app → Arbr (classify → route) → model → provider,
+// built entirely from the logged record. No backend dependency.
+function RequestFlow({ r }) {
+  const classify = CLASSIFY[r.classifiedBy] || CLASSIFY.keyword;
+  const classifySub = [
+    classify.label,
+    r.difficulty ? `${r.difficulty}${r.difficultyScore ? ` ${r.difficultyScore}/10` : ""}` : null,
+    r.confidence != null ? `conf ${Number(r.confidence).toFixed(2)}` : null,
+  ].filter(Boolean).join(" · ");
+  const changed = r.modelRequested && r.modelRequested !== r.model;
+  return (
+    <div className="flex items-center gap-2 overflow-x-auto pb-1">
+      <FlowNode label="App" value={r.application || "—"} />
+      <FlowArrow />
+      <FlowNode label="Classify" value={r.taskType || "—"} sub={classifySub} />
+      <FlowArrow />
+      <div className="flex shrink-0 flex-col items-center gap-1 px-1">
+        <span className="text-[10px] uppercase tracking-wide text-gray-400">Route</span>
+        <Badge tone={ROUTING_TONE[r.routingDecision]}>{r.routingDecision}</Badge>
+      </div>
+      <FlowArrow />
+      {r.cacheHit && (<><FlowNode label="Cache" value="hit" /><FlowArrow /></>)}
+      <FlowNode
+        label="Model"
+        value={changed
+          ? <span><span className="text-gray-400 line-through">{r.modelRequested}</span> → {r.model}</span>
+          : (r.model || "—")}
+      />
+      <FlowArrow />
+      <FlowNode label="Provider" value={r.provider || "—"} />
+      {r.status !== "success" && <span className="shrink-0"><Badge tone="red">{r.status}</Badge></span>}
+    </div>
+  );
+}
+
 const EMPTY_FILTER = { application: "", workflow: "", department: "", model: "", provider: "", taskType: "" };
 
 const PERIODS = [
@@ -196,6 +243,7 @@ export default function RequestsTable({ fixedFilters = {}, hiddenFilterKeys = []
             <div className="text-sm text-red-600">{detail._error}</div>
           ) : (
             <div className="space-y-5">
+              <RequestFlow r={detail} />
               <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
                 <Stat label="Status" value={detail.status} />
                 <Stat label="Routing" value={detail.routingDecision} />


### PR DESCRIPTION
## What

Adds a **per-request routing-flow strip** at the top of the request **drilldown** (the Drawer from #43) — a visual of how that specific request actually flowed:

**App → Classify → Route → Model → Provider**

- **Classify** node shows `taskType` + how it was determined (provided / rule-based / AI) + difficulty (`difficulty` + `difficultyScore`/10) + confidence.
- **Route** is the `routingDecision` badge (reuses `ROUTING_TONE`).
- **Model** shows `modelRequested → model` only when they differ (e.g. a downgrade), single node otherwise.
- A **Cache** node appears on a cache hit; a red status marker on non-success.

Makes Arbr's routing legible at a glance: "this prompt was classified coding/light, routed by the AI policy, requested gpt-4o but served nova-lite on bedrock."

## Why it's low-risk
Frontend-only, presentational. **No backend/API/schema change** — every field comes from the record `GET /requests/:id` already returns. Reuses the existing `Badge` + `ROUTING_TONE`; the strip is `overflow-x-auto` so it never breaks the Drawer layout.

## Testing
esbuild-validated `RequestsTable.jsx`.

## Verify on deploy
Open requests of different shapes: an **explicit** request → single model node + `explicit` badge; an **auto** request → classify node (taskType + difficulty) + `ai` badge + served model; a **downgrade** → `modelRequested → model` differs; a **cache hit** → cache node; a **failure** → red marker.

## Note
Built on #43 (now merged). Out of scope / possible follow-ons: an aggregate Sankey (apps → taskTypes → models) and a static architecture diagram for docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
