### PR TITLE
fix: seed maxOutputTokens for built-in models

### DIFF
--- a/server/src/seed/seedModels.js
+++ b/server/src/seed/seedModels.js
@@ -9,17 +9,17 @@
 //
 // HOW TO UPDATE: change model data below, then increment SEED_VERSION by 1.
 // registry.init() will detect the version mismatch on next server start and re-seed automatically.
-const SEED_VERSION = 2;
+const SEED_VERSION = 3;
 
 const SEED = [
   // ── Anthropic ──
-  { id: "claude-opus-4-8",   label: "Claude Opus 4.8",         provider: "anthropic",    inputPer1M: 5.00,  outputPer1M: 25.00, tier: "premium", bestUsedFor: "Complex reasoning, long-form analysis, and nuanced generation",   releaseDate: "2025-06", contextWindow: 200000 },
-  { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6",       provider: "anthropic",    inputPer1M: 3.00,  outputPer1M: 15.00, tier: "mid",     bestUsedFor: "Balanced speed and capability for most tasks",                    releaseDate: "2025-04", contextWindow: 200000 },
-  { id: "claude-haiku-4-5",  label: "Claude Haiku 4.5",        provider: "anthropic",    inputPer1M: 1.00,  outputPer1M: 5.00,  tier: "light",   bestUsedFor: "Fast, lightweight tasks and high-volume completions",             releaseDate: "2025-02", contextWindow: 200000 },
+  { id: "claude-opus-4-8",   label: "Claude Opus 4.8",         provider: "anthropic",    inputPer1M: 5.00,  outputPer1M: 25.00, tier: "premium", bestUsedFor: "Complex reasoning, long-form analysis, and nuanced generation",   releaseDate: "2025-06", contextWindow: 200000, maxOutputTokens: 32000 },
+  { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6",       provider: "anthropic",    inputPer1M: 3.00,  outputPer1M: 15.00, tier: "mid",     bestUsedFor: "Balanced speed and capability for most tasks",                    releaseDate: "2025-04", contextWindow: 200000, maxOutputTokens: 64000 },
+  { id: "claude-haiku-4-5",  label: "Claude Haiku 4.5",        provider: "anthropic",    inputPer1M: 1.00,  outputPer1M: 5.00,  tier: "light",   bestUsedFor: "Fast, lightweight tasks and high-volume completions",             releaseDate: "2025-02", contextWindow: 200000, maxOutputTokens: 64000 },
 
   // ── OpenAI ──
-  { id: "gpt-4o",            label: "GPT-4o",                  provider: "openai",       inputPer1M: 2.50,  outputPer1M: 10.00, tier: "premium", bestUsedFor: "Multimodal tasks, vision, and complex reasoning",                 releaseDate: "2024-05", contextWindow: 128000 },
-  { id: "gpt-4o-mini",       label: "GPT-4o Mini",             provider: "openai",       inputPer1M: 0.15,  outputPer1M: 0.60,  tier: "light",   bestUsedFor: "Fast and cost-efficient general tasks",                          releaseDate: "2024-07", contextWindow: 128000 },
+  { id: "gpt-4o",            label: "GPT-4o",                  provider: "openai",       inputPer1M: 2.50,  outputPer1M: 10.00, tier: "premium", bestUsedFor: "Multimodal tasks, vision, and complex reasoning",                 releaseDate: "2024-05", contextWindow: 128000, maxOutputTokens: 16384 },
+  { id: "gpt-4o-mini",       label: "GPT-4o Mini",             provider: "openai",       inputPer1M: 0.15,  outputPer1M: 0.60,  tier: "light",   bestUsedFor: "Fast and cost-efficient general tasks",                          releaseDate: "2024-07", contextWindow: 128000, maxOutputTokens: 16384 },
 
   // ── Google Gemini ──
   { id: "gemini-2.5-pro",        label: "Gemini 2.5 Pro",        provider: "gemini",     inputPer1M: 1.25,  outputPer1M: 10.00, tier: "premium", bestUsedFor: "Advanced reasoning and million-token long context",               releaseDate: "2025-03", contextWindow: 1000000 },
@@ -27,23 +27,23 @@ const SEED = [
   { id: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash Lite", provider: "gemini",     inputPer1M: 0.10,  outputPer1M: 0.40,  tier: "light",   bestUsedFor: "Ultra-fast, cost-effective high-volume completions",              releaseDate: "2025-04", contextWindow: 1000000 },
 
   // ── Amazon Bedrock — Nova ──
-  { id: "us.amazon.nova-pro-v1:0",   label: "Nova Pro",   provider: "bedrock-nova", inputPer1M: 0.80,  outputPer1M: 3.20,  tier: "mid",   bestUsedFor: "Complex enterprise tasks with multimodal inputs",                  releaseDate: "2024-12", contextWindow: 300000 },
-  { id: "us.amazon.nova-lite-v1:0",  label: "Nova Lite",  provider: "bedrock-nova", inputPer1M: 0.06,  outputPer1M: 0.24,  tier: "light", bestUsedFor: "Fast multimodal tasks with cost efficiency",                       releaseDate: "2024-12", contextWindow: 300000 },
-  { id: "us.amazon.nova-micro-v1:0", label: "Nova Micro", provider: "bedrock-nova", inputPer1M: 0.035, outputPer1M: 0.14,  tier: "light", bestUsedFor: "Text-only, lowest latency and cost on Bedrock",                    releaseDate: "2024-12", contextWindow: 128000 },
+  { id: "us.amazon.nova-pro-v1:0",   label: "Nova Pro",   provider: "bedrock-nova", inputPer1M: 0.80,  outputPer1M: 3.20,  tier: "mid",   bestUsedFor: "Complex enterprise tasks with multimodal inputs",                  releaseDate: "2024-12", contextWindow: 300000, maxOutputTokens: 10000 },
+  { id: "us.amazon.nova-lite-v1:0",  label: "Nova Lite",  provider: "bedrock-nova", inputPer1M: 0.06,  outputPer1M: 0.24,  tier: "light", bestUsedFor: "Fast multimodal tasks with cost efficiency",                       releaseDate: "2024-12", contextWindow: 300000, maxOutputTokens: 10000 },
+  { id: "us.amazon.nova-micro-v1:0", label: "Nova Micro", provider: "bedrock-nova", inputPer1M: 0.035, outputPer1M: 0.14,  tier: "light", bestUsedFor: "Text-only, lowest latency and cost on Bedrock",                    releaseDate: "2024-12", contextWindow: 128000, maxOutputTokens: 10000 },
 
   // ── Amazon Bedrock — cross-inference (third-party models on Bedrock) ──
-  { id: "zai.glm-5",                              label: "GLM-5",                       provider: "bedrock-nova", inputPer1M: 1.00,  outputPer1M: 3.20,  tier: "mid",     bestUsedFor: "Chinese-English reasoning and generation",                       releaseDate: "2025-03", contextWindow: 128000 },
-  { id: "zai.glm-4.7-flash",                      label: "GLM-4.7 Flash",               provider: "bedrock-nova", inputPer1M: 0.14,  outputPer1M: 0.14,  tier: "light",   bestUsedFor: "Fast Chinese-English tasks",                                     releaseDate: "2025-04", contextWindow: 128000 },
+  { id: "zai.glm-5",                              label: "GLM-5",                       provider: "bedrock-nova", inputPer1M: 1.00,  outputPer1M: 3.20,  tier: "mid",     bestUsedFor: "Chinese-English reasoning and generation",                       releaseDate: "2025-03", contextWindow: 128000, maxOutputTokens: 128000 },
+  { id: "zai.glm-4.7-flash",                      label: "GLM-4.7 Flash",               provider: "bedrock-nova", inputPer1M: 0.14,  outputPer1M: 0.14,  tier: "light",   bestUsedFor: "Fast Chinese-English tasks",                                     releaseDate: "2025-04", contextWindow: 128000, maxOutputTokens: 32000 },
   { id: "moonshotai.kimi-k2.5",                   label: "Kimi K2.5",                   provider: "bedrock-nova", inputPer1M: 0.60,  outputPer1M: 3.00,  tier: "mid",     bestUsedFor: "Long context reasoning and document analysis",                    releaseDate: "2025-05", contextWindow: 128000 },
   // Converse API uses qwen.qwen3-next-80b-a3b (no -instruct suffix); the -instruct variant
   // is the Chat Completions / bedrock-mantle endpoint name only.
-  { id: "qwen.qwen3-next-80b-a3b",                label: "Qwen3 Next",                  provider: "bedrock-nova", inputPer1M: 0.50,  outputPer1M: 1.20,  tier: "light",   bestUsedFor: "Multilingual reasoning, coding, and instruction following",       releaseDate: "2025-05", contextWindow: 131072 },
-  { id: "deepseek.v3.2",                          label: "DeepSeek V3.2",               provider: "bedrock-nova", inputPer1M: 0.62,  outputPer1M: 1.85,  tier: "light",   bestUsedFor: "Cost-efficient coding and general reasoning",                    releaseDate: "2025-05", contextWindow: 128000 },
-  { id: "us.deepseek.r1-v1:0",                    label: "DeepSeek R1",                 provider: "bedrock-nova", inputPer1M: 1.35,  outputPer1M: 5.40,  tier: "premium", bestUsedFor: "Step-by-step chain-of-thought reasoning",                        releaseDate: "2025-01", contextWindow: 128000 },
-  { id: "google.gemma-3-12b-it",                  label: "Gemma 3 12B",                 provider: "bedrock-nova", inputPer1M: 0.09,  outputPer1M: 0.29,  tier: "light",   bestUsedFor: "Lightweight open-weight tasks on AWS infrastructure",             releaseDate: "2025-03", contextWindow: 128000 },
-  { id: "anthropic.claude-3-5-sonnet-20241022-v2:0", label: "Claude 3.5 Sonnet (Bedrock)", provider: "bedrock-nova", inputPer1M: 3.00, outputPer1M: 15.00, tier: "premium", bestUsedFor: "Enterprise tasks on AWS with Claude-class capability",           releaseDate: "2024-10", contextWindow: 200000 },
-  { id: "meta.llama3-70b-instruct-v1:0",          label: "Llama 3 70B",                 provider: "bedrock-nova", inputPer1M: 0.99,  outputPer1M: 0.99,  tier: "mid",     bestUsedFor: "Open-weight reasoning and instruction following",                 releaseDate: "2024-04", contextWindow: 8192   },
-  { id: "meta.llama3-8b-instruct-v1:0",           label: "Llama 3 8B",                  provider: "bedrock-nova", inputPer1M: 0.22,  outputPer1M: 0.22,  tier: "light",   bestUsedFor: "Fast open-weight tasks with minimal cost",                       releaseDate: "2024-04", contextWindow: 8192   },
+  { id: "qwen.qwen3-next-80b-a3b",                label: "Qwen3 Next",                  provider: "bedrock-nova", inputPer1M: 0.50,  outputPer1M: 1.20,  tier: "light",   bestUsedFor: "Multilingual reasoning, coding, and instruction following",       releaseDate: "2025-05", contextWindow: 131072, maxOutputTokens: 32768 },
+  { id: "deepseek.v3.2",                          label: "DeepSeek V3.2",               provider: "bedrock-nova", inputPer1M: 0.62,  outputPer1M: 1.85,  tier: "light",   bestUsedFor: "Cost-efficient coding and general reasoning",                    releaseDate: "2025-05", contextWindow: 128000, maxOutputTokens: 163840 },
+  { id: "us.deepseek.r1-v1:0",                    label: "DeepSeek R1",                 provider: "bedrock-nova", inputPer1M: 1.35,  outputPer1M: 5.40,  tier: "premium", bestUsedFor: "Step-by-step chain-of-thought reasoning",                        releaseDate: "2025-01", contextWindow: 128000, maxOutputTokens: 32768 },
+  { id: "google.gemma-3-12b-it",                  label: "Gemma 3 12B",                 provider: "bedrock-nova", inputPer1M: 0.09,  outputPer1M: 0.29,  tier: "light",   bestUsedFor: "Lightweight open-weight tasks on AWS infrastructure",             releaseDate: "2025-03", contextWindow: 128000, maxOutputTokens: 8192 },
+  { id: "anthropic.claude-3-5-sonnet-20241022-v2:0", label: "Claude 3.5 Sonnet (Bedrock)", provider: "bedrock-nova", inputPer1M: 3.00, outputPer1M: 15.00, tier: "premium", bestUsedFor: "Enterprise tasks on AWS with Claude-class capability",           releaseDate: "2024-10", contextWindow: 200000, maxOutputTokens: 8192 },
+  { id: "meta.llama3-70b-instruct-v1:0",          label: "Llama 3 70B",                 provider: "bedrock-nova", inputPer1M: 0.99,  outputPer1M: 0.99,  tier: "mid",     bestUsedFor: "Open-weight reasoning and instruction following",                 releaseDate: "2024-04", contextWindow: 8192, maxOutputTokens: 8192 },
+  { id: "meta.llama3-8b-instruct-v1:0",           label: "Llama 3 8B",                  provider: "bedrock-nova", inputPer1M: 0.22,  outputPer1M: 0.22,  tier: "light",   bestUsedFor: "Fast open-weight tasks with minimal cost",                       releaseDate: "2024-04", contextWindow: 8192, maxOutputTokens: 8192 },
 
   // ── DeepSeek (direct API) ──
   { id: "deepseek-chat",     label: "DeepSeek Chat",           provider: "deepseek",     inputPer1M: 0.27,  outputPer1M: 1.10,  tier: "light",   bestUsedFor: "Cost-efficient coding and conversational AI",                    releaseDate: "2025-01", contextWindow: 64000  },


### PR DESCRIPTION
## Why

#46 added a per-model `max_tokens` clamp, but its data source — the LiteLLM sync — only populates models whose catalog key is provider-prefixed. After deploying #46 and running a sync on prod, **1454/1522** models got a cap, but **17 built-ins did not**, including `gpt-4o` — the exact model the OpenCode 400 was about. So for those the clamp is still a no-op.

The 17 fall into three buckets the sync can't reach:
- **OpenAI built-ins** (`gpt-4o`, `gpt-4o-mini`) — stored under *bare* keys in LiteLLM, which the sync deliberately skips.
- **Claude built-ins** (`claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5`) — Arbr's own IDs, not verbatim in LiteLLM.
- **Bedrock Nova / cross-inference** (`us.amazon.nova-*`, `zai.glm-*`, `deepseek.*`, `google.gemma-*`, `meta.llama3-*`, `qwen.*`, bedrock Claude 3.5) — `us.*` / provider-prefixed IDs.

## Change

Seed `maxOutputTokens` for those 17 built-ins so the clamp protects them out of the box, independent of any sync. Values are grounded in the freshly-synced catalog's upstream equivalents (Bedrock/Anthropic caps) or well-known limits (`gpt-4o`/`gpt-4o-mini` = 16384). Models the sync already covers (Gemini, DeepSeek-direct, Grok, Groq Llama, Moonshot) are left to the sync. `SEED_VERSION` 2 → 3 so `registry.init()` re-seeds on boot.

## Deploy note

Re-seeding `$set`s built-in baseline fields, so **run a LiteLLM model sync after this deploys** to re-refine pricing on the sync-matched built-ins. The prod `maxTokensGuardrail` is currently set to 16384 as a global backstop and can stay until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)