### PR TITLE
feat: budget warnings, CSV export, cost trend chart

### DIFF
--- a/server/src/analytics/aggregate.js
+++ b/server/src/analytics/aggregate.js
@@ -174,10 +174,32 @@ async function providerHealth() {
   }));
 }
 
+// Daily (or hourly) time-series of requests, cost, and failures for the selected window.
+// bucket: "day" (default) or "hour". Useful for the Overview trend chart.
+async function timeseries(filter, bucket = "day") {
+  const match = buildMatch(filter);
+  const fmt = bucket === "hour" ? "%Y-%m-%dT%H" : "%Y-%m-%d";
+  const rows = await RequestRecord.aggregate([
+    { $match: match },
+    {
+      $group: {
+        _id: { $dateToString: { format: fmt, date: "$timestamp", timezone: "UTC" } },
+        requests: { $sum: 1 },
+        cost: { $sum: "$totalCost" },
+        failures: { $sum: { $cond: [{ $eq: ["$status", "failure"] }, 1, 0] } },
+      },
+    },
+    { $sort: { _id: 1 } },
+    { $project: { _id: 0, date: "$_id", requests: 1, cost: 1, failures: 1 } },
+  ]);
+  return rows;
+}
+
 module.exports = {
   buildMatch,
   overview,
   spend,
+  timeseries,
   byApplication,
   byTeam,
   byWorkflow,

--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -94,7 +94,7 @@ const CAP_ACTIONS = ["alert", "downgrade", "block"];
 
 router.post("/caps", async (req, res, next) => {
   try {
-    const { dimension, value, period, limit, action } = req.body || {};
+    const { dimension, value, period, limit, action, warningThreshold } = req.body || {};
     if (!(Number(limit) > 0)) return res.status(400).json({ error: "limit must be a positive number" });
     const allowed = ["application", "provider", "department", "workflow", "model"];
     const dim = dimension && allowed.includes(dimension) ? dimension : null;
@@ -105,6 +105,7 @@ router.post("/caps", async (req, res, next) => {
       period: period === "day" ? "day" : "month",
       limit: Number(limit),
       action: CAP_ACTIONS.includes(action) ? action : "alert",
+      warningThreshold: warningThreshold != null ? Math.min(1, Math.max(0, Number(warningThreshold))) : 0.8,
       enabled: true,
     });
     capEngine.invalidate();
@@ -120,6 +121,7 @@ router.patch("/caps/:id", async (req, res, next) => {
     if (Number(req.body.limit) > 0) update.limit = Number(req.body.limit);
     if (req.body.period === "day" || req.body.period === "month") update.period = req.body.period;
     if (CAP_ACTIONS.includes(req.body.action)) update.action = req.body.action;
+    if (req.body.warningThreshold != null) update.warningThreshold = Math.min(1, Math.max(0, Number(req.body.warningThreshold)));
     const cap = await Cap.findByIdAndUpdate(req.params.id, update, { new: true }).lean();
     capEngine.invalidate();
     setImmediate(() => logAction("cap.update", "cap", req.params.id, update));
@@ -475,6 +477,13 @@ router.get("/analytics/by/:dimension", async (req, res, next) => {
   } catch (e) { next(e); }
 });
 
+router.get("/analytics/timeseries", async (req, res, next) => {
+  try {
+    const bucket = req.query.bucket === "hour" ? "hour" : "day";
+    res.json(await analytics.timeseries(req.query, bucket));
+  } catch (e) { next(e); }
+});
+
 router.get("/analytics/realised-savings", async (req, res, next) => {
   try { res.json(await analytics.realisedSavings(req.query)); } catch (e) { next(e); }
 });
@@ -495,6 +504,33 @@ router.get("/requests", async (req, res, next) => {
       RequestRecord.countDocuments(match),
     ]);
     res.json({ items, total, page, limit });
+  } catch (e) { next(e); }
+});
+
+// CSV export — same filters as /requests but no pagination; streams all matching rows.
+router.get("/requests/export", async (req, res, next) => {
+  try {
+    const match = analytics.buildMatch(req.query);
+    const COLS = [
+      "timestamp", "requestId", "application", "workflow", "department", "userId",
+      "taskType", "model", "modelRequested", "provider", "routingDecision", "classifiedBy",
+      "promptTokens", "completionTokens", "totalTokens", "totalCost",
+      "latencyMs", "status", "cacheHit", "difficulty", "difficultyScore",
+    ];
+    function csvCell(v) {
+      if (v == null) return "";
+      if (v instanceof Date) return v.toISOString();
+      const s = String(v);
+      return (s.includes(",") || s.includes('"') || s.includes("\n")) ? `"${s.replace(/"/g, '""')}"` : s;
+    }
+    res.setHeader("Content-Type", "text/csv; charset=utf-8");
+    res.setHeader("Content-Disposition", 'attachment; filename="requests.csv"');
+    res.write(COLS.join(",") + "\n");
+    const cursor = RequestRecord.find(match).select(COLS.join(" ")).sort({ timestamp: -1 }).lean().cursor();
+    for await (const doc of cursor) {
+      res.write(COLS.map((c) => csvCell(doc[c])).join(",") + "\n");
+    }
+    res.end();
   } catch (e) { next(e); }
 });
 

--- a/server/src/models/Cap.js
+++ b/server/src/models/Cap.js
@@ -14,6 +14,9 @@ const capSchema = new mongoose.Schema(
     // alert = flag only; downgrade = force the provider's light model while breached;
     // block = reject requests in scope (429) until the window rolls past.
     action: { type: String, enum: ["alert", "downgrade", "block"], default: "alert" },
+    // Fraction of limit at which a cap_warning webhook fires (0 = disabled, default 0.8 = 80%).
+    // Only applies to block/downgrade caps — alert caps are display-only.
+    warningThreshold: { type: Number, default: 0.8 },
     enabled: { type: Boolean, default: true },
     createdAt: { type: Date, default: Date.now },
   },

--- a/server/src/routing/capEngine.js
+++ b/server/src/routing/capEngine.js
@@ -40,6 +40,21 @@ async function _breachedEnforcing() {
         spent,
         action: cap.action,
       }));
+    } else {
+      // Near-threshold warning: fire before the cap is actually breached so users can act.
+      const warnAt = cap.warningThreshold ?? 0.8;
+      if (warnAt > 0 && spent / cap.limit >= warnAt) {
+        setImmediate(() => notifier.notify("cap_warning", {
+          key: `warn:${cap._id}`,
+          dimension: cap.dimension || "global",
+          value: cap.value || null,
+          period: cap.period,
+          limit: cap.limit,
+          spent,
+          ratio: Math.round((spent / cap.limit) * 1000) / 1000,
+          action: cap.action,
+        }));
+      }
     }
   }
   _cache = { breached, at: Date.now() };

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.26.0"
+        "react-router-dom": "^6.26.0",
+        "recharts": "^3.9.1"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.3.1",
@@ -794,6 +795,32 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.3",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
@@ -1160,6 +1187,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1205,11 +1244,80 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1440,6 +1548,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -1470,6 +1587,127 @@
         "node": ">=4"
       }
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1487,6 +1725,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -1518,6 +1762,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
+      "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1567,6 +1821,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -1694,6 +1954,25 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-binary-path": {
@@ -2200,6 +2479,36 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -2264,6 +2573,57 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.9.1.tgz",
+      "integrity": "sha512-WMcwlXcB7l+BbxiEdyClkG+1sxrMHNZpzT577LEvU4+rXPd8oTAy1wXk72hnk2KOOmxuLvw3z5DtXT7HEAydtg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^11.1.8",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.2.0",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -2493,6 +2853,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -2592,12 +2958,43 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.26.0"
+    "react-router-dom": "^6.26.0",
+    "recharts": "^3.9.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.1",

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -45,12 +45,22 @@ export const api = {
   gatewayProviders: () => fetch("/v1/providers", { headers: { "Content-Type": "application/json" } }).then((r) => r.json()),
 
   overview: (filter) => req(`/analytics/overview${qs(filter)}`),
+  timeseries: (filter) => req(`/analytics/timeseries${qs(filter)}`),
   by: (dimension, filter) => req(`/analytics/by/${dimension}${qs(filter)}`),
   realisedSavings: (filter) => req(`/analytics/realised-savings${qs(filter)}`),
   facets: () => req("/analytics/facets"),
 
   requests: (filter) => req(`/requests${qs(filter)}`),
   request: (id) => req(`/requests/${encodeURIComponent(id)}`),
+  exportRequests: (filter) => {
+    const url = `/api/requests/export${qs(filter)}`;
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "requests.csv";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  },
 
   recommendations: (status) => req(`/recommendations${qs({ status })}`),
   recompute: () => req("/recommendations/recompute", { method: "POST" }),

--- a/web/src/components/RequestsTable.jsx
+++ b/web/src/components/RequestsTable.jsx
@@ -298,6 +298,13 @@ export default function RequestsTable({ fixedFilters = {}, hiddenFilterKeys = []
             <div className="mt-4 flex items-center justify-between text-sm text-gray-500">
               <span>{fmt.num(data.total)} records</span>
               <div className="flex items-center gap-2">
+                <button
+                  className="btn-outline"
+                  onClick={() => api.exportRequests({ ...filter, ...fixedFilters, ...range })}
+                  title="Download all matching records as CSV"
+                >
+                  Export CSV
+                </button>
                 <button className="btn-outline" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>Prev</button>
                 <span>Page {page}</span>
                 <button className="btn-outline" disabled={page * data.limit >= data.total} onClick={() => setPage((p) => p + 1)}>Next</button>

--- a/web/src/pages/Budgets.jsx
+++ b/web/src/pages/Budgets.jsx
@@ -36,7 +36,7 @@ function SpendBar({ cap }) {
 function CapRow({ cap, onRefresh }) {
   const [editing, setEditing] = useState(false);
   const [deleting, setDeleting] = useState(false);
-  const [form, setForm] = useState({ limit: cap.limit, period: cap.period, action: cap.action });
+  const [form, setForm] = useState({ limit: cap.limit, period: cap.period, action: cap.action, warningThreshold: Math.round((cap.warningThreshold ?? 0.8) * 100) });
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState(null);
 
@@ -52,7 +52,7 @@ function CapRow({ cap, onRefresh }) {
     if (!lim || lim <= 0) return setErr("Limit must be a positive number.");
     setBusy(true);
     setErr(null);
-    try { await api.updateCap(cap._id, { limit: lim, period: form.period, action: form.action }); await onRefresh(); setEditing(false); }
+    try { await api.updateCap(cap._id, { limit: lim, period: form.period, action: form.action, warningThreshold: Number(form.warningThreshold) / 100 }); await onRefresh(); setEditing(false); }
     catch (e) { setErr(e.message); }
     finally { setBusy(false); }
   };
@@ -110,9 +110,17 @@ function CapRow({ cap, onRefresh }) {
                   <option value="alert">Alert only (no enforcement)</option>
                 </select>
               </div>
+              {form.action !== "alert" && (
+                <div>
+                  <div className="label mb-1">Warn at (%)</div>
+                  <input className="input w-20" type="number" min="0" max="99" step="5"
+                    value={form.warningThreshold} onChange={(e) => setForm({ ...form, warningThreshold: e.target.value })}
+                    title="Fire a webhook warning before the cap is reached (0 = disabled)" />
+                </div>
+              )}
               <div className="flex gap-2">
                 <button className="btn-primary" onClick={save} disabled={busy}>Save</button>
-                <button className="btn-outline" onClick={() => { setEditing(false); setErr(null); setForm({ limit: cap.limit, period: cap.period, action: cap.action }); }}>
+                <button className="btn-outline" onClick={() => { setEditing(false); setErr(null); setForm({ limit: cap.limit, period: cap.period, action: cap.action, warningThreshold: Math.round((cap.warningThreshold ?? 0.8) * 100) }); }}>
                   Cancel
                 </button>
               </div>
@@ -148,6 +156,7 @@ function CreateForm({ providers, applications, onCreated }) {
   const [period, setPeriod] = useState("day");
   const [limit, setLimit] = useState("");
   const [action, setAction] = useState("block");
+  const [warningThreshold, setWarningThreshold] = useState(80);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState(null);
 
@@ -165,7 +174,7 @@ function CreateForm({ providers, applications, onCreated }) {
     if (!value.trim()) return setErr("Enter a scope value.");
     setBusy(true);
     try {
-      await api.createCap({ dimension: dim, value: value.trim(), period, limit: lim, action });
+      await api.createCap({ dimension: dim, value: value.trim(), period, limit: lim, action, warningThreshold: Number(warningThreshold) / 100 });
       setValue("");
       setLimit("");
       await onCreated();
@@ -230,6 +239,15 @@ function CreateForm({ providers, applications, onCreated }) {
             <option value="alert">Alert only (no enforcement)</option>
           </select>
         </div>
+
+        {action !== "alert" && (
+          <div>
+            <div className="label mb-1">Warn at (%)</div>
+            <input className="input w-20" type="number" min="0" max="99" step="5" value={warningThreshold}
+              onChange={(e) => setWarningThreshold(e.target.value)}
+              title="Fire a webhook warning before the cap is reached (0 = disabled)" />
+          </div>
+        )}
 
         <button className="btn-primary" onClick={submit} disabled={busy}>
           {busy ? "Adding…" : "Add constraint"}

--- a/web/src/pages/Overview.jsx
+++ b/web/src/pages/Overview.jsx
@@ -3,12 +3,85 @@ import { api, fmt } from "../api.js";
 import { Stat, Card, Table, Spinner, Tabs, useTabParam } from "../components/ui.jsx";
 import ByDimension from "./ByDimension.jsx";
 import RequestsTable from "../components/RequestsTable.jsx";
+import {
+  ComposedChart, Bar, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend,
+  ResponsiveContainer,
+} from "recharts";
 
 const TABS = [
   ["summary",    "Summary"],
   ["dimensions", "By dimension"],
   ["requests",   "Requests"],
 ];
+
+const TREND_PERIODS = [
+  { label: "7 days",  days: 7 },
+  { label: "30 days", days: 30 },
+  { label: "90 days", days: 90 },
+];
+
+function trendRange(days) {
+  const to = new Date();
+  const from = new Date(to);
+  from.setDate(from.getDate() - days);
+  return { from: from.toISOString(), to: to.toISOString() };
+}
+
+function TrendChart() {
+  const [period, setPeriod] = useState(1); // default 30 days
+  const [rows, setRows] = useState(null);
+
+  useEffect(() => {
+    setRows(null);
+    api.timeseries(trendRange(TREND_PERIODS[period].days))
+      .then(setRows)
+      .catch(() => setRows([]));
+  }, [period]);
+
+  return (
+    <Card title="Cost & request trend">
+      <div className="mb-3 flex items-center justify-between">
+        <p className="text-sm text-gray-500">Daily totals — cost (bars) and requests (line).</p>
+        <div className="flex items-center gap-1 rounded-lg border border-gray-200 bg-gray-50 p-1">
+          {TREND_PERIODS.map((p, i) => (
+            <button
+              key={p.label}
+              onClick={() => setPeriod(i)}
+              className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+                period === i ? "bg-white text-arbr-charcoal shadow-sm border border-gray-200" : "text-gray-500 hover:text-arbr-charcoal"
+              }`}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      {rows === null ? (
+        <div className="flex h-48 items-center justify-center text-sm text-gray-400">Loading…</div>
+      ) : rows.length === 0 ? (
+        <div className="flex h-48 items-center justify-center text-sm text-gray-400">No data for this period.</div>
+      ) : (
+        <ResponsiveContainer width="100%" height={220}>
+          <ComposedChart data={rows} margin={{ top: 4, right: 16, left: 0, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+            <XAxis dataKey="date" tick={{ fontSize: 11 }} tickFormatter={(d) => d.slice(5)} />
+            <YAxis yAxisId="cost" orientation="left" tick={{ fontSize: 11 }}
+              tickFormatter={(v) => `$${v.toFixed(2)}`} width={58} />
+            <YAxis yAxisId="reqs" orientation="right" tick={{ fontSize: 11 }} width={44} />
+            <Tooltip
+              formatter={(value, name) => name === "cost" ? [`$${value.toFixed(4)}`, "Cost"] : [value.toLocaleString(), "Requests"]}
+              labelFormatter={(d) => `Date: ${d}`}
+            />
+            <Legend wrapperStyle={{ fontSize: 12 }} />
+            <Bar yAxisId="cost" dataKey="cost" name="cost" fill="#4ade80" opacity={0.8} radius={[2, 2, 0, 0]} />
+            <Line yAxisId="reqs" dataKey="requests" name="requests" type="monotone"
+              stroke="#6366f1" strokeWidth={2} dot={false} />
+          </ComposedChart>
+        </ResponsiveContainer>
+      )}
+    </Card>
+  );
+}
 
 function Summary() {
   const [data, setData] = useState(null);
@@ -40,6 +113,8 @@ function Summary() {
         <Stat label="Cached tokens" value={fmt.num(data.cachedReadTokens)} />
         <Stat label="Cache savings" value={fmt.usd(data.cacheSavingUsd)} />
       </div>
+
+      <TrendChart />
 
       {savings?.rows?.length > 0 && (
         <Card title="Realised savings by substitution">


### PR DESCRIPTION
## Three short-effort, high-impact improvements

### 1. Budget threshold warnings
Previously a webhook only fired when a budget was **already breached** (100%). Users had no warning.

- **`Cap` model** — new `warningThreshold` field (default `0.8` = 80%)
- **`capEngine`** — fires `cap_warning` webhook when spend crosses the threshold but hasn't hit the limit yet; reuses the existing 5-minute dedup window
- **Budgets UI** — "Warn at (%)" input on both the create form and inline edit; hidden for alert-only caps (they don't enforce, so warnings don't apply)

Webhook payload addition:
\`\`\`json
{ "event": "cap_warning", "spent": 42.10, "limit": 50.00, "ratio": 0.842, ... }
\`\`\`

### 2. CSV export for request logs
Previously requests were only viewable 50 at a time with no way to pull them into Sheets or BI tools.

- **`GET /requests/export`** — same filter params as `/requests`; streams all matching rows as CSV with no pagination cap
- **`api.exportRequests()`** — triggers a browser file download
- **RequestsTable** — "Export CSV" button appears next to the pagination controls; exports whatever the current filter state is

### 3. Cost & request trend chart on Overview
Previously the Overview showed all-time aggregate totals with no trend visibility.

- **`analytics.timeseries()`** — MongoDB `$dateToString` daily bucket aggregation returning `{ date, requests, cost, failures }[]`
- **`GET /analytics/timeseries`** — new route accepting the standard filter params plus `bucket=day|hour`
- **Overview Summary tab** — `ComposedChart` (recharts, newly added) showing cost as green bars (left axis) and request count as a purple line (right axis); 7 / 30 / 90 day period selector

## Test plan
- [ ] Set a budget cap at $X, spend to 80%, confirm webhook fires with `event: "cap_warning"` before the block kicks in
- [ ] Set `warningThreshold` to 0 on a cap and confirm no warning webhook fires
- [ ] Click "Export CSV" on a filtered request view — confirm the download includes all rows (not just the current page) with correct columns
- [ ] Navigate to Overview → Summary — confirm the trend chart renders with bars + line; switch between 7/30/90 day periods
- [ ] Verify chart cost totals roughly match the "Total cost" stat card for the same window

🤖 Generated with [Claude Code](https://claude.com/claude-code)