### PR TITLE
feat: explain why each request was routed + fix request-detail layout

### DIFF
--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -110,24 +110,34 @@ async function resolveRoute(body, { router, eff, application, workflow, appConfi
   const difficultyScore = typeof cls.difficultyScore === "number" ? cls.difficultyScore : null;
   const confidence = typeof cls.confidence === "number" ? cls.confidence : null;
 
+  // routingExplain captures the non-derivable "why" (rule matched, policy source/base,
+  // default scope, later overrides). The UI narrates from this + the flat fields.
+  const explain = { basis: null, classificationUsed: false };
+
   let served, routingDecision;
   if (explicit) {
     served = explicit;
     routingDecision = "explicit";
+    explain.basis = "explicit";
   } else {
     served = resolveDefault(body, eff);
     routingDecision = "passthrough";
+    explain.basis = "passthrough";
+    explain.defaultScope = "global";
     // Per-app default: override the global default model when the key specifies one.
     if (appConfig.defaultModel) {
       const known = pricing.getModel(appConfig.defaultModel);
       if (known && eff.liveIds.includes(known.provider)) {
         served = { provider: known.provider, model: appConfig.defaultModel, knownPricing: true };
+        explain.defaultScope = "app";
       }
     }
     const route = await ruleEngine.findRoute({ taskType, application, workflow });
     if (route) {
       served = { provider: route.provider, model: route.model };
       routingDecision = "rule";
+      explain.basis = "rule";
+      explain.rule = { condition: route.condition || null, note: route.note || null };
     } else if (routingMode === "ai") {
       const aiMap = appDbConfig?.aiPolicyAssignments
         ? appDbConfig.aiPolicyAssignments
@@ -135,10 +145,18 @@ async function resolveRoute(body, { router, eff, application, workflow, appConfi
       // A low-confidence classification shouldn't drive a difficulty-based downgrade;
       // fall back to the task's default policy pick when we're unsure.
       const effDifficulty = (confidence == null || confidence >= 0.5) ? difficulty : null;
+      const base = aiPolicy.lookup(aiMap, taskType);
       const hit = aiPolicy.resolveModel({ map: aiMap, taskType, difficulty: effDifficulty, eff });
       if (hit && eff.liveIds.includes(hit.provider)) {
         served = { provider: hit.provider, model: hit.model };
         routingDecision = "ai";
+        explain.basis = "ai";
+        explain.policy = {
+          source: appDbConfig?.aiPolicyAssignments ? "app" : "global",
+          base: base ? base.model : null,
+          adjustedByDifficulty: !!(base && base.model !== hit.model),
+          effDifficulty: effDifficulty || null,
+        };
       }
     } else if (routingMode === "guardrail") {
       const policy = await policyEngine.getEffective();
@@ -146,15 +164,20 @@ async function resolveRoute(body, { router, eff, application, workflow, appConfi
       if (auto) {
         served = { provider: auto.provider, model: auto.model };
         routingDecision = "auto";
+        explain.basis = "auto";
       }
     }
   }
+  explain.classificationUsed =
+    explain.basis === "ai" || explain.basis === "auto" ||
+    (explain.basis === "rule" && !!explain.rule?.condition?.taskType);
 
   // Per-app allowed-model enforcement: if the key restricts which models it can reach
   // and routing landed outside that set, fall back to the key's default or reject.
   if (appConfig.allowedModels?.length > 0 && !appConfig.allowedModels.includes(served.model)) {
     const fallbackKnown = appConfig.defaultModel ? pricing.getModel(appConfig.defaultModel) : null;
     if (fallbackKnown && eff.liveIds.includes(fallbackKnown.provider)) {
+      explain.override = { type: "allowed", from: served.model, to: appConfig.defaultModel };
       served = { provider: fallbackKnown.provider, model: appConfig.defaultModel, knownPricing: true };
       routingDecision = "passthrough";
     } else {
@@ -170,12 +193,13 @@ async function resolveRoute(body, { router, eff, application, workflow, appConfi
   if (appDbConfig?.modelOptOut?.length > 0 && appDbConfig.modelOptOut.includes(served.model)) {
     const fallback = resolveDefault(body, eff);
     if (!appDbConfig.modelOptOut.includes(fallback.model)) {
+      explain.override = { type: "optout", from: served.model, to: fallback.model };
       served = fallback;
       routingDecision = "passthrough";
     }
   }
 
-  return { served, routingDecision, taskType, classifiedBy, cls, difficulty, difficultyScore, confidence };
+  return { served, routingDecision, taskType, classifiedBy, cls, difficulty, difficultyScore, confidence, explain };
 }
 
 async function handleChat(req, res) {
@@ -241,9 +265,9 @@ async function handleChat(req, res) {
     allowedModels: req.apiKey?.allowedModels || [],
     defaultModel: req.apiKey?.defaultModel || null,
   };
-  let served, routingDecision, taskType, classifiedBy, cls, difficulty, difficultyScore, confidence;
+  let served, routingDecision, taskType, classifiedBy, cls, difficulty, difficultyScore, confidence, explain;
   try {
-    ({ served, routingDecision, taskType, classifiedBy, cls, difficulty, difficultyScore, confidence } =
+    ({ served, routingDecision, taskType, classifiedBy, cls, difficulty, difficultyScore, confidence, explain } =
       await resolveRoute(body, { router, eff, application: meta.application, workflow: meta.workflow, appConfig, appDbConfig: appCfg }));
   } catch (err) {
     if (err.code === "model_not_allowed") {
@@ -275,12 +299,14 @@ async function handleChat(req, res) {
   const enf = await capEngine.enforcement({ application: meta.application, provider: served.provider });
   if (enf) {
     if (enf.action === "block") {
+      explain.override = { type: "budget", action: "block",
+        cap: { scope: capEngine.describeScope(enf.cap), period: enf.cap.period, limit: enf.cap.limit } };
       setImmediate(() =>
         logger.write({
           requestId, timestamp, ...meta,
           provider: served.provider, model: served.model, modelRequested,
           taskType, classifiedBy, latencyMs: 0, status: "blocked",
-          routingDecision: "budget", cacheHit: false,
+          routingDecision: "budget", cacheHit: false, routingExplain: explain,
         })
       );
       return res.status(429).json({
@@ -291,6 +317,8 @@ async function handleChat(req, res) {
     // downgrade
     const target = pricing.suggestLightTarget(served.model);
     if (target) {
+      explain.override = { type: "budget", action: "downgrade", from: served.model, to: target.model,
+        cap: { scope: capEngine.describeScope(enf.cap), period: enf.cap.period, limit: enf.cap.limit } };
       served = { provider: target.provider, model: target.model };
       routingDecision = "budget";
     }
@@ -331,7 +359,7 @@ async function handleChat(req, res) {
           completionTokens: cached.usage?.outputTokens || 0,
           totalTokens: cached.usage?.totalTokens || 0,
           latencyMs: 0, status: "success",
-          routingDecision: "cache", cacheHit: true,
+          routingDecision: "cache", cacheHit: true, routingExplain: explain,
           messages: body.messages, responseText: cached.text,
         })
       );
@@ -356,14 +384,17 @@ async function handleChat(req, res) {
         requestId, timestamp, ...meta,
         provider: served.provider, model: served.model, modelRequested,
         taskType, classifiedBy, latencyMs: 0, status: "failure", routingDecision,
-        errorMessage,
+        errorMessage, routingExplain: explain,
       })
     );
     return res.status(502).json({ error: "provider_error", message: errorMessage });
   }
 
   const { result, usedFallback } = invocation;
-  if (usedFallback) routingDecision = "fallback";
+  if (usedFallback) {
+    routingDecision = "fallback";
+    explain.override = { type: "fallback", from: served.model, to: result.modelId };
+  }
 
   // 4 · RETURN — response on its way back immediately.
   res.set({
@@ -395,7 +426,7 @@ async function handleChat(req, res) {
     logger.write({
       requestId, timestamp, ...meta,
       provider: result.providerId, model: result.modelId, modelRequested,
-      taskType, classifiedBy, difficulty, difficultyScore, confidence,
+      taskType, classifiedBy, difficulty, difficultyScore, confidence, routingExplain: explain,
       promptTokens: result.usage?.inputTokens || 0,
       completionTokens: result.usage?.outputTokens || 0,
       totalTokens: result.usage?.totalTokens || 0,

--- a/server/src/gateway/openaiCompat.js
+++ b/server/src/gateway/openaiCompat.js
@@ -155,7 +155,7 @@ function translateToolCalls(toolCalls) {
 async function proxyOpenAICompat(ctx) {
   const {
     res, body, served, modelRequested, meta, requestId, timestamp,
-    taskType, classifiedBy, difficulty, difficultyScore, confidence, routingDecision, eff, baseURL,
+    taskType, classifiedBy, difficulty, difficultyScore, confidence, routingDecision, routingExplain, eff, baseURL,
   } = ctx;
 
   const apiKey = eff.providers[served.provider]?.credential?.apiKey || "none";
@@ -168,7 +168,7 @@ async function proxyOpenAICompat(ctx) {
       logger.write({
         requestId, timestamp, ...meta,
         provider: served.provider, model: served.model, modelRequested,
-        taskType, classifiedBy, difficulty, difficultyScore, confidence, routingDecision, cacheHit: false,
+        taskType, classifiedBy, difficulty, difficultyScore, confidence, routingDecision, routingExplain, cacheHit: false,
         knownPricing: served.knownPricing,
         messages: body.messages,
         ...extra,
@@ -330,9 +330,9 @@ async function handleOpenAICompat(req, res) {
     allowedModels: req.apiKey?.allowedModels || [],
     defaultModel: req.apiKey?.defaultModel || null,
   };
-  let served, routingDecision, taskType, classifiedBy, difficulty, difficultyScore, confidence;
+  let served, routingDecision, taskType, classifiedBy, difficulty, difficultyScore, confidence, explain;
   try {
-    ({ served, routingDecision, taskType, classifiedBy, difficulty, difficultyScore, confidence } =
+    ({ served, routingDecision, taskType, classifiedBy, difficulty, difficultyScore, confidence, explain } =
       await resolveRoute(normalized, { router, eff, application: meta.application, workflow: meta.workflow, appConfig, appDbConfig: appCfg }));
   } catch (err) {
     if (err.code === "model_not_allowed") {
@@ -359,7 +359,11 @@ async function handleOpenAICompat(req, res) {
       return res.status(429).json(errBody);
     }
     const target = pricing.suggestLightTarget(served.model);
-    if (target) { served = { provider: target.provider, model: target.model }; routingDecision = "budget"; }
+    if (target) {
+      if (explain) explain.override = { type: "budget", action: "downgrade", from: served.model, to: target.model,
+        cap: { scope: capEngine.describeScope(enf.cap), period: enf.cap.period, limit: enf.cap.limit } };
+      served = { provider: target.provider, model: target.model }; routingDecision = "budget";
+    }
   }
 
   // Per-model output clamp: cap max_tokens to the SERVED model's known ceiling. Tool agents
@@ -411,7 +415,7 @@ async function handleOpenAICompat(req, res) {
       routing: routingDecision, taskType });
     return proxyOpenAICompat({
       res, body, served, modelRequested, meta, requestId, timestamp,
-      taskType, classifiedBy, difficulty, difficultyScore, confidence, routingDecision, eff, baseURL: compatBaseURL,
+      taskType, classifiedBy, difficulty, difficultyScore, confidence, routingDecision, routingExplain: explain, eff, baseURL: compatBaseURL,
     });
   }
 
@@ -525,7 +529,7 @@ async function handleOpenAICompat(req, res) {
           provider: served.provider, model: served.model, modelRequested,
           taskType, classifiedBy, difficulty, difficultyScore, confidence,
           promptTokens, completionTokens, totalTokens, cachedReadTokens, cacheWriteTokens,
-          latencyMs: Date.now() - start, status: "success", routingDecision, cacheHit: false,
+          latencyMs: Date.now() - start, status: "success", routingDecision, routingExplain: explain, cacheHit: false,
           knownPricing: served.knownPricing,
           messages: body.messages, responseText: chunkText(aiMsg) || null,
         })
@@ -537,7 +541,7 @@ async function handleOpenAICompat(req, res) {
           requestId, timestamp, ...meta,
           provider: served.provider, model: served.model, modelRequested,
           taskType, classifiedBy, latencyMs: Date.now() - start,
-          status: "failure", routingDecision, cacheHit: false, errorMessage,
+          status: "failure", routingDecision, routingExplain: explain, cacheHit: false, errorMessage,
         })
       );
       if (body.stream) {
@@ -594,14 +598,14 @@ async function handleOpenAICompat(req, res) {
           requestId, timestamp, ...meta,
           provider: served.provider, model: served.model, modelRequested,
           taskType, classifiedBy, latencyMs: Date.now() - start,
-          status: "failure", routingDecision, cacheHit: false, errorMessage,
+          status: "failure", routingDecision, routingExplain: explain, cacheHit: false, errorMessage,
         })
       );
       return;
     }
 
     const { result, usedFallback } = invocation;
-    if (usedFallback) routingDecision = "fallback";
+    if (usedFallback) { routingDecision = "fallback"; if (explain) explain.override = { type: "fallback", from: served.model, to: result.modelId }; }
 
     const promptTokens = result.usage?.inputTokens || 0;
     const completionTokens = result.usage?.outputTokens || 0;
@@ -643,7 +647,7 @@ async function handleOpenAICompat(req, res) {
         provider: result.providerId, model: result.modelId, modelRequested,
         taskType, classifiedBy, difficulty, difficultyScore, confidence,
         promptTokens, completionTokens, totalTokens, cachedReadTokens, cacheWriteTokens,
-        latencyMs: Date.now() - start, status: "success", routingDecision, cacheHit: false,
+        latencyMs: Date.now() - start, status: "success", routingDecision, routingExplain: explain, cacheHit: false,
         knownPricing: served.knownPricing,
         messages: body.messages, responseText: result.text,
       })
@@ -670,7 +674,7 @@ async function handleOpenAICompat(req, res) {
         requestId, timestamp, ...meta,
         provider: served.provider, model: served.model, modelRequested,
         taskType, classifiedBy, latencyMs: 0, status: "failure", routingDecision,
-        errorMessage,
+        errorMessage, routingExplain: explain,
       })
     );
     return res.status(502).json({
@@ -679,7 +683,7 @@ async function handleOpenAICompat(req, res) {
   }
 
   const { result, usedFallback } = invocation;
-  if (usedFallback) routingDecision = "fallback";
+  if (usedFallback) { routingDecision = "fallback"; if (explain) explain.override = { type: "fallback", from: served.model, to: result.modelId }; }
 
   res.json({
     id: `chatcmpl-${requestId}`,
@@ -707,7 +711,7 @@ async function handleOpenAICompat(req, res) {
       totalTokens:      result.usage?.totalTokens  || 0,
       cachedReadTokens: result.usage?.cachedReadTokens || 0,
       cacheWriteTokens: result.usage?.cacheWriteTokens || 0,
-      latencyMs: result.latencyMs, status: "success", routingDecision, cacheHit: false,
+      latencyMs: result.latencyMs, status: "success", routingDecision, routingExplain: explain, cacheHit: false,
       knownPricing: served.knownPricing,
       messages: body.messages, responseText: result.text,
     })

--- a/server/src/models/RequestRecord.js
+++ b/server/src/models/RequestRecord.js
@@ -59,6 +59,12 @@ const requestRecordSchema = new mongoose.Schema(
     confidence: { type: Number, default: null },
     cacheHit: { type: Boolean, default: false },
 
+    // WHY this model was served — the non-derivable reasoning captured at decision time
+    // (which rule matched, the AI-policy source/base, a breached budget cap, a fallback
+    // origin). The UI narrates from this plus the flat fields above. Null on older records.
+    // Shape: { basis, classificationUsed, rule?, policy?, defaultScope?, override? }
+    routingExplain: { type: mongoose.Schema.Types.Mixed, default: null },
+
     // Captured context (full prompt + response). PII-masked at write time when
     // Settings.piiMaskingEnabled is on, and size-capped. Headers are intentionally NOT
     // stored (they carry Authorization/API keys). Governed by retentionDays auto-purge.

--- a/server/src/routing/ruleEngine.js
+++ b/server/src/routing/ruleEngine.js
@@ -42,7 +42,8 @@ async function findRoute(ctx) {
   const rules = await getEnabledRules();
   for (const rule of rules) {
     if (matches(rule, ctx)) {
-      return { provider: rule.target.provider, model: rule.target.model, ruleId: rule._id };
+      return { provider: rule.target.provider, model: rule.target.model, ruleId: rule._id,
+               condition: rule.condition, note: rule.note };
     }
   }
   return null;

--- a/web/src/components/RequestsTable.jsx
+++ b/web/src/components/RequestsTable.jsx
@@ -10,13 +10,87 @@ const CLASSIFY = {
   ai:       { tone: "violet", label: "AI" },
 };
 
-// One node in the request-flow strip.
+// One node in the request-flow strip. Caps width + wraps so long model ids
+// (e.g. "moonshotai.kimi-k2.5") don't push the strip off the drawer.
 function FlowNode({ label, value, sub }) {
   return (
-    <div className="flex shrink-0 flex-col items-center rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-center">
+    <div className="flex max-w-[150px] shrink-0 flex-col items-center rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-center">
       <div className="text-[10px] uppercase tracking-wide text-gray-400">{label}</div>
-      <div className="text-sm font-medium text-arbr-charcoal">{value}</div>
-      {sub && <div className="text-[10px] text-gray-400">{sub}</div>}
+      <div className="break-words text-sm font-medium text-arbr-charcoal">{value}</div>
+      {sub && <div className="break-words text-[10px] text-gray-400">{sub}</div>}
+    </div>
+  );
+}
+
+// Plain-English narration of WHY this model was served, built from routingExplain
+// (captured at decision time) plus the flat record fields. Falls back gracefully on
+// older records that predate routingExplain.
+function explainRouting(r) {
+  const x = r.routingExplain || {};
+  const d = r.routingDecision;
+  const lines = [];
+  const clsBits = [
+    r.taskType,
+    r.difficulty ? `${r.difficulty}${r.difficultyScore ? ` ${r.difficultyScore}/10` : ""}` : null,
+    r.confidence != null ? `confidence ${Number(r.confidence).toFixed(2)}` : null,
+  ].filter(Boolean).join(", ");
+
+  if (d === "explicit") {
+    lines.push(`The client explicitly requested ${r.model}, so Arbr served it directly without applying a routing policy.`);
+  } else if (d === "rule") {
+    const c = x.rule?.condition || {};
+    const on = [c.taskType && `task ${c.taskType}`, c.application && `app ${c.application}`, c.workflow && `workflow ${c.workflow}`].filter(Boolean).join(", ");
+    lines.push(`A routing rule${on ? ` (matching ${on})` : ""} directed this request to ${r.model}.`);
+    if (x.rule?.note) lines.push(`Rule note: ${x.rule.note}`);
+  } else if (d === "ai") {
+    lines.push(`Auto-routing: Arbr classified this as ${clsBits || "unknown"}, and the ${x.policy?.source || "global"} AI policy mapped it to ${r.model}.`);
+    if (x.policy?.adjustedByDifficulty && x.policy?.base) {
+      lines.push(`The policy's base pick was ${x.policy.base}; difficulty${x.policy.effDifficulty ? ` (${x.policy.effDifficulty})` : ""} adjusted it to ${r.model}.`);
+    }
+  } else if (d === "auto") {
+    lines.push(`Guardrail auto-routing substituted ${r.model} based on the task type (${r.taskType || "—"}).`);
+  } else if (d === "cache") {
+    lines.push(`Served from Arbr's response cache — an identical earlier request to ${r.model} was reused, with no new model call.`);
+  } else if (d === "fallback") {
+    lines.push(`The primary model failed, so Arbr fell back to ${r.model}.`);
+  } else if (d === "budget") {
+    lines.push(`A budget cap was breached, so Arbr overrode the routing.`);
+  } else {
+    lines.push(x.defaultScope === "app"
+      ? `No rule or policy matched, so Arbr served this application's default model, ${r.model}.`
+      : `No model was pinned and no rule or policy matched, so Arbr served the default model, ${r.model}.`);
+  }
+
+  const ov = x.override;
+  if (ov?.type === "budget" && ov.action === "downgrade") {
+    lines.push(`Budget override: cap "${ov.cap?.scope}" (${ov.cap?.period}, $${ov.cap?.limit}) was over limit, so ${ov.from} was downgraded to ${ov.to}.`);
+  } else if (ov?.type === "budget" && ov.action === "block") {
+    lines.push(`Budget cap "${ov.cap?.scope}" (${ov.cap?.period}, $${ov.cap?.limit}) was over limit; the request was blocked.`);
+  } else if (ov?.type === "fallback") {
+    lines.push(`Fallback: ${ov.from} failed, so Arbr retried on ${ov.to}.`);
+  } else if (ov?.type === "allowed") {
+    lines.push(`${ov.from} is not in this API key's allowed-model set, so Arbr served the key's default, ${ov.to}.`);
+  } else if (ov?.type === "optout") {
+    lines.push(`${ov.from} is opted out for this application, so Arbr served ${ov.to} instead.`);
+  }
+
+  if (x.classificationUsed === false && r.taskType && (d === "explicit" || d === "passthrough" || d === "cache")) {
+    lines.push(`Classification ran (${r.taskType}${r.difficulty ? `, ${r.difficulty}` : ""}) but did not influence routing.`);
+  }
+  return lines;
+}
+
+function RoutingExplanation({ r }) {
+  const lines = explainRouting(r);
+  return (
+    <div className="rounded-lg border border-arbr-green-200 bg-arbr-green-50 p-4">
+      <div className="mb-1 flex items-center gap-2">
+        <span className="label">Why this routing</span>
+        <Badge tone={ROUTING_TONE[r.routingDecision]}>{r.routingDecision}</Badge>
+      </div>
+      <ul className="space-y-1 text-sm text-arbr-charcoal">
+        {lines.map((l, i) => <li key={i}>{l}</li>)}
+      </ul>
     </div>
   );
 }
@@ -243,13 +317,11 @@ export default function RequestsTable({ fixedFilters = {}, hiddenFilterKeys = []
             <div className="text-sm text-red-600">{detail._error}</div>
           ) : (
             <div className="space-y-5">
+              <RoutingExplanation r={detail} />
               <RequestFlow r={detail} />
-              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+              <div className="grid grid-cols-3 gap-3">
                 <Stat label="Status" value={detail.status} />
-                <Stat label="Routing" value={detail.routingDecision} />
                 <Stat label="Latency" value={fmt.ms(detail.latencyMs)} />
-                <Stat label="Requested → Served" value={detail.modelRequested === detail.model ? detail.model : `${detail.modelRequested} → ${detail.model}`} />
-                <Stat label="Task" value={detail.taskType || "—"} sub={`${detail.classifiedBy || "—"}${detail.difficulty ? ` · ${detail.difficulty}${detail.difficultyScore ? ` (${detail.difficultyScore}/10)` : ""}` : ""}${detail.confidence != null ? ` · conf ${Number(detail.confidence).toFixed(2)}` : ""}`} />
                 <Stat label="Cost" value={fmt.usd(detail.totalCost)} />
               </div>
               <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">


### PR DESCRIPTION
## Problem

The request drilldown (added in #43/#44) just restated the row: a routing badge, the task, requested→served. It never explained **why** a particular model was served. And long model ids (e.g. `moonshotai.kimi-k2.5`) overflowed both the flow strip and the stat cards.

## Change

**Capture the reasoning at decision time** (the parts not already in flat columns) and narrate it.

- `resolveRoute` builds a `routingExplain` object: `basis` (explicit / rule / ai / auto / passthrough), `classificationUsed`, the matched rule's `condition` + `note`, the AI-policy `source` / `base` / difficulty adjustment, `defaultScope`, and `override` for budget downgrades/blocks (with cap scope+limit), fallback origin, and allowed-model / opt-out redirects.
- Threaded through **every** gateway log site: `handler.js` (success, cache, budget-block, failure, fallback) and `openaiCompat.js` (proxy `logRecord`, native-tool, streaming and non-streaming paths).
- Stored on `RequestRecord.routingExplain` (Mixed; `null` on older records).
- `ruleEngine.findRoute` now returns the matched `condition` + `note`.

**UI**
- New **"Why this routing"** block at the top of the drilldown, narrating the decision in plain English from `routingExplain` + flat fields. Examples:
  - *explicit*: "The client explicitly requested moonshotai.kimi-k2.5, so Arbr served it directly… Classification ran (coding, mid) but did not influence routing."
  - *ai*: "Auto-routing: classified as coding, mid 7/10, confidence 0.82, and the global AI policy mapped it to nova-pro."
  - *budget*: "Budget override: cap \"opencode-amit daily\" ($5) was over limit, so gpt-4o was downgraded to nova-lite."
- Dropped the redundant Routing / Task / Requested→Served stats (all already in the flow strip); kept Status / Latency / Cost.
- `FlowNode` caps width and wraps, so long model ids no longer run off the drawer.

Graceful for old records: with no `routingExplain`, the narration falls back to the flat fields.

## Verify
- `node --check` on all backend files; `smoke:classify` 24/24, `smoke:maxtokens` 7/7, `smoke:simulate` 8/8, `smoke:logging` 9/9.
- esbuild JSX check on `RequestsTable.jsx`.
- Needs a deploy (backend + web). New requests get `routingExplain`; existing rows degrade gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)