### PR TITLE
feat: connect any OpenAI-compatible provider + auto-import its models

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -37,6 +37,7 @@ export default defineConfig({
         items: [
           { text: 'Connect LibreChat', link: '/integrations/librechat' },
           { text: 'Connect OpenCode', link: '/integrations/opencode' },
+          { text: 'Connect NVIDIA', link: '/integrations/nvidia' },
         ]
       },
       {

--- a/docs/integrations/nvidia.md
+++ b/docs/integrations/nvidia.md
@@ -1,0 +1,57 @@
+# Connect NVIDIA (or any OpenAI-compatible provider)
+
+Arbr can route to any provider that exposes an OpenAI-compatible API, without a code change. NVIDIA's
+[build.nvidia.com](https://build.nvidia.com) is a good example: a single free `nvapi-` key unlocks 100+
+models (DeepSeek, Qwen, Kimi, GLM, MiniMax, …) at `https://integrate.api.nvidia.com/v1`.
+
+## 1. Connect the provider
+
+In the dashboard, go to **Models**. NVIDIA appears in the provider catalog (its models are already in the
+registry from the model sync). Open it and **Connect**: the base URL is prefilled
+(`https://integrate.api.nvidia.com/v1`); paste your `nvapi-` key and save. Use **Test connection** to
+verify.
+
+For a provider not in the catalog, use **Add custom provider** and supply:
+- **Provider ID** — a slug, e.g. `my-provider`
+- **Base URL** — the OpenAI-compatible root, ending in `/v1`
+- **API key**
+
+The key is stored encrypted; the provider goes live immediately.
+
+## 2. Import its models
+
+On the connected provider, click **Discover models**. Arbr calls the provider's `GET /v1/models` and lists
+what's available. Select the ones you want and **Import** — they're registered as routable models.
+
+- Models Arbr already knows (from the LiteLLM catalog sync) keep their pricing and capability metadata.
+- Unknown models are imported with `$0` pricing (cost logs as $0 until you set a price on the model). You
+  can edit pricing per model afterward.
+
+For NVIDIA specifically, its catalog models are already synced, so many will show as **registered** and
+route as soon as you connect the key.
+
+## 3. Route to it
+
+Reference an imported model by id from any client:
+
+```sh
+curl -X POST https://your-arbr-host/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer ab_…' \
+  -d '{ "model": "deepseek-ai/deepseek-v4-flash", "messages": [{ "role": "user", "content": "Hello" }] }'
+```
+
+Arbr proxies the request to the provider's endpoint with your stored key, preserving tools, streaming, and
+vision. It shows up in **Overview** / **Requests** like any other model, and can be used in rules and the
+AI policy.
+
+## Notes
+- **Rate limits** are the provider's, not Arbr's (NVIDIA's free tier is ~40 req/min).
+- **Pricing** for a newly-imported model defaults to $0 until you set it; spend reporting is only accurate
+  once pricing is entered (or inherited from the catalog).
+- Everything stays OpenAI-compatible, so there's no vendor lock-in — swap the model id and go.
+
+## Related
+- [Providers overview](/providers/overview)
+- [OpenAI-compatible endpoint](/gateway/openai-compat)
+- [Model registry](/models)

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "smoke:logging": "node server/scripts/logging-smoke.js",
     "smoke:maxtokens": "node server/scripts/maxtokens-smoke.js",
     "smoke:eval": "node server/scripts/eval-smoke.js",
+    "smoke:import": "node server/scripts/import-smoke.js",
     "lint": "eslint server/src",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",

--- a/server/scripts/import-smoke.js
+++ b/server/scripts/import-smoke.js
@@ -1,0 +1,30 @@
+// Pure-logic smoke for custom-provider model import decisions. Run: npm run smoke:import
+const { classifyModelImport } = require("../src/providers/importLogic");
+
+let pass = 0, fail = 0;
+const eq = (got, exp, msg) => {
+  if (got === exp) { pass++; } else { fail++; console.log(`FAIL: ${msg} — got ${got}, expected ${exp}`); }
+};
+
+const connectable = new Set(["openai", "anthropic", "gemini", "other-custom"]);
+
+// 1. No existing row → create fresh under the provider.
+eq(classifyModelImport(null, "nvidia-nim", connectable), "create", "no existing → create");
+
+// 2. Already registered under this provider → skip.
+eq(classifyModelImport({ provider: "nvidia-nim", builtIn: false }, "nvidia-nim", connectable), "skip-exists", "same provider → skip-exists");
+
+// 3. Orphaned synced row (not built-in, provider not connectable) → adopt (re-point).
+eq(classifyModelImport({ provider: "some-synced-prefix", builtIn: false }, "nvidia-nim", connectable), "adopt", "orphaned synced → adopt");
+
+// 4. Built-in model → never hijack.
+eq(classifyModelImport({ provider: "openai", builtIn: true }, "nvidia-nim", connectable), "conflict", "built-in → conflict");
+
+// 5. Owned by another connectable (known) provider → don't hijack.
+eq(classifyModelImport({ provider: "openai", builtIn: false }, "nvidia-nim", connectable), "conflict", "known provider owns id → conflict");
+
+// 6. Owned by another live custom provider → don't hijack.
+eq(classifyModelImport({ provider: "other-custom", builtIn: false }, "nvidia-nim", connectable), "conflict", "other custom owns id → conflict");
+
+console.log(`${pass}/${pass + fail} passed`);
+process.exit(fail ? 1 : 0);

--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -32,7 +32,8 @@ const EvalPair = require("../models/EvalPair");
 const { invalidateCampaignCache } = require("../eval/shadow");
 const { summarizeEvalPairs } = require("../eval/logic");
 const secrets = require("../security/secrets");
-const { config } = require("../config");
+const { config, KNOWN_PROVIDERS } = require("../config");
+const { classifyModelImport } = require("../providers/importLogic");
 
 const router = express.Router();
 
@@ -357,6 +358,67 @@ router.post("/custom-providers/:id/test", async (req, res) => {
   } catch (e) {
     res.json({ ok: false, message: String(e.message || e) });
   }
+});
+
+// Discover a custom provider's models via its OpenAI-compatible GET /v1/models endpoint.
+// Annotates each with whether it's already known in the registry (so the UI can enrich pricing).
+router.get("/custom-providers/:id/models", async (req, res) => {
+  try {
+    const doc = await CustomProvider.findOne({ id: req.params.id }).lean();
+    if (!doc) return res.status(404).json({ ok: false, message: "provider not found" });
+    const apiKey = secrets.decrypt(doc);
+    const upstream = await fetch(`${doc.baseURL}/models`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    const data = await upstream.json().catch(() => null);
+    if (!upstream.ok) return res.json({ ok: false, message: `upstream ${upstream.status}: ${data?.error?.message || ""}` });
+    const list = Array.isArray(data?.data) ? data.data : (Array.isArray(data) ? data : []);
+    const models = list.map((m) => (typeof m === "string" ? m : m?.id)).filter(Boolean).map((id) => {
+      const known = pricing.getModel(id);
+      return { id, known: !!known, registered: !!known && known.provider === doc.id };
+    });
+    res.json({ ok: true, models });
+  } catch (e) {
+    res.json({ ok: false, message: String(e.message || e) });
+  }
+});
+
+// Bulk-register selected discovered models under a custom provider. Adopts orphaned synced rows
+// (re-points their provider) and enriches from the existing catalog; unmatched → $0 pricing row.
+router.post("/custom-providers/:id/models", async (req, res, next) => {
+  try {
+    const doc = await CustomProvider.findOne({ id: req.params.id }).lean();
+    if (!doc) return res.status(404).json({ error: "not_found" });
+    const ids = Array.isArray(req.body?.models) ? req.body.models.filter((x) => typeof x === "string" && x.trim()) : [];
+    if (!ids.length) return res.status(400).json({ error: "models must be a non-empty array of ids" });
+
+    // Providers we must not hijack: built-in known providers + other live custom providers.
+    const otherCustom = await CustomProvider.find({ enabled: true }, { id: 1 }).lean();
+    const connectable = new Set([...KNOWN_PROVIDERS, ...otherCustom.map((c) => c.id).filter((cid) => cid !== doc.id)]);
+
+    const result = { created: 0, adopted: 0, skipped: 0, conflicts: [] };
+    for (const id of ids) {
+      const existing = await ModelEntry.findOne({ id }).lean();
+      const action = classifyModelImport(existing, doc.id, connectable);
+      if (action === "create") {
+        await ModelEntry.create({
+          id, provider: doc.id, label: id, tier: "mid",
+          inputPer1M: 0, outputPer1M: 0, builtIn: false, enabled: true,
+        });
+        result.created++;
+      } else if (action === "adopt") {
+        await ModelEntry.updateOne({ id }, { $set: { provider: doc.id, enabled: true } });
+        result.adopted++;
+      } else if (action === "conflict") {
+        result.conflicts.push(id);
+      } else {
+        result.skipped++;
+      }
+    }
+    await pricing.reload();
+    setImmediate(() => logAction("customProvider.importModels", "customProvider", doc.id, { count: ids.length, created: result.created, adopted: result.adopted }));
+    res.json(result);
+  } catch (e) { next(e); }
 });
 
 // ── model registry ──

--- a/server/src/providers/importLogic.js
+++ b/server/src/providers/importLogic.js
@@ -1,0 +1,22 @@
+// Pure decision for importing a discovered model id into the registry under a custom
+// provider. Dependency-free so it can be unit-tested without a DB.
+//
+//   existing      — the current ModelEntry row for this id ({ provider, builtIn }), or null
+//   providerId    — the custom provider we're importing into
+//   connectable   — Set of provider ids that are "owned" (built-in known providers + other live
+//                   custom providers) and must NOT be hijacked by a re-point
+//
+// Returns one of:
+//   "create"      — no such id yet → register a fresh row under providerId
+//   "skip-exists" — already registered under this provider → no-op
+//   "adopt"       — an ORPHANED synced row (e.g. LiteLLM-discovered `nvidia-nim`) → re-point its
+//                   provider to providerId so it becomes routable (keeps its pricing/capabilities)
+//   "conflict"    — id is owned by a built-in or another connectable provider → refuse (don't hijack)
+function classifyModelImport(existing, providerId, connectable) {
+  if (!existing) return "create";
+  if (existing.provider === providerId) return "skip-exists";
+  if (existing.builtIn || (connectable && connectable.has(existing.provider))) return "conflict";
+  return "adopt";
+}
+
+module.exports = { classifyModelImport };

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -125,6 +125,8 @@ export const api = {
   updateCustomProvider: (id, body) => req(`/custom-providers/${encodeURIComponent(id)}`, { method: "PATCH", body: JSON.stringify(body) }),
   removeCustomProvider: (id) => req(`/custom-providers/${encodeURIComponent(id)}`, { method: "DELETE" }),
   testCustomProvider: (id, model) => req(`/custom-providers/${encodeURIComponent(id)}/test`, { method: "POST", body: JSON.stringify({ model }) }),
+  discoverProviderModels: (id) => req(`/custom-providers/${encodeURIComponent(id)}/models`),
+  importProviderModels: (id, models) => req(`/custom-providers/${encodeURIComponent(id)}/models`, { method: "POST", body: JSON.stringify({ models }) }),
 
   governance: () => req("/governance"),
   updateGovernance: (body) => req("/governance", { method: "PATCH", body: JSON.stringify(body) }),

--- a/web/src/pages/Models.jsx
+++ b/web/src/pages/Models.jsx
@@ -487,8 +487,37 @@ function AddModelForm({ providerId, models, onSave, onClose }) {
 // ── ModelList ─────────────────────────────────────────────────────────────────
 
 function ModelList({ providerId, models, onRefresh }) {
-  const [adding, setAdding] = useState(false);
   const providerModels = models.filter((m) => m.provider === providerId);
+  const [disc, setDisc]       = useState(null);   // array of {id, known, registered} | { error } | null
+  const [sel, setSel]         = useState({});     // id -> selected
+  const [busy, setBusy]       = useState(false);
+  const [summary, setSummary] = useState(null);
+
+  async function discover() {
+    setBusy(true); setSummary(null); setDisc(null);
+    try {
+      const r = await api.discoverProviderModels(providerId);
+      if (!r.ok) { setDisc({ error: r.message }); return; }
+      setDisc(r.models);
+      const s = {};
+      r.models.forEach((m) => { if (!m.registered) s[m.id] = true; });  // default: import all not-yet-registered
+      setSel(s);
+    } catch (e) { setDisc({ error: e.message }); }
+    finally { setBusy(false); }
+  }
+
+  async function importSelected() {
+    const chosen = Object.keys(sel).filter((id) => sel[id]);
+    if (!chosen.length) return;
+    setBusy(true);
+    try {
+      const r = await api.importProviderModels(providerId, chosen);
+      setSummary(r); setDisc(null); onRefresh();
+    } catch (e) { setSummary({ error: e.message }); }
+    finally { setBusy(false); }
+  }
+
+  const selectedCount = Object.values(sel).filter(Boolean).length;
 
   return (
     <div className="space-y-3">
@@ -496,11 +525,41 @@ function ModelList({ providerId, models, onRefresh }) {
         <h3 className="text-sm font-semibold text-gray-700">
           Models <span className="font-normal text-gray-400">({providerModels.length})</span>
         </h3>
+        <button onClick={discover} disabled={busy} className={BTN_GHOST}>
+          {busy && !disc ? "Discovering…" : "Discover models"}
+        </button>
       </div>
-      {/* + Add model hidden for now */}
 
-      {providerModels.length === 0 && !adding && (
-        <p className="text-sm text-gray-400 py-4 text-center">No models registered for this provider.</p>
+      {summary && (
+        summary.error
+          ? <p className="text-sm text-red-600">{summary.error}</p>
+          : <p className="text-sm text-arbr-green-700">Imported: {summary.created} new, {summary.adopted} adopted, {summary.skipped} already present{summary.conflicts?.length ? `, ${summary.conflicts.length} skipped (owned by another provider)` : ""}.</p>
+      )}
+
+      {disc && disc.error && <p className="text-sm text-red-600">Discovery failed: {disc.error}</p>}
+      {Array.isArray(disc) && (
+        <div className="rounded-lg border border-gray-200 p-3">
+          <div className="mb-2 flex items-center justify-between">
+            <span className="text-sm text-gray-500">{disc.length} models from provider · {selectedCount} selected</span>
+            <button onClick={importSelected} disabled={busy || !selectedCount} className={BTN_PRIMARY}>
+              {busy ? "Importing…" : `Import selected (${selectedCount})`}
+            </button>
+          </div>
+          <div className="max-h-64 space-y-1 overflow-y-auto">
+            {disc.map((m) => (
+              <label key={m.id} className="flex items-center gap-2 rounded px-2 py-1 text-sm hover:bg-gray-50">
+                <input type="checkbox" checked={!!sel[m.id]} disabled={m.registered}
+                  onChange={(e) => setSel((s) => ({ ...s, [m.id]: e.target.checked }))} />
+                <span className="font-mono text-gray-700">{m.id}</span>
+                {m.registered ? <Badge tone="green">registered</Badge> : m.known && <Badge tone="gray">known pricing</Badge>}
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {providerModels.length === 0 && !disc && (
+        <p className="text-sm text-gray-400 py-4 text-center">No models registered. Use “Discover models” to import from the provider.</p>
       )}
 
       <div className="space-y-2">
@@ -751,6 +810,7 @@ function CustomProviderDetail({ provider, models, onRefresh, onDeleted }) {
 // url: pre-filled value (empty = account-specific, user must supply)
 // hint: shown below the Base URL field to guide the user
 const PROVIDER_ENDPOINT_INFO = {
+  "nvidia-nim":  { url: "https://integrate.api.nvidia.com/v1", hint: "Free nvapi- key from build.nvidia.com" },
   "mistral":     { url: "https://api.mistral.ai/v1" },
   "cohere":      { url: "https://api.cohere.ai/v1" },
   "together-ai": { url: "https://api.together.xyz/v1" },


### PR DESCRIPTION
## Why

An operator wanted NVIDIA's free OpenAI-compatible endpoint (`integrate.api.nvidia.com/v1`) and found no way to add it. Root cause: the LiteLLM sync imports NVIDIA models as **orphaned** `nvidia-nim` rows, but `nvidia-nim` isn't in `KNOWN_PROVIDERS`, so it's un-connectable, and the native router has no adapter for it. Arbr already supports **custom OpenAI-compatible providers** end-to-end (baseURL + key → proxied via `openaiCompat`), but it wasn't discoverable and each model had to be registered by hand — untenable for NVIDIA's 100+ models.

This closes both gaps **generically** (works for any OpenAI-compatible provider), with NVIDIA as the proof case.

## What's in it

- **Catalog connect (Phase 1):** add NVIDIA NIM to `PROVIDER_ENDPOINT_INFO` so it appears in the provider catalog with a prefilled base URL. Connecting it (custom-provider id `nvidia-nim`) makes its **already-synced** models instantly routable — their provider id now matches a live provider.
- **Model auto-discovery (Phase 2):**
  - `GET /custom-providers/:id/models` — calls the provider's OpenAI-compatible `GET /v1/models`, annotates each with `known` / `registered`.
  - `POST /custom-providers/:id/models` — bulk-registers selected ids. Uses a pure decision (`importLogic.js`): **adopt** an orphaned synced row (re-point its provider, keeping pricing/capabilities), **create** a fresh $0-priced row for unknown models, **skip** already-registered, and **refuse** to hijack built-in / other-provider ids.
  - UI: a **Discover models** button on a custom provider with registered/known badges and bulk import.
- **Docs:** "Connect NVIDIA (or any OpenAI-compatible provider)" integration guide + sidebar entry.

## Pricing note (by design)
Imported models that match the LiteLLM catalog inherit pricing/capabilities; unmatched ones register with `$0` pricing (`knownPricing:false` behavior — cost logs as $0) rather than blocking. Operators can set pricing per model afterward.

## Verify
- `node --check` all files; `smoke:import` 6/6; existing smokes green (maxtokens/classify/cache); esbuild JSX on `Models.jsx`.
- Live: Models → NVIDIA → Connect (prefilled URL) → paste `nvapi-` key → Test → Discover models → import → route `/v1/chat/completions` with an imported model → confirm it proxies to `integrate.api.nvidia.com` and logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)