### PR TITLE
feat: shadow-eval a candidate model on live traffic

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "smoke:simulate": "node server/scripts/simulate-smoke.js",
     "smoke:logging": "node server/scripts/logging-smoke.js",
     "smoke:maxtokens": "node server/scripts/maxtokens-smoke.js",
+    "smoke:eval": "node server/scripts/eval-smoke.js",
     "lint": "eslint server/src",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",

--- a/server/scripts/eval-smoke.js
+++ b/server/scripts/eval-smoke.js
@@ -1,0 +1,44 @@
+// Pure-logic smoke for shadow-eval (no DB / no provider keys). Run: npm run smoke:eval
+const { isSingleShot, shouldSample, parseVerdict, summarizeEvalPairs } = require("../src/eval/logic");
+
+let pass = 0, fail = 0;
+const eq = (got, exp, msg) => {
+  const g = JSON.stringify(got), e = JSON.stringify(exp);
+  if (g === e) { pass++; } else { fail++; console.log(`FAIL: ${msg} — got ${g}, expected ${e}`); }
+};
+
+// 1. isSingleShot — the mirror-safety guard.
+eq(isSingleShot("just a string prompt", false), true, "string prompt is single-shot");
+eq(isSingleShot([{ role: "system", content: "x" }, { role: "user", content: "hi" }], false), true, "system+user is single-shot");
+eq(isSingleShot([{ role: "user", content: "a" }, { role: "assistant", content: "b" }, { role: "user", content: "c" }], false), false, "multi-turn (has assistant) not single-shot");
+eq(isSingleShot([{ role: "user", content: "a" }, { role: "tool", content: "b" }], false), false, "tool history not single-shot");
+eq(isSingleShot([{ role: "user", content: "a" }], true), false, "tools present not single-shot");
+
+// 2. shouldSample — sampling decision.
+eq(shouldSample(0.05, 0.1), true, "0.05 < 0.1 samples");
+eq(shouldSample(0.5, 0.1), false, "0.5 >= 0.1 skips");
+eq(shouldSample(0.5, 0), false, "rate 0 never samples");
+
+// 3. parseVerdict — candidate is B.
+eq(parseVerdict('{"winner":"B","reason":"clearer"}').verdict, "better", "B → better");
+eq(parseVerdict('{"winner":"A","reason":"more accurate"}').verdict, "worse", "A → worse");
+eq(parseVerdict('here is my call: {"winner":"tie","reason":"same"}').verdict, "equal", "tie → equal (embedded)");
+eq(parseVerdict("no json here").verdict, "equal", "unparseable → equal fallback");
+
+// 4. summarizeEvalPairs — verdict + cost/latency aggregation.
+const pairs = [
+  { verdict: "better", prodCost: 0.10, candidateCost: 0.02, prodLatencyMs: 1000, candidateLatencyMs: 800 },
+  { verdict: "equal",  prodCost: 0.10, candidateCost: 0.02, prodLatencyMs: 1000, candidateLatencyMs: 800 },
+  { verdict: "worse",  prodCost: 0.10, candidateCost: 0.02, prodLatencyMs: 1000, candidateLatencyMs: 800 },
+  { verdict: null,     prodCost: 0.10, candidateCost: 0.02, prodLatencyMs: 1000, candidateLatencyMs: 800 }, // not yet judged
+];
+const s = summarizeEvalPairs(pairs);
+eq(s.pairs, 4, "total pairs");
+eq(s.judged, 3, "judged count excludes null verdict");
+eq([s.better, s.equal, s.worse], [1, 1, 1], "win/tie/loss counts");
+eq(Number(s.lossRate.toFixed(4)), 0.3333, "lossRate = 1/3 of judged");
+eq(Number(s.costDeltaPct.toFixed(2)), -0.80, "candidate 80% cheaper");
+eq(s.avgCandidateLatencyMs, 800, "avg candidate latency");
+
+console.log(`${pass}/${pass + fail} passed`);
+process.exit(fail ? 1 : 0);

--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -27,6 +27,10 @@ const pricing = require("../pricing/registry");
 const ModelEntry = require("../models/ModelEntry");
 const CustomProvider = require("../models/CustomProvider");
 const Settings = require("../models/Settings");
+const EvalCampaign = require("../models/EvalCampaign");
+const EvalPair = require("../models/EvalPair");
+const { invalidateCampaignCache } = require("../eval/shadow");
+const { summarizeEvalPairs } = require("../eval/logic");
 const secrets = require("../security/secrets");
 const { config } = require("../config");
 
@@ -943,6 +947,81 @@ router.post("/app-configs/:app/set-default-policy", async (req, res, next) => {
     await Settings.updateOne({ key: "global" }, { $set: { aiPolicy: cfg.aiPolicyAssignments } }, { upsert: true });
     aiPolicy.invalidate?.();
     setImmediate(() => logAction("appConfig.setDefaultPolicy", "settings", "global", { from: req.params.app }));
+    res.json({ ok: true });
+  } catch (e) { next(e); }
+});
+
+// ── Shadow-eval campaigns ─────────────────────────────────────────────────────
+router.get("/eval/campaigns", async (req, res, next) => {
+  try {
+    const campaigns = await EvalCampaign.find().sort({ createdAt: -1 }).lean();
+    const withCounts = await Promise.all(campaigns.map(async (c) => ({
+      ...c, pairCount: await EvalPair.countDocuments({ campaignId: c._id }),
+    })));
+    res.json(withCounts);
+  } catch (e) { next(e); }
+});
+
+router.post("/eval/campaigns", async (req, res, next) => {
+  try {
+    const { application, candidateModel, judgeModel, sampleRate, thresholds, name } = req.body || {};
+    if (!application) return res.status(400).json({ error: "application is required" });
+    if (!candidateModel) return res.status(400).json({ error: "candidateModel is required" });
+    const doc = await EvalCampaign.create({
+      application, candidateModel, name: name || "",
+      judgeModel: judgeModel || null,
+      sampleRate: sampleRate != null ? Math.min(1, Math.max(0, Number(sampleRate))) : 0.1,
+      thresholds: {
+        minPairs: thresholds?.minPairs != null ? Math.max(1, Number(thresholds.minPairs)) : 50,
+        maxLossRate: thresholds?.maxLossRate != null ? Math.min(1, Math.max(0, Number(thresholds.maxLossRate))) : 0.1,
+      },
+    });
+    invalidateCampaignCache();
+    setImmediate(() => logAction("evalCampaign.create", "evalCampaign", String(doc._id), { application, candidateModel }));
+    res.status(201).json(doc);
+  } catch (e) { next(e); }
+});
+
+router.get("/eval/campaigns/:id", async (req, res, next) => {
+  try {
+    const c = await EvalCampaign.findById(req.params.id).lean().catch(() => null);
+    if (!c) return res.status(404).json({ error: "not found" });
+    const pairs = await EvalPair.find({ campaignId: c._id },
+      { prodCost: 1, candidateCost: 1, prodLatencyMs: 1, candidateLatencyMs: 1, verdict: 1 }).lean();
+    res.json({ ...c, summary: summarizeEvalPairs(pairs) });
+  } catch (e) { next(e); }
+});
+
+router.get("/eval/campaigns/:id/pairs", async (req, res, next) => {
+  try {
+    const items = await EvalPair.find({ campaignId: req.params.id }).sort({ timestamp: -1 }).limit(50).lean();
+    res.json({ items });
+  } catch (e) { next(e); }
+});
+
+router.patch("/eval/campaigns/:id", async (req, res, next) => {
+  try {
+    const b = req.body || {};
+    const update = {};
+    if (b.status && ["active", "paused", "done"].includes(b.status)) update.status = b.status;
+    if (b.sampleRate != null) update.sampleRate = Math.min(1, Math.max(0, Number(b.sampleRate)));
+    if (b.judgeModel !== undefined) update.judgeModel = b.judgeModel || null;
+    if (b.thresholds) update.thresholds = {
+      minPairs: b.thresholds.minPairs != null ? Math.max(1, Number(b.thresholds.minPairs)) : 50,
+      maxLossRate: b.thresholds.maxLossRate != null ? Math.min(1, Math.max(0, Number(b.thresholds.maxLossRate))) : 0.1,
+    };
+    const c = await EvalCampaign.findByIdAndUpdate(req.params.id, { $set: update }, { new: true }).lean();
+    if (!c) return res.status(404).json({ error: "not found" });
+    invalidateCampaignCache();
+    res.json(c);
+  } catch (e) { next(e); }
+});
+
+router.delete("/eval/campaigns/:id", async (req, res, next) => {
+  try {
+    await EvalCampaign.findByIdAndDelete(req.params.id);
+    await EvalPair.deleteMany({ campaignId: req.params.id });
+    invalidateCampaignCache();
     res.json({ ok: true });
   } catch (e) { next(e); }
 });

--- a/server/src/eval/judge.js
+++ b/server/src/eval/judge.js
@@ -1,0 +1,47 @@
+// LLM-as-judge: grade a candidate response (B) against the prod response (A) for the same
+// request. Returns { verdict: "better"|"equal"|"worse", rationale } from the candidate's
+// perspective, or null when no judge model is available. Used by shadow-eval.
+const pricing = require("../pricing/registry");
+const { parseVerdict } = require("./logic");
+
+function lastUserText(messages) {
+  if (typeof messages === "string") return messages;
+  if (!Array.isArray(messages)) return "";
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m && m.role === "user") return typeof m.content === "string" ? m.content : JSON.stringify(m.content);
+  }
+  const first = messages.find((m) => m && m.content);
+  return first ? (typeof first.content === "string" ? first.content : JSON.stringify(first.content)) : "";
+}
+
+async function judge({ router, eff, judgeModel, messages, prodText, candidateText }) {
+  if (!judgeModel) return null;
+  const jm = pricing.getModel(judgeModel);
+  if (!jm || !eff?.liveIds?.includes(jm.provider)) return null; // judge model not live → capture pair only
+  const prompt = [
+    "You are impartially evaluating two AI responses to the SAME user request. Decide which better",
+    "fulfills the request (correctness, completeness, instruction-following). Be strict.",
+    "",
+    "USER REQUEST:",
+    lastUserText(messages),
+    "",
+    "RESPONSE A (current model):",
+    String(prodText || "").slice(0, 6000),
+    "",
+    "RESPONSE B (candidate model):",
+    String(candidateText || "").slice(0, 6000),
+    "",
+    'Reply with ONLY JSON: {"winner": "A" | "B" | "tie", "reason": "<one short sentence>"}',
+  ].join("\n");
+  try {
+    const res = await router.complete({
+      messages: prompt, providerOverride: jm.provider, modelOverride: judgeModel, temperature: 0,
+    });
+    return parseVerdict(res.text || "");
+  } catch {
+    return null;
+  }
+}
+
+module.exports = { judge, lastUserText };

--- a/server/src/eval/logic.js
+++ b/server/src/eval/logic.js
@@ -1,0 +1,56 @@
+// Pure shadow-eval logic — dependency-free (no mongoose/pricing) so it can be unit-tested
+// without a DB. Shared by shadow.js, judge.js, and the API routes.
+
+// Single-shot = safe to mirror: no tools, and no prior assistant/tool turns (one-and-done).
+// Multi-turn / agentic traffic is skipped (a mirrored candidate would want side-effecting actions).
+function isSingleShot(messages, hasTools) {
+  if (hasTools) return false;
+  if (typeof messages === "string") return true;
+  if (!Array.isArray(messages)) return false;
+  return !messages.some((m) => m && (m.role === "tool" || m.role === "assistant"));
+}
+
+// Sampling decision (pure): mirror when rand < rate.
+function shouldSample(rand, rate) {
+  return rand < (Number(rate) || 0);
+}
+
+// Lenient parse of the judge's reply into a candidate-perspective verdict (B = candidate).
+function parseVerdict(text) {
+  const raw = String(text || "");
+  const m = raw.match(/\{[\s\S]*\}/);
+  if (m) {
+    try {
+      const j = JSON.parse(m[0]);
+      const w = String(j.winner || j.verdict || "").trim().toUpperCase();
+      const reason = j.reason || j.rationale || "";
+      if (w === "B") return { verdict: "better", rationale: reason };
+      if (w === "A") return { verdict: "worse", rationale: reason };
+      if (w === "TIE" || w === "EQUAL" || w === "SAME") return { verdict: "equal", rationale: reason };
+    } catch { /* fall through */ }
+  }
+  return { verdict: "equal", rationale: raw.slice(0, 300) };
+}
+
+// Aggregate a campaign's pairs into a verdict summary (win/tie/loss, cost + latency delta).
+function summarizeEvalPairs(pairs) {
+  const judged = pairs.filter((p) => p.verdict);
+  const better = judged.filter((p) => p.verdict === "better").length;
+  const equal  = judged.filter((p) => p.verdict === "equal").length;
+  const worse  = judged.filter((p) => p.verdict === "worse").length;
+  const n = pairs.length;
+  const sum = (f) => pairs.reduce((a, p) => a + (Number(f(p)) || 0), 0);
+  const prodCost = sum((p) => p.prodCost), candidateCost = sum((p) => p.candidateCost);
+  const prodLat = sum((p) => p.prodLatencyMs), candLat = sum((p) => p.candidateLatencyMs);
+  return {
+    pairs: n, judged: judged.length, better, equal, worse,
+    winRate:  judged.length ? better / judged.length : null,
+    lossRate: judged.length ? worse  / judged.length : null,
+    prodCost, candidateCost,
+    costDeltaPct: prodCost > 0 ? (candidateCost - prodCost) / prodCost : null,
+    avgProdLatencyMs: n ? prodLat / n : 0,
+    avgCandidateLatencyMs: n ? candLat / n : 0,
+  };
+}
+
+module.exports = { isSingleShot, shouldSample, parseVerdict, summarizeEvalPairs };

--- a/server/src/eval/shadow.js
+++ b/server/src/eval/shadow.js
@@ -1,0 +1,97 @@
+// Shadow-eval: mirror a sampled fraction of an app's single-shot traffic to a candidate
+// model AFTER the prod response is already served, judge candidate-vs-prod, and record the
+// pair. Called fire-and-forget from the gateway's post-response setImmediate block. It must
+// NEVER throw into or delay the served request.
+const EvalCampaign = require("../models/EvalCampaign");
+const EvalPair = require("../models/EvalPair");
+const Settings = require("../models/Settings");
+const pricing = require("../pricing/registry");
+const { maskMessages, maskPii, clampText } = require("../logging/piiFilter");
+const { judge } = require("./judge");
+const { isSingleShot, shouldSample } = require("./logic");
+
+// Short-lived active-campaign cache per application (mirrors getAppConfig in handler.js).
+const _campaignCache = new Map(); // application -> { campaign, expiresAt }
+async function getActiveCampaign(application) {
+  if (!application || application === "unknown") return null;
+  const cached = _campaignCache.get(application);
+  if (cached && cached.expiresAt > Date.now()) return cached.campaign;
+  const campaign = await EvalCampaign.findOne({ application, status: "active" }).catch(() => null);
+  _campaignCache.set(application, { campaign, expiresAt: Date.now() + 30_000 });
+  return campaign;
+}
+function invalidateCampaignCache() { _campaignCache.clear(); }
+
+function costOf(model, usage) {
+  const u = usage || {};
+  return pricing.costFor(model, u.inputTokens || 0, u.outputTokens || 0).totalCost;
+}
+
+// Fire the "safe to switch" webhook once thresholds clear.
+async function checkThresholdAndNotify(campaign) {
+  if (campaign.notifiedAt) return;
+  const t = campaign.thresholds || {};
+  const minPairs = t.minPairs || 50;
+  const maxLossRate = t.maxLossRate != null ? t.maxLossRate : 0.1;
+  const judged = await EvalPair.find({ campaignId: campaign._id, verdict: { $ne: null } }, { verdict: 1 }).lean();
+  if (judged.length < minPairs) return;
+  const loss = judged.filter((p) => p.verdict === "worse").length / judged.length;
+  if (loss > maxLossRate) return;
+  const s = await Settings.get().catch(() => null);
+  const url = s?.webhookUrl;
+  if (url) {
+    const payload = {
+      text: `Arbr shadow-eval: candidate "${campaign.candidateModel}" looks healthy for app `
+          + `"${campaign.application}" (${judged.length} judged, ${(loss * 100).toFixed(1)}% worse). Safe to switch.`,
+      campaignId: String(campaign._id), application: campaign.application,
+      candidateModel: campaign.candidateModel, judgedPairs: judged.length, lossRate: loss,
+    };
+    try {
+      await fetch(url, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
+    } catch { /* swallow */ }
+  }
+  campaign.notifiedAt = new Date();
+  await campaign.save().catch(() => {});
+}
+
+// prod = { model, provider, latencyMs, text, usage }
+async function maybeShadowEval({ application, taskType, messages, hasTools, requestId, prod, router, eff }) {
+  try {
+    const campaign = await getActiveCampaign(application);
+    if (!campaign || !router || !eff) return;
+    if (!isSingleShot(messages, hasTools)) return;
+    if (!shouldSample(Math.random(), campaign.sampleRate)) return;
+    const cm = pricing.getModel(campaign.candidateModel);
+    if (!cm || !eff.liveIds.includes(cm.provider)) return;   // candidate not live → skip
+    if (cm.id === prod.model) return;                        // same model → nothing to compare
+
+    const candidate = await router.complete({
+      messages, providerOverride: cm.provider, modelOverride: campaign.candidateModel,
+    }).catch(() => null);
+    if (!candidate) return;
+
+    const s = await Settings.get().catch(() => null);
+    const mask = !!s?.piiMaskingEnabled;
+    const msgArr = Array.isArray(messages) ? messages : [{ role: "user", content: String(messages ?? "") }];
+    const pair = new EvalPair({
+      campaignId: campaign._id, requestId, application, taskType, timestamp: new Date(),
+      prodModel: prod.model, prodProvider: prod.provider, prodCost: costOf(prod.model, prod.usage),
+      prodLatencyMs: prod.latencyMs, prodResponse: clampText(mask ? maskPii(prod.text || "") : (prod.text || "")),
+      candidateModel: campaign.candidateModel, candidateProvider: cm.provider,
+      candidateCost: costOf(campaign.candidateModel, candidate.usage), candidateLatencyMs: candidate.latencyMs,
+      candidateResponse: clampText(mask ? maskPii(candidate.text || "") : (candidate.text || "")),
+      judgeModel: campaign.judgeModel || null,
+      messages: mask ? maskMessages(msgArr) : msgArr,
+    });
+
+    const v = await judge({
+      router, eff, judgeModel: campaign.judgeModel, messages, prodText: prod.text, candidateText: candidate.text,
+    });
+    if (v) { pair.verdict = v.verdict; pair.rationale = v.rationale; }
+    await pair.save();
+
+    if (pair.verdict) await checkThresholdAndNotify(campaign);
+  } catch { /* never affect the served request */ }
+}
+
+module.exports = { maybeShadowEval, getActiveCampaign, invalidateCampaignCache, isSingleShot };

--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -17,6 +17,7 @@ const policyEngine = require("../routing/policy");
 const aiPolicy = require("../routing/aiPolicy");
 const capEngine = require("../routing/capEngine");
 const responseCache = require("../routing/responseCache");
+const { maybeShadowEval } = require("../eval/shadow");
 const logger = require("../logging/logger");
 const Settings = require("../models/Settings");
 const ApplicationConfig = require("../models/ApplicationConfig");
@@ -436,6 +437,11 @@ async function handleChat(req, res) {
       routingDecision, cacheHit: false,
       knownPricing: served.knownPricing,
       messages: body.messages, responseText: result.text,
+    });
+    // Shadow-eval: mirror to a candidate model if a campaign is active for this app (self-guarded, non-blocking).
+    maybeShadowEval({
+      application: meta.application, taskType, messages: body.messages, hasTools: false, requestId, router, eff,
+      prod: { model: result.modelId, provider: result.providerId, latencyMs: result.latencyMs, text: result.text, usage: result.usage },
     });
   });
 }

--- a/server/src/gateway/openaiCompat.js
+++ b/server/src/gateway/openaiCompat.js
@@ -9,6 +9,7 @@ const { resolveRoute, invokeWithFallback, getAppConfig } = require("./handler");
 const capEngine = require("../routing/capEngine");
 const pricing = require("../pricing/registry");
 const logger = require("../logging/logger");
+const { maybeShadowEval } = require("../eval/shadow");
 const { PROVIDERS } = require("../config");
 const Settings = require("../models/Settings");
 
@@ -155,7 +156,7 @@ function translateToolCalls(toolCalls) {
 async function proxyOpenAICompat(ctx) {
   const {
     res, body, served, modelRequested, meta, requestId, timestamp,
-    taskType, classifiedBy, difficulty, difficultyScore, confidence, routingDecision, routingExplain, eff, baseURL,
+    taskType, classifiedBy, difficulty, difficultyScore, confidence, routingDecision, routingExplain, eff, router, baseURL,
   } = ctx;
 
   const apiKey = eff.providers[served.provider]?.credential?.apiKey || "none";
@@ -209,6 +210,12 @@ async function proxyOpenAICompat(ctx) {
       cachedReadTokens: (u.prompt_tokens_details && u.prompt_tokens_details.cached_tokens) || 0,
       responseText: data.choices?.[0]?.message?.content || null,
       latencyMs, status: "success",
+    });
+    maybeShadowEval({
+      application: meta.application, taskType, messages: body.messages, hasTools: !!(body.tools && body.tools.length),
+      requestId, router, eff,
+      prod: { model: served.model, provider: served.provider, latencyMs, text: data.choices?.[0]?.message?.content || "",
+              usage: { inputTokens: u.prompt_tokens || 0, outputTokens: u.completion_tokens || 0 } },
     });
     return;
   }
@@ -415,7 +422,7 @@ async function handleOpenAICompat(req, res) {
       routing: routingDecision, taskType });
     return proxyOpenAICompat({
       res, body, served, modelRequested, meta, requestId, timestamp,
-      taskType, classifiedBy, difficulty, difficultyScore, confidence, routingDecision, routingExplain: explain, eff, baseURL: compatBaseURL,
+      taskType, classifiedBy, difficulty, difficultyScore, confidence, routingDecision, routingExplain: explain, eff, router, baseURL: compatBaseURL,
     });
   }
 
@@ -701,7 +708,7 @@ async function handleOpenAICompat(req, res) {
     },
   });
 
-  setImmediate(() =>
+  setImmediate(() => {
     logger.write({
       requestId, timestamp, ...meta,
       provider: result.providerId, model: result.modelId, modelRequested,
@@ -714,8 +721,13 @@ async function handleOpenAICompat(req, res) {
       latencyMs: result.latencyMs, status: "success", routingDecision, routingExplain: explain, cacheHit: false,
       knownPricing: served.knownPricing,
       messages: body.messages, responseText: result.text,
-    })
-  );
+    });
+    maybeShadowEval({
+      application: meta.application, taskType, messages: body.messages, hasTools: !!(body.tools && body.tools.length),
+      requestId, router, eff,
+      prod: { model: result.modelId, provider: result.providerId, latencyMs: result.latencyMs, text: result.text, usage: result.usage },
+    });
+  });
 }
 
 module.exports = { handleOpenAICompat };

--- a/server/src/models/EvalCampaign.js
+++ b/server/src/models/EvalCampaign.js
@@ -1,0 +1,25 @@
+// A shadow-eval campaign: mirror a sampled fraction of one application's single-shot
+// traffic to a candidate model (without serving it), judge candidate-vs-prod, and gate a
+// model switch on a healthy verdict. See server/src/eval/shadow.js.
+const mongoose = require("mongoose");
+
+const evalCampaignSchema = new mongoose.Schema(
+  {
+    name:           { type: String, default: "" },
+    application:    { type: String, required: true, index: true }, // target app whose traffic is mirrored
+    candidateModel: { type: String, required: true },              // model being evaluated
+    judgeModel:     { type: String, default: null },               // LLM judge; null = capture pairs only, no verdict
+    sampleRate:     { type: Number, default: 0.1, min: 0, max: 1 }, // fraction of eligible requests mirrored
+    status:         { type: String, enum: ["active", "paused", "done"], default: "active", index: true },
+    // "Safe to switch" gate: notify once pairs >= minPairs AND lossRate <= maxLossRate.
+    thresholds:     {
+      minPairs:    { type: Number, default: 50 },
+      maxLossRate: { type: Number, default: 0.1 },
+    },
+    notifiedAt:     { type: Date, default: null }, // set when the webhook has fired, so it fires once
+    createdBy:      { type: String, default: "console" },
+  },
+  { timestamps: true, collection: "eval_campaigns" }
+);
+
+module.exports = mongoose.model("EvalCampaign", evalCampaignSchema);

--- a/server/src/models/EvalPair.js
+++ b/server/src/models/EvalPair.js
@@ -1,0 +1,38 @@
+// One shadow-eval observation: the prod response (actually served) paired with the
+// candidate response (mirrored, never served) for the same request, plus the judge verdict.
+// Prompt/responses are PII-masked at write time (same as RequestRecord) and size-capped.
+const mongoose = require("mongoose");
+
+const evalPairSchema = new mongoose.Schema(
+  {
+    campaignId: { type: mongoose.Schema.Types.ObjectId, ref: "EvalCampaign", required: true, index: true },
+    requestId:  { type: String, index: true },
+    timestamp:  { type: Date, default: Date.now, index: true },
+    application: { type: String, index: true },
+    taskType:   { type: String },
+
+    // Prod (served)
+    prodModel:      { type: String },
+    prodProvider:   { type: String },
+    prodCost:       { type: Number, default: 0 },
+    prodLatencyMs:  { type: Number, default: 0 },
+    prodResponse:   { type: String, default: null },
+
+    // Candidate (mirrored, not served)
+    candidateModel:     { type: String },
+    candidateProvider:  { type: String },
+    candidateCost:      { type: Number, default: 0 },
+    candidateLatencyMs: { type: Number, default: 0 },
+    candidateResponse:  { type: String, default: null },
+
+    // Judge verdict, from the candidate's perspective vs prod. null = not yet judged.
+    verdict:   { type: String, enum: ["better", "equal", "worse", null], default: null, index: true },
+    rationale: { type: String, default: null },
+    judgeModel: { type: String, default: null },
+
+    messages:  { type: mongoose.Schema.Types.Mixed, default: null }, // request payload (masked)
+  },
+  { collection: "eval_pairs" }
+);
+
+module.exports = mongoose.model("EvalPair", evalPairSchema);

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -9,6 +9,7 @@ import Requests from "./pages/Requests.jsx";
 import Settings from "./pages/Settings.jsx";
 import Docs from "./pages/Docs.jsx";
 import Models from "./pages/Models.jsx";
+import ModelEvals from "./pages/ModelEvals.jsx";
 import Budgets from "./pages/Budgets.jsx";
 import Audit from "./pages/Audit.jsx";
 import Governance from "./pages/Governance.jsx";
@@ -41,6 +42,7 @@ export default function App() {
         <Route path="/routing" element={<Routing onChange={refreshStatus} />} />
         <Route path="/budgets" element={<Budgets onChange={refreshStatus} />} />
         <Route path="/models" element={<Models />} />
+        <Route path="/evals" element={<ModelEvals />} />
         <Route path="/settings" element={<Settings onChange={refreshStatus} />} />
         <Route path="/governance" element={<Governance />} />
         <Route path="/audit" element={<Audit />} />

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -139,6 +139,14 @@ export const api = {
   generateAppPolicy: (app, excludeModels = [], goal = "balanced", windowDays) => req(`/app-configs/${encodeURIComponent(app)}/generate-policy`, { method: "POST", body: JSON.stringify({ excludeModels, goal, windowDays }) }),
   simulateAppPolicy: (app, assignments, windowDays) => req(`/app-configs/${encodeURIComponent(app)}/simulate`, { method: "POST", body: JSON.stringify({ assignments, windowDays }) }),
   setAppDefaultPolicy: (app) => req(`/app-configs/${encodeURIComponent(app)}/set-default-policy`, { method: "POST" }),
+
+  // Shadow-eval campaigns
+  evalCampaigns: () => req("/eval/campaigns"),
+  evalCampaign: (id) => req(`/eval/campaigns/${id}`),
+  createEvalCampaign: (body) => req("/eval/campaigns", { method: "POST", body: JSON.stringify(body) }),
+  updateEvalCampaign: (id, body) => req(`/eval/campaigns/${id}`, { method: "PATCH", body: JSON.stringify(body) }),
+  deleteEvalCampaign: (id) => req(`/eval/campaigns/${id}`, { method: "DELETE" }),
+  evalCampaignPairs: (id) => req(`/eval/campaigns/${id}/pairs`),
 };
 
 export const fmt = {

--- a/web/src/components/Layout.jsx
+++ b/web/src/components/Layout.jsx
@@ -12,6 +12,7 @@ const NAV_GROUPS = [
     { to: "/routing",  label: "Routing" },
     { to: "/budgets",  label: "Budgets" },
     { to: "/models",   label: "Models" },
+    { to: "/evals",    label: "Model Evals" },
     { to: "/settings", label: "Settings" },
   ] },
   { section: "Governance", items: [

--- a/web/src/pages/ModelEvals.jsx
+++ b/web/src/pages/ModelEvals.jsx
@@ -1,0 +1,219 @@
+import React, { useEffect, useState, useCallback } from "react";
+import { api, fmt } from "../api.js";
+import { Card, Table, Badge, Stat, Drawer, CodeBlock, Spinner, ConfirmDialog } from "../components/ui.jsx";
+
+const VERDICT_TONE = { better: "green", equal: "gray", worse: "red" };
+const STATUS_TONE = { active: "green", paused: "amber", done: "gray" };
+
+const pct = (n) => (n == null ? "—" : `${(n * 100).toFixed(1)}%`);
+const signedPct = (n) => (n == null ? "—" : `${n > 0 ? "+" : ""}${(n * 100).toFixed(1)}%`);
+
+// Create-campaign form. Models come from the registry; application is free-text (any app that sends traffic).
+function NewCampaign({ models, apps, onCreated }) {
+  const [form, setForm] = useState({ application: "", candidateModel: "", judgeModel: "", sampleRate: 0.1, minPairs: 50, maxLossRate: 0.1 });
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState(null);
+  const set = (k, v) => setForm((f) => ({ ...f, [k]: v }));
+
+  const submit = async () => {
+    setErr(null); setBusy(true);
+    try {
+      await api.createEvalCampaign({
+        application: form.application.trim(),
+        candidateModel: form.candidateModel,
+        judgeModel: form.judgeModel || null,
+        sampleRate: Number(form.sampleRate),
+        thresholds: { minPairs: Number(form.minPairs), maxLossRate: Number(form.maxLossRate) },
+      });
+      setForm({ application: "", candidateModel: "", judgeModel: "", sampleRate: 0.1, minPairs: 50, maxLossRate: 0.1 });
+      onCreated();
+    } catch (e) { setErr(e.message); } finally { setBusy(false); }
+  };
+
+  return (
+    <Card title="New shadow-eval campaign">
+      <p className="mb-4 text-sm text-gray-500">
+        Mirror a sampled slice of an application's single-shot traffic to a candidate model without serving it,
+        judge candidate-vs-current, and get notified when it's safe to switch.
+      </p>
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
+        <div>
+          <div className="label mb-1">Application</div>
+          <input className="input w-full" list="eval-apps" placeholder="e.g. my-pipeline"
+            value={form.application} onChange={(e) => set("application", e.target.value)} />
+          <datalist id="eval-apps">{apps.map((a) => <option key={a} value={a} />)}</datalist>
+        </div>
+        <div>
+          <div className="label mb-1">Candidate model</div>
+          <select className="input w-full" value={form.candidateModel} onChange={(e) => set("candidateModel", e.target.value)}>
+            <option value="">Select…</option>
+            {models.map((m) => <option key={m.id} value={m.id}>{m.label || m.id}</option>)}
+          </select>
+        </div>
+        <div>
+          <div className="label mb-1">Judge model <span className="text-gray-400">(optional)</span></div>
+          <select className="input w-full" value={form.judgeModel} onChange={(e) => set("judgeModel", e.target.value)}>
+            <option value="">Capture pairs only (no verdict)</option>
+            {models.map((m) => <option key={m.id} value={m.id}>{m.label || m.id}</option>)}
+          </select>
+        </div>
+        <div>
+          <div className="label mb-1">Sample rate</div>
+          <input className="input w-full" type="number" step="0.05" min="0" max="1"
+            value={form.sampleRate} onChange={(e) => set("sampleRate", e.target.value)} />
+        </div>
+        <div>
+          <div className="label mb-1">Min pairs to notify</div>
+          <input className="input w-full" type="number" min="1"
+            value={form.minPairs} onChange={(e) => set("minPairs", e.target.value)} />
+        </div>
+        <div>
+          <div className="label mb-1">Max loss rate</div>
+          <input className="input w-full" type="number" step="0.05" min="0" max="1"
+            value={form.maxLossRate} onChange={(e) => set("maxLossRate", e.target.value)} />
+        </div>
+      </div>
+      {err && <div className="mt-3 text-sm text-red-600">{err}</div>}
+      <div className="mt-4">
+        <button className="btn-secondary text-sm" disabled={busy || !form.application.trim() || !form.candidateModel} onClick={submit}>
+          {busy ? "Creating…" : "Start campaign"}
+        </button>
+      </div>
+    </Card>
+  );
+}
+
+// Verdict summary + recent pairs for one campaign.
+function CampaignDetail({ id, onClose }) {
+  const [detail, setDetail] = useState(null);
+  const [pairs, setPairs] = useState(null);
+  const [pair, setPair] = useState(null);
+
+  useEffect(() => {
+    api.evalCampaign(id).then(setDetail).catch((e) => setDetail({ _error: e.message }));
+    api.evalCampaignPairs(id).then((d) => setPairs(d.items)).catch(() => setPairs([]));
+  }, [id]);
+
+  if (!detail) return <Drawer title="Campaign" onClose={onClose}><Spinner /></Drawer>;
+  if (detail._error) return <Drawer title="Campaign" onClose={onClose}><div className="text-sm text-red-600">{detail._error}</div></Drawer>;
+
+  const s = detail.summary || {};
+  const pairCols = [
+    { key: "timestamp", header: "Time", render: (r) => <span className="whitespace-nowrap text-gray-500">{fmt.date(r.timestamp)}</span> },
+    { key: "verdict", header: "Verdict", render: (r) => r.verdict ? <Badge tone={VERDICT_TONE[r.verdict]}>{r.verdict}</Badge> : <span className="text-gray-400">—</span> },
+    { key: "cost", header: "Cost (prod → cand)", render: (r) => <span>{fmt.usd(r.prodCost)} → {fmt.usd(r.candidateCost)}</span> },
+    { key: "lat", header: "Latency", render: (r) => <span>{fmt.ms(r.prodLatencyMs)} → {fmt.ms(r.candidateLatencyMs)}</span> },
+  ];
+
+  return (
+    <Drawer title={`Campaign · ${detail.candidateModel}`} onClose={onClose}>
+      <div className="space-y-5">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Stat label="Pairs" value={fmt.num(s.pairs)} sub={`${fmt.num(s.judged)} judged`} />
+          <Stat label="Win / tie / loss" value={`${s.better || 0}/${s.equal || 0}/${s.worse || 0}`} sub={`loss ${pct(s.lossRate)}`} />
+          <Stat label="Cost delta" value={signedPct(s.costDeltaPct)} sub="candidate vs prod" />
+          <Stat label="Latency" value={fmt.ms(s.avgCandidateLatencyMs)} sub={`prod ${fmt.ms(s.avgProdLatencyMs)}`} />
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
+          App <b>{detail.application}</b> · candidate <b>{detail.candidateModel}</b> · judge {detail.judgeModel || "none"} ·
+          sample {pct(detail.sampleRate)} · notify at {detail.thresholds?.minPairs} pairs, loss ≤ {pct(detail.thresholds?.maxLossRate)}
+          {detail.notifiedAt && <span className="ml-1 text-arbr-green-700">· healthy-notification sent</span>}
+        </div>
+        <div>
+          <div className="label mb-1">Recent pairs</div>
+          {pairs === null ? <Spinner /> : <Table columns={pairCols} rows={pairs} empty="No pairs yet." onRowClick={setPair} />}
+        </div>
+      </div>
+      {pair && (
+        <Drawer title="Eval pair" onClose={() => setPair(null)}>
+          <div className="space-y-4">
+            <div className="flex items-center gap-2">
+              {pair.verdict ? <Badge tone={VERDICT_TONE[pair.verdict]}>{pair.verdict}</Badge> : <Badge tone="gray">unjudged</Badge>}
+              <span className="text-sm text-gray-500">{pair.taskType || "—"}</span>
+            </div>
+            {pair.rationale && <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">{pair.rationale}</div>}
+            <div>
+              <div className="label mb-1">Prompt</div>
+              {pair.messages ? <CodeBlock lang="json" code={JSON.stringify(pair.messages, null, 2)} /> : <div className="text-xs text-gray-400">(not captured)</div>}
+            </div>
+            <div>
+              <div className="label mb-1">Prod response · {pair.prodModel} · {fmt.usd(pair.prodCost)}</div>
+              {pair.prodResponse ? <CodeBlock code={pair.prodResponse} /> : <div className="text-xs text-gray-400">(not captured)</div>}
+            </div>
+            <div>
+              <div className="label mb-1">Candidate response · {pair.candidateModel} · {fmt.usd(pair.candidateCost)}</div>
+              {pair.candidateResponse ? <CodeBlock code={pair.candidateResponse} /> : <div className="text-xs text-gray-400">(not captured)</div>}
+            </div>
+          </div>
+        </Drawer>
+      )}
+    </Drawer>
+  );
+}
+
+export default function ModelEvals() {
+  const [campaigns, setCampaigns] = useState(null);
+  const [models, setModels] = useState([]);
+  const [apps, setApps] = useState([]);
+  const [openId, setOpenId] = useState(null);
+  const [confirmDel, setConfirmDel] = useState(null);
+  const [err, setErr] = useState(null);
+
+  const load = useCallback(() => {
+    api.evalCampaigns().then(setCampaigns).catch((e) => setErr(e.message));
+  }, []);
+
+  useEffect(() => {
+    load();
+    api.models().then((m) => setModels(m || [])).catch(() => {});
+    api.facets().then((f) => setApps(f?.applications || [])).catch(() => {});
+  }, [load]);
+
+  const setStatus = async (c, status) => { await api.updateEvalCampaign(c._id, { status }); load(); };
+  const remove = async (c) => { setConfirmDel(null); await api.deleteEvalCampaign(c._id); load(); };
+
+  const columns = [
+    { key: "application", header: "Application", render: (c) => <span className="font-medium">{c.application}</span> },
+    { key: "candidateModel", header: "Candidate" },
+    { key: "judgeModel", header: "Judge", render: (c) => c.judgeModel || <span className="text-gray-400">none</span> },
+    { key: "status", header: "Status", render: (c) => <Badge tone={STATUS_TONE[c.status]}>{c.status}</Badge> },
+    { key: "pairCount", header: "Pairs", render: (c) => fmt.num(c.pairCount) },
+    { key: "sampleRate", header: "Sample", render: (c) => pct(c.sampleRate) },
+    { key: "actions", header: "", render: (c) => (
+      <span className="flex gap-2" onClick={(e) => e.stopPropagation()}>
+        <button className="btn-outline text-xs" onClick={() => setOpenId(c._id)}>View</button>
+        {c.status === "active"
+          ? <button className="btn-outline text-xs" onClick={() => setStatus(c, "paused")}>Pause</button>
+          : c.status === "paused" && <button className="btn-outline text-xs" onClick={() => setStatus(c, "active")}>Resume</button>}
+        <button className="btn-outline text-xs text-red-600" onClick={() => setConfirmDel(c)}>Delete</button>
+      </span>
+    ) },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-arbr-charcoal">Model Evals</h1>
+        <p className="mt-1 text-sm text-gray-500">Safely evaluate a candidate model on your own live traffic before switching.</p>
+      </div>
+
+      <NewCampaign models={models} apps={apps} onCreated={load} />
+
+      <Card title="Campaigns">
+        {err && <div className="mb-3 text-sm text-red-600">{err}</div>}
+        {campaigns === null ? <Spinner /> : <Table columns={columns} rows={campaigns} empty="No campaigns yet." onRowClick={(c) => setOpenId(c._id)} />}
+      </Card>
+
+      {openId && <CampaignDetail id={openId} onClose={() => setOpenId(null)} />}
+      {confirmDel && (
+        <ConfirmDialog
+          title="Delete campaign?"
+          message={`This removes the campaign and its ${fmt.num(confirmDel.pairCount)} eval pairs.`}
+          confirmLabel="Delete"
+          onConfirm={() => remove(confirmDel)}
+          onCancel={() => setConfirmDel(null)}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Why

First concrete step toward the goal-driven, self-improving router: everything in that vision is blocked on one capability Arbr lacks — **scoring a routing outcome on real traffic**. This ships that as a bounded, human-gated **"evaluate a candidate model on your own live traffic"** feature (inspiration: mirror traffic + auto-generated evals + safe-to-switch gate). It delivers spend-reduction value immediately and builds the quality-measurement keystone the future learning loop reuses.

## How it works

For an active `EvalCampaign` (candidate model + target app + sample rate + optional judge model), the gateway mirrors a sampled slice of that app's **single-shot** traffic to the candidate **after** the prod response is already served. The candidate output is never returned to the client. Arbr records the pair (cost / latency / both responses) plus an LLM-judge verdict (candidate-vs-prod), aggregates win/tie/loss + cost/latency delta, and fires the existing governance webhook once thresholds clear ("safe to switch").

## What's in it

- **Models:** `EvalCampaign`, `EvalPair` (PII-masked + retention, same as `RequestRecord`).
- **`server/src/eval/`:** `logic.js` (pure, dep-free: single-shot guard, sampling, verdict parse, summary), `judge.js` (LLM-as-judge), `shadow.js` (mirror → record → judge → notify; fire-and-forget, self-guarded, never touches the served response).
- **Gateway hooks** in the existing post-response `setImmediate` blocks (`handler.js` + `openaiCompat` proxy + native non-streaming success).
- **API:** `/eval/campaigns` CRUD + `:id` summary + `:id/pairs`.
- **Web:** a **Model Evals** page — campaign setup, verdict summary (win/tie/loss, cost/latency delta), and a pair drilldown (prompt + prod vs candidate responses).
- **`smoke:eval`** covers the pure logic (18/18).

## Scope & guards (by design)

- **Single-shot only.** Agentic/multi-turn traffic is skipped — a mirrored candidate would want to execute side-effecting tools.
- **Bounded cost.** Mirroring + judging add spend; controlled by `sampleRate`; judge is optional (capture-only mode).
- **Human-gated.** The switch stays manual for now (one-click switch is the next increment). Streaming shadow-eval is a fast-follow.
- **Privacy.** Mirror + judge run through the existing PII masking + retention.

## Verify
- `node --check` on all backend files; `smoke:eval` 18/18; existing smokes green (maxtokens/classify/simulate/logging/cache); esbuild JSX on new/changed pages.
- Live: create a campaign on a single-shot app with a cheaper candidate → prod responses unchanged, `EvalPair`s accrue, summary shows cost delta + win/tie/loss, webhook fires when thresholds clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)