### PR TITLE
fix(routing): cost policy targets 30-50% savings, not zero cost

### DIFF
--- a/server/src/routing/aiPolicy.js
+++ b/server/src/routing/aiPolicy.js
@@ -224,9 +224,10 @@ function parseJsonBlock(text) {
 const COST_SENSITIVITY = { light: 0.20, mid: 0.25, premium: 0.10 };
 
 // Goal-driven cost-vs-capability weight. "balanced" (default) keeps today's per-tier behavior;
-// "cost" weights cost heavily (cheapest capable model); "quality" weights capability (best model).
+// "cost" favours cheaper models while preserving a meaningful capability floor (target 30-50% savings,
+// not zero-cost); "quality" weights capability almost exclusively.
 function goalWeight(goal, tier) {
-  if (goal === "cost") return 0.6;
+  if (goal === "cost") return 0.30;
   if (goal === "quality") return 0.05;
   return COST_SENSITIVITY[tier] || 0.25; // "balanced" / unset
 }
@@ -294,7 +295,7 @@ async function _computeAssignments({ router, eff, excludeModels = [], goal = "ba
       `- Vary assignments — don't give every task the same model\n` +
       `- Choose the model best suited for each task's requirements\n` +
       (goal === "cost"
-        ? `- GOAL: minimize cost — prefer the cheapest model that can do each task acceptably\n`
+        ? `- GOAL: reduce cost by 30–50% vs using premium models everywhere. Use light-tier for simple tasks (faq, translation, classification, support-response, summarisation). Use mid-tier for moderate tasks (coding, extraction, content generation). Reserve premium only where deep reasoning is truly required. Vary assignments across models — do NOT map every task to the same model, and do NOT choose a model purely because its price is zero; each task must be handled by something genuinely capable of it.\n`
         : goal === "quality"
         ? `- GOAL: maximize quality — prefer the most capable model for each task, cost is secondary\n`
         : `- GOAL: balance capability and cost\n`) +
@@ -336,7 +337,14 @@ function _scoringFallback(task, liveModels, catalogMap, eff, tierOverride, goal)
   const hardFallback = liveModels[0].id;
 
   function poolFor(tier) {
-    if (tier === "premium") return liveModels;
+    if (tier === "premium") {
+      // cost mode: allow mid as the floor (skip light — premium tasks need real capability)
+      if (goal === "cost") {
+        const p = [...(byTier.mid || []), ...(byTier.premium || [])];
+        return p.length ? p : liveModels;
+      }
+      return liveModels;
+    }
     const p = tier === "light"
       ? [...(byTier.light || [])]
       : [...(byTier.light || []), ...(byTier.mid || [])];


### PR DESCRIPTION
## Problem

When generating an AI routing policy with the **Cost** optimization goal, the router collapsed every task onto the cheapest/free model — bringing projected cost to \$0.00. A 100% cost reduction defeats the purpose; real-world use requires capable models, not free ones.

Three layers were all pointing the same direction:

| Layer | Old behaviour | Effect |
|---|---|---|
| LLM prompt | "minimize cost — prefer the cheapest model that can do each task acceptably" | LLM treats "acceptably" as "free is fine" |
| `goalWeight("cost")` | `0.60` | 60% score weight on cheapness → free model wins math |
| `poolFor("premium")` | returns ALL models | Free light models competed (and won) for deep-reasoning tasks |

## Fix

**1. `goalWeight("cost")` — `0.60` → `0.30`**
Cost is now 30% of the score, capability 70%. A $0.50/1M mid-tier model scoring 0.8 on capability beats a free model scoring 0.3.

**2. `poolFor("premium")` in cost mode — uses mid+premium pool**
Free/light models can no longer be assigned to premium-tier tasks (reasoning, document analysis, architecture) even under aggressive cost optimisation.

**3. LLM prompt rewritten**
- Target: "30–50% savings vs using premium everywhere"
- Explicit tier guidance: light for faq/translation/classification, mid for coding/extraction/content, premium only for deep reasoning
- Hard instruction: "do NOT pick a model purely because it costs zero"

## Expected result

After regenerating with the Cost goal, the projected savings should be in the 30–50% range with varied model assignments across light and mid tiers — not a single free model for everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)