### PR TITLE
docs: add Integrations guides — Connect LibreChat & OpenCode

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -35,6 +35,7 @@ export default defineConfig({
       {
         text: 'Integrations',
         items: [
+          { text: 'Connect LibreChat', link: '/integrations/librechat' },
           { text: 'Connect OpenCode', link: '/integrations/opencode' },
         ]
       },

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -33,6 +33,12 @@ export default defineConfig({
         ]
       },
       {
+        text: 'Integrations',
+        items: [
+          { text: 'Connect OpenCode', link: '/integrations/opencode' },
+        ]
+      },
+      {
         text: 'Providers',
         collapsed: false,
         items: [

--- a/docs/gateway/openai-compat.md
+++ b/docs/gateway/openai-compat.md
@@ -138,3 +138,5 @@ client.chat.completions.create(
 ## Chat UI integration (LibreChat, OpenWebUI, etc.)
 
 Set the base URL to `http://your-arbr-host:4100` and your gateway key as the API key. The UI works immediately — every message is now routed, logged, and governed by Arbr.
+
+For terminal-based coding agents, see [Connect OpenCode](/integrations/opencode).

--- a/docs/gateway/openai-compat.md
+++ b/docs/gateway/openai-compat.md
@@ -139,4 +139,4 @@ client.chat.completions.create(
 
 Set the base URL to `http://your-arbr-host:4100` and your gateway key as the API key. The UI works immediately — every message is now routed, logged, and governed by Arbr.
 
-For terminal-based coding agents, see [Connect OpenCode](/integrations/opencode).
+For step-by-step guides, see [Connect LibreChat](/integrations/librechat) and, for terminal-based coding agents, [Connect OpenCode](/integrations/opencode).

--- a/docs/integrations/librechat.md
+++ b/docs/integrations/librechat.md
@@ -1,0 +1,108 @@
+# Connect LibreChat
+
+[LibreChat](https://www.librechat.ai) is a self-hosted, multi-model chat UI. Because Arbr exposes an
+OpenAI-compatible endpoint, you can add Arbr as a **custom endpoint** in LibreChat — every message
+your users send is then routed, costed, logged, and governed by Arbr, with no change to LibreChat
+itself.
+
+No Arbr code change is required. You add Arbr as a custom endpoint in `librechat.yaml`.
+
+## 1. Create a gateway API key
+
+In the Arbr dashboard, go to **Settings → API keys** and create a key bound to an application
+(e.g. `librechat`). The application name is how this traffic shows up in **Overview**, **Requests**,
+budgets, and per-app routing policy.
+
+If **Require API keys** is on (the default for a deployed instance), this step is mandatory and the
+key also drives attribution. Put the key in LibreChat's `.env`:
+
+```sh
+# LibreChat .env
+ARBR_API_KEY=ab_…
+```
+
+## 2. Add Arbr as a custom endpoint
+
+Edit `librechat.yaml` and add Arbr under `endpoints.custom`:
+
+```yaml
+version: 1.2.1
+cache: true
+
+endpoints:
+  custom:
+    - name: "Arbr"
+      apiKey: "${ARBR_API_KEY}"
+      baseURL: "https://your-arbr-host/v1"
+      models:
+        default:
+          - "claude-haiku-4-5"
+          - "gpt-4o"
+          - "gemini-2.5-flash"
+        fetch: false
+      titleConvo: true
+      titleModel: "claude-haiku-4-5"
+      modelDisplayLabel: "Arbr"
+```
+
+- `baseURL` points at your Arbr gateway with the `/v1` suffix — e.g. `http://localhost:4100/v1` for a
+  local instance, or `https://your-arbr-host/v1` for a deployed one.
+- `apiKey` reads the key from LibreChat's environment via `${ARBR_API_KEY}`.
+- `models.default` lists the models the picker offers. Each entry is an Arbr model id — see
+  **Models** in the dashboard, or [Model registry](/models), for valid ids.
+- Set `models.fetch: true` instead of a `default` list to have LibreChat pull the live model list
+  from Arbr's `/v1/models` endpoint automatically.
+
+Restart LibreChat. **Arbr** now appears as an endpoint in the model selector.
+
+::: tip Running both in Docker
+If LibreChat runs in a container and Arbr runs on the host, `localhost` won't resolve from inside the
+container — use `http://host.docker.internal:4100/v1`. If both run in the same Docker network, use the
+Arbr service name, e.g. `http://arbr:4100/v1`.
+:::
+
+## Auto-routing works well here
+
+Unlike an agentic coding tool, LibreChat is plain chat — so you can lean on Arbr's routing. Add
+`auto` (or any model you've set up routing for) to the model list and let Arbr classify each message
+and pick the cheapest model that fits:
+
+```yaml
+      models:
+        default:
+          - "auto"
+          - "claude-haiku-4-5"
+          - "gpt-4o"
+```
+
+Users pick **auto**; Arbr decides the served model per message. The decision shows up per request in
+the dashboard. See [Routing](/routing) for how classification and the AI policy choose.
+
+## Avoid truncated replies
+
+LibreChat sends a `max_tokens` derived from the selected model's config. If it sends a small value,
+replies get cut off mid-sentence. Two things to check:
+
+- Arbr's default output cap is 4096 tokens (`ARBR_DEFAULT_MAX_TOKENS`) — raise it on the Arbr instance
+  if your chats need longer answers. See [Configuration](/configuration).
+- In LibreChat, set a sensible `maxOutputTokens` for the endpoint/model so it doesn't request a tiny
+  ceiling.
+
+## Verify it's flowing through Arbr
+
+Send a message in LibreChat, then open the Arbr dashboard:
+
+- **Overview / Requests** — filter by application `librechat`; you should see the message with its
+  served model, provider, token counts, cost, and latency.
+- Click a row to open the **request drilldown** and confirm the routing decision and the
+  prompt/response were captured.
+
+If the endpoint doesn't appear or calls fail, check that `baseURL` ends in `/v1`, that `ARBR_API_KEY`
+is set in LibreChat's `.env`, and that the key is valid in **Settings → API keys**.
+
+## Related
+
+- [OpenAI-compatible endpoint](/gateway/openai-compat) — the API LibreChat talks to
+- [Connect OpenCode](/integrations/opencode) — the same pattern for a terminal coding agent
+- [Routing](/routing) — how Arbr picks models, and how `auto` classification works
+- [Budgets & governance](/budgets) — caps and kill-switches that apply to LibreChat traffic too

--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -1,0 +1,104 @@
+# Connect OpenCode
+
+[OpenCode](https://opencode.ai) is a terminal-based AI coding agent. Because Arbr exposes an
+OpenAI-compatible endpoint, OpenCode can send every request through Arbr — so all of your agentic
+coding traffic is routed, costed, logged, and governed alongside the rest of your AI usage.
+
+No Arbr code change is required. You add Arbr as a custom provider in OpenCode's config.
+
+## 1. Create a gateway API key
+
+In the Arbr dashboard, go to **Settings → API keys** and create a key bound to an application
+(e.g. `opencode`). The application name is how this traffic shows up in **Overview**, **Requests**,
+budgets, and per-app routing policy — so give it a name you'll recognise.
+
+If **Require API keys** is on (the default for a deployed instance), this step is mandatory and the
+key also drives attribution. Copy the key (`ab_…`) and export it:
+
+```sh
+export ARBR_API_KEY="ab_…"
+```
+
+## 2. Add Arbr as a provider in `opencode.json`
+
+OpenCode reads `opencode.json` from your project root (or `~/.config/opencode/opencode.json` for a
+global config). Register Arbr as an OpenAI-compatible provider:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "arbr": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Arbr",
+      "options": {
+        "baseURL": "https://your-arbr-host/v1",
+        "apiKey": "{env:ARBR_API_KEY}"
+      },
+      "models": {
+        "claude-haiku-4-5": { "name": "Claude Haiku 4.5 (via Arbr)" },
+        "gpt-4o":           { "name": "GPT-4o (via Arbr)" },
+        "bedrock-nova-pro": { "name": "Nova Pro (via Arbr)" }
+      }
+    }
+  }
+}
+```
+
+- `baseURL` points at your Arbr gateway with the `/v1` suffix — e.g. `http://localhost:4100/v1` for a
+  local instance, or `https://your-arbr-host/v1` for a deployed one.
+- `apiKey` reads the key from the environment via `{env:ARBR_API_KEY}` so it never lands in the file.
+- `models` lists the models you want OpenCode to offer. Each key is an Arbr model id — see
+  **Models** in the dashboard, or [Model registry](/models), for valid ids.
+
+## 3. Select an Arbr model
+
+Pick a model in OpenCode (the picker shows them as `arbr/<model>`), or pin one in config:
+
+```json
+{
+  "model": "arbr/claude-haiku-4-5"
+}
+```
+
+That's it — OpenCode now drives every request through Arbr.
+
+## Pin a tool-capable model — don't use `auto`
+
+::: warning Use a pass-through, tool-capable model
+OpenCode is agentic: it leans heavily on **tool calls** (read file, edit, run command). Pin a model
+that preserves tool calls end to end — the OpenAI-compatible providers (OpenAI / LiteLLM proxy) and
+**Bedrock Nova** are reliable here.
+
+Avoid routing OpenCode through `"auto"`. Auto-routing may land the request on a path that collapses
+or drops `tool_calls`, which leaves the agent unable to act on the response. For an agent, pin a
+specific tool-capable model rather than letting the classifier choose.
+:::
+
+If you want Arbr to still apply budgets and logging while keeping tool calls intact, pin an explicit
+model id (as above) instead of `auto`. You keep observability and governance; OpenCode keeps its
+tools.
+
+## Give the agent enough output room
+
+Agentic edits can be large. Arbr's default output cap is 4096 tokens
+(`ARBR_DEFAULT_MAX_TOKENS`). If OpenCode responses get truncated mid-edit, either raise that on the
+Arbr instance or have OpenCode send a larger `max_tokens`. See [Configuration](/configuration).
+
+## Verify it's flowing through Arbr
+
+Run a prompt in OpenCode, then open the Arbr dashboard:
+
+- **Overview / Requests** — filter by application `opencode`; you should see the request with its
+  served model, provider, token counts, cost, and latency.
+- Click a row to open the **request drilldown** and confirm the routing decision and the
+  prompt/response were captured.
+
+If nothing shows up, check that `baseURL` ends in `/v1`, that `ARBR_API_KEY` is exported in the same
+shell OpenCode runs in, and that the key is valid in **Settings → API keys**.
+
+## Related
+
+- [OpenAI-compatible endpoint](/gateway/openai-compat) — the API OpenCode talks to
+- [Routing](/routing) — how Arbr picks models, and how explicit pins override auto
+- [Budgets & governance](/budgets) — caps and kill-switches that apply to OpenCode traffic too


### PR DESCRIPTION
## What

Two new docs pages under a new **Integrations** section, covering how to put Arbr in front of OpenAI-compatible clients via the `/v1` endpoint. No Arbr code change — each client just registers Arbr as a custom provider/endpoint.

### Connect LibreChat (`docs/integrations/librechat.md`)
- App-bound gateway key → `librechat.yaml` `endpoints.custom` block (`baseURL` ending `/v1`, `apiKey` from `${ARBR_API_KEY}`, model list or `fetch: true`).
- Docker note (`host.docker.internal` / service-name base URLs).
- Auto-routing is a good fit for plain chat (contrast with the agentic tool-call case below).
- Truncation / `ARBR_DEFAULT_MAX_TOKENS` guidance.

### Connect OpenCode (`docs/integrations/opencode.md`)
- App-bound gateway key → `opencode.json` provider (`@ai-sdk/openai-compatible`, `baseURL` ending `/v1`, `apiKey` from `{env:ARBR_API_KEY}`, `models` map) → select `arbr/<model>`.
- **Pin a tool-capable pass-through model, not `"auto"`** — OpenCode is tool-call heavy, and auto-routing can land on a path that collapses `tool_calls`.

Both pages end with a verify-in-dashboard step and cross-links.

## Also
- New **Integrations** sidebar section.
- Cross-link from the OpenAI-compat gateway page to both guides.

Docs-only. `node --check` passes on the sidebar config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)