### PR TITLE
fix: clamp max_tokens to the served model output ceiling

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "smoke:savings": "node server/scripts/savings-smoke.js",
     "smoke:simulate": "node server/scripts/simulate-smoke.js",
     "smoke:logging": "node server/scripts/logging-smoke.js",
+    "smoke:maxtokens": "node server/scripts/maxtokens-smoke.js",
     "lint": "eslint server/src",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",

--- a/server/scripts/maxtokens-smoke.js
+++ b/server/scripts/maxtokens-smoke.js
@@ -1,0 +1,28 @@
+// Pure-logic smoke test for the per-model max_tokens clamp (no DB / no provider keys).
+// Run: npm run smoke:maxtokens
+const { clampMaxTokens } = require("../src/pricing/clamp");
+
+let pass = 0, fail = 0;
+const eq = (got, exp, msg) => {
+  if (got === exp) { pass++; } else { fail++; console.log(`FAIL: ${msg} — got ${got}, expected ${exp}`); }
+};
+
+// 1. Over-large request is clamped to the model's ceiling (the OpenCode → gpt-4o case).
+eq(clampMaxTokens(32000, 16384), 16384, "32000 clamped to 16384");
+
+// 2. Request within range is left untouched.
+eq(clampMaxTokens(8000, 16384), 8000, "8000 within 16384 unchanged");
+
+// 3. Exactly at the cap is left untouched.
+eq(clampMaxTokens(16384, 16384), 16384, "16384 at cap unchanged");
+
+// 4. Unknown cap (model not synced) → never clamps, behavior unchanged.
+eq(clampMaxTokens(32000, null), 32000, "unknown cap leaves request as-is");
+eq(clampMaxTokens(32000, 0), 32000, "zero/falsy cap leaves request as-is");
+
+// 5. No client max_tokens → nothing to clamp (provider/default applies downstream).
+eq(clampMaxTokens(undefined, 16384), undefined, "no request value passes through");
+eq(clampMaxTokens(null, 16384), null, "null request value passes through");
+
+console.log(`${pass}/${pass + fail} passed`);
+process.exit(fail ? 1 : 0);

--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -296,6 +296,11 @@ async function handleChat(req, res) {
     }
   }
 
+  // Per-model output clamp: cap maxTokens to the SERVED model's known ceiling, so an
+  // over-large client value doesn't 400 upstream. Only clamps when the cap is known
+  // (populated by the LiteLLM sync); unknown → left untouched.
+  body.maxTokens = pricing.clampMaxTokens(body.maxTokens, pricing.maxOutputFor(served.model));
+
   // Response cache, keyed by the decided served model.
   {
     const cached = responseCache.get(served.model, body.messages);

--- a/server/src/gateway/openaiCompat.js
+++ b/server/src/gateway/openaiCompat.js
@@ -362,6 +362,12 @@ async function handleOpenAICompat(req, res) {
     if (target) { served = { provider: target.provider, model: target.model }; routingDecision = "budget"; }
   }
 
+  // Per-model output clamp: cap max_tokens to the SERVED model's known ceiling. Tool agents
+  // (e.g. OpenCode) request very large output budgets; without this, an over-large value is
+  // forwarded verbatim and the upstream 400s ("max_tokens is too large"). Only clamps when the
+  // model's cap is known (populated by the LiteLLM sync); unknown → left untouched.
+  body.max_tokens = pricing.clampMaxTokens(body.max_tokens, pricing.maxOutputFor(served.model));
+
   // Transparent passthrough for OpenAI-compatible providers (e.g. LiteLLM): forward the raw
   // body so tools/tool_calls/vision/response_format/streaming survive intact. Native providers
   // (anthropic/gemini/bedrock) fall through to the LangChain path below.

--- a/server/src/litellm/sync.js
+++ b/server/src/litellm/sync.js
@@ -185,6 +185,7 @@ async function run() {
       builtIn:       false,
       enabled:       true,
       contextWindow: parseInt(ltEntry.max_input_tokens, 10) || null,
+      maxOutputTokens: parseInt(ltEntry.max_output_tokens, 10) || null,
       litellmSyncedAt: now,
       ...extractFlags(ltEntry),
     });
@@ -236,6 +237,8 @@ async function run() {
 
     const maxIn = parseInt(ltEntry.max_input_tokens, 10);
     if (isFinite(maxIn) && maxIn > 0) update.contextWindow = maxIn;
+    const maxOut = parseInt(ltEntry.max_output_tokens, 10);
+    if (isFinite(maxOut) && maxOut > 0) update.maxOutputTokens = maxOut;
 
     const flags = extractFlags(ltEntry);
     for (const [k, v] of Object.entries(flags)) {

--- a/server/src/models/ModelEntry.js
+++ b/server/src/models/ModelEntry.js
@@ -18,6 +18,9 @@ const modelEntrySchema = new mongoose.Schema(
     bestUsedFor:   { type: String, default: "" },
     releaseDate:   { type: String, default: "" },
     contextWindow: { type: Number, default: null },
+    // Max completion (output) tokens the model accepts. Populated from LiteLLM's
+    // max_output_tokens. null = unknown → the gateway leaves client max_tokens untouched.
+    maxOutputTokens: { type: Number, default: null },
     capabilities: {
       coding:    { type: Number, default: null },
       reasoning: { type: Number, default: null },

--- a/server/src/pricing/clamp.js
+++ b/server/src/pricing/clamp.js
@@ -1,0 +1,10 @@
+// Pure max_tokens clamp, kept dependency-free (no mongoose) so both gateway paths and the
+// smoke test can use it without a DB. Returns the value to actually send: the requested
+// max_tokens capped at `cap`, or the requested value untouched when `cap` is falsy (unknown)
+// or the request is already within range.
+function clampMaxTokens(requested, cap) {
+  if (cap && requested && requested > cap) return cap;
+  return requested;
+}
+
+module.exports = { clampMaxTokens };

--- a/server/src/pricing/registry.js
+++ b/server/src/pricing/registry.js
@@ -6,6 +6,7 @@
 const ModelEntry = require("../models/ModelEntry");
 const Settings = require("../models/Settings");
 const { run: seedModels, SEED_VERSION } = require("../seed/seedModels");
+const { clampMaxTokens } = require("./clamp");
 
 // Task types that are "cheap work" — safe candidates for a lighter model.
 const CHEAP_TASK_TYPES = new Set([
@@ -101,6 +102,13 @@ function costFor(modelId, promptTokens = 0, completionTokens = 0, cache = {}) {
   return { inputCost, outputCost, totalCost: inputCost + outputCost };
 }
 
+// Max completion tokens the model accepts, or null when unknown. The gateway uses this
+// to clamp an over-large client max_tokens to the served model's ceiling.
+function maxOutputFor(modelId) {
+  const m = _cache[modelId];
+  return m && m.maxOutputTokens ? m.maxOutputTokens : null;
+}
+
 function suggestLightTarget(modelId) {
   const m = _cache[modelId];
   if (!m) return null;
@@ -122,5 +130,7 @@ module.exports = {
   isPremium,
   isCheapTask,
   costFor,
+  maxOutputFor,
+  clampMaxTokens,
   suggestLightTarget,
 };


### PR DESCRIPTION
## Problem

A teammate connecting OpenCode to Arbr hit:

```
upstream 400: max_tokens is too large: 32000. This model supports at most
16384 completion tokens, whereas you provided 32000.
```

OpenCode (and tool agents generally) request a large output budget. The request was served by `gpt-4o`, which caps completion at 16384. Arbr forwarded `max_tokens: 32000` verbatim → upstream 400. The only existing guard was the global `maxTokensGuardrail` (unset by default); there was no per-model awareness.

## Fix

Capture each model's `max_output_tokens` from the LiteLLM sync (already in the source JSON, just dropped today) and clamp the request's `max_tokens` to the **served** model's ceiling — after routing and any budget downgrade — in both gateway paths.

- **ModelEntry** — add `maxOutputTokens` (nullable).
- **litellm/sync** — capture `max_output_tokens` on insert + refresh.
- **pricing/registry** — `maxOutputFor(model)`; pure `clampMaxTokens` lives in `pricing/clamp.js` (dependency-free so it's unit-testable without a DB).
- **gateway** — `handler.js` + `openaiCompat.js` clamp the served-model `max_tokens`.
- **smoke:maxtokens** — clamp / no-clamp / at-cap / unknown-cap / no-value (7/7 pass).

**Graceful:** when a model's cap is unknown (not yet synced), the request is left untouched — nothing regresses.

## Deploy note

The cap is populated by the LiteLLM model sync. After deploying, run a **model sync** (dashboard, or `POST /api/litellm/sync`) so existing model rows pick up `maxOutputTokens`. Until then the clamp is a no-op and the global `maxTokensGuardrail` remains the fallback. The "give the agent output room" guidance in the OpenCode docs (PR #45) still applies.

## Verify
- `npm run smoke:maxtokens` → 7/7
- Live: connect OpenCode pinned to `gpt-4o`, send a request → no more `max_tokens is too large`; request lands in the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)