### PR TITLE
fix: filter model discovery to chat-capable + clearer provider test

### DIFF
--- a/server/scripts/import-smoke.js
+++ b/server/scripts/import-smoke.js
@@ -1,5 +1,5 @@
 // Pure-logic smoke for custom-provider model import decisions. Run: npm run smoke:import
-const { classifyModelImport } = require("../src/providers/importLogic");
+const { classifyModelImport, isChatLikelyModelId } = require("../src/providers/importLogic");
 
 let pass = 0, fail = 0;
 const eq = (got, exp, msg) => {
@@ -25,6 +25,15 @@ eq(classifyModelImport({ provider: "openai", builtIn: false }, "nvidia-nim", con
 
 // 6. Owned by another live custom provider → don't hijack.
 eq(classifyModelImport({ provider: "other-custom", builtIn: false }, "nvidia-nim", connectable), "conflict", "other custom owns id → conflict");
+
+// 7. Chat-likely filter: real chat models pass; embeddings/rerankers/etc. are excluded.
+eq(isChatLikelyModelId("meta/llama-3.1-8b-instruct"), true, "llama chat → chat-likely");
+eq(isChatLikelyModelId("openai/gpt-oss-20b"), true, "gpt-oss → chat-likely");
+eq(isChatLikelyModelId("deepseek-ai/deepseek-r1"), true, "deepseek-r1 → chat-likely");
+eq(isChatLikelyModelId("nvidia/nv-embedqa-e5-v5"), false, "embedding → excluded");
+eq(isChatLikelyModelId("nvidia/rerank-qa-mistral-4b"), false, "reranker → excluded");
+eq(isChatLikelyModelId("nvidia/nemoretriever-parse"), false, "retriever → excluded");
+eq(isChatLikelyModelId("stabilityai/stable-diffusion-3"), false, "image-gen → excluded");
 
 console.log(`${pass}/${pass + fail} passed`);
 process.exit(fail ? 1 : 0);

--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -33,7 +33,7 @@ const { invalidateCampaignCache } = require("../eval/shadow");
 const { summarizeEvalPairs } = require("../eval/logic");
 const secrets = require("../security/secrets");
 const { config, KNOWN_PROVIDERS } = require("../config");
-const { classifyModelImport } = require("../providers/importLogic");
+const { classifyModelImport, isChatLikelyModelId } = require("../providers/importLogic");
 
 const router = express.Router();
 
@@ -351,7 +351,12 @@ router.post("/custom-providers/:id/test", async (req, res) => {
     });
     const data = await upstream.json().catch(() => null);
     if (!upstream.ok) {
-      return res.json({ ok: false, message: `upstream ${upstream.status}: ${data?.error?.message || ""}` });
+      // A 404 here almost always means the tested MODEL isn't served (auth/endpoint are fine),
+      // not that the connection is broken — say so, since the tested model may be arbitrary.
+      const hint = upstream.status === 404
+        ? ` — model "${model}" not found on this provider (connection/auth look OK; try a chat model this provider hosts)`
+        : `: ${data?.error?.message || ""}`;
+      return res.json({ ok: false, model, message: `upstream ${upstream.status}${hint}` });
     }
     const reply = data?.choices?.[0]?.message?.content || "";
     res.json({ ok: true, model, sample: reply.slice(0, 60) });
@@ -375,7 +380,7 @@ router.get("/custom-providers/:id/models", async (req, res) => {
     const list = Array.isArray(data?.data) ? data.data : (Array.isArray(data) ? data : []);
     const models = list.map((m) => (typeof m === "string" ? m : m?.id)).filter(Boolean).map((id) => {
       const known = pricing.getModel(id);
-      return { id, known: !!known, registered: !!known && known.provider === doc.id };
+      return { id, known: !!known, registered: !!known && known.provider === doc.id, chatLikely: isChatLikelyModelId(id) };
     });
     res.json({ ok: true, models });
   } catch (e) {

--- a/server/src/providers/importLogic.js
+++ b/server/src/providers/importLogic.js
@@ -19,4 +19,13 @@ function classifyModelImport(existing, providerId, connectable) {
   return "adopt";
 }
 
-module.exports = { classifyModelImport };
+// An OpenAI-compatible provider's GET /v1/models lists everything it hosts — including
+// non-chat models (embeddings, rerankers, retrievers, moderation, OCR, speech, image-gen)
+// that 404 on /chat/completions and must not be routed to. Heuristic id filter so discovery
+// can default-select only chat-capable models. Conservative: keeps vision/multimodal chat.
+const NON_CHAT_MODEL = /embed|rerank|retriev|guardrail|moderation|paddleocr|whisper|parakeet|\briva\b|diffusion|sdxl|\bflux\b|\bclip\b|\bocr\b|\btts\b|text-to-speech|speech-to-text/i;
+function isChatLikelyModelId(id) {
+  return !NON_CHAT_MODEL.test(String(id || ""));
+}
+
+module.exports = { classifyModelImport, isChatLikelyModelId };

--- a/web/src/pages/Models.jsx
+++ b/web/src/pages/Models.jsx
@@ -61,6 +61,11 @@ function tierTone(tier) {
   return tier === "premium" ? "violet" : tier === "mid" ? "indigo" : "teal";
 }
 
+// Mirror of server importLogic.isChatLikelyModelId — used to pick a sensible model for
+// the "Test connection" probe (non-chat models 404 on /chat/completions).
+const NON_CHAT_MODEL_RE = /embed|rerank|retriev|guardrail|moderation|paddleocr|whisper|parakeet|\briva\b|diffusion|sdxl|\bflux\b|\bclip\b|\bocr\b|\btts\b|text-to-speech|speech-to-text/i;
+const isChatLikely = (id) => !NON_CHAT_MODEL_RE.test(String(id || ""));
+
 function StatusDot({ live }) {
   return (
     <span className={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${live ? "bg-arbr-green-600" : "bg-gray-300"}`} />
@@ -501,7 +506,9 @@ function ModelList({ providerId, models, onRefresh }) {
       if (!r.ok) { setDisc({ error: r.message }); return; }
       setDisc(r.models);
       const s = {};
-      r.models.forEach((m) => { if (!m.registered) s[m.id] = true; });  // default: import all not-yet-registered
+      // Default-select only not-yet-registered, chat-capable models. Non-chat models
+      // (embeddings/rerankers/etc.) 404 on /chat/completions, so leave them unchecked.
+      r.models.forEach((m) => { if (!m.registered && m.chatLikely !== false) s[m.id] = true; });
       setSel(s);
     } catch (e) { setDisc({ error: e.message }); }
     finally { setBusy(false); }
@@ -546,6 +553,7 @@ function ModelList({ providerId, models, onRefresh }) {
               {busy ? "Importing…" : `Import selected (${selectedCount})`}
             </button>
           </div>
+          <p className="mb-2 text-[11px] text-gray-400">Non-chat models (embeddings, rerankers, etc.) are unchecked by default — they don't work on /chat/completions.</p>
           <div className="max-h-64 space-y-1 overflow-y-auto">
             {disc.map((m) => (
               <label key={m.id} className="flex items-center gap-2 rounded px-2 py-1 text-sm hover:bg-gray-50">
@@ -553,6 +561,7 @@ function ModelList({ providerId, models, onRefresh }) {
                   onChange={(e) => setSel((s) => ({ ...s, [m.id]: e.target.checked }))} />
                 <span className="font-mono text-gray-700">{m.id}</span>
                 {m.registered ? <Badge tone="green">registered</Badge> : m.known && <Badge tone="gray">known pricing</Badge>}
+                {m.chatLikely === false && <Badge tone="amber">non-chat</Badge>}
               </label>
             ))}
           </div>
@@ -739,10 +748,13 @@ function CustomProviderDetail({ provider, models, onRefresh, onDeleted }) {
   }
 
   async function testConn() {
-    const firstModel = models.find((m) => m.provider === provider.id);
+    // Prefer a chat-capable model so the test reflects the connection, not an arbitrary
+    // non-chat model that would 404 on /chat/completions.
+    const mine = models.filter((m) => m.provider === provider.id);
+    const testModel = mine.find((m) => isChatLikely(m.id)) || mine[0];
     setTesting(true); setTestResult(null);
     try {
-      const r = await api.testCustomProvider(provider.id, firstModel?.id || null);
+      const r = await api.testCustomProvider(provider.id, testModel?.id || null);
       setTestResult(r);
     } catch { setTestResult({ ok: false, message: "Request failed" }); }
     finally { setTesting(false); }
@@ -777,7 +789,9 @@ function CustomProviderDetail({ provider, models, onRefresh, onDeleted }) {
 
       {testResult && (
         <div className={`text-sm rounded-lg px-4 py-3 ${testResult.ok ? "bg-arbr-green-50 text-arbr-green-800 border border-arbr-green-200" : "bg-red-50 text-red-700 border border-red-200"}`}>
-          {testResult.ok ? `✓ Connected · "${testResult.sample}"` : `✗ ${testResult.message}`}
+          {testResult.ok
+            ? `✓ Connected · model: ${testResult.model}${testResult.sample ? ` · "${testResult.sample}"` : ""}`
+            : `✗ ${testResult.message}`}
         </div>
       )}
 


### PR DESCRIPTION
## Context
Follow-up to #55/#56. Connecting NVIDIA worked, but its `/v1/models` returns everything it hosts (chat + embeddings, rerankers, retrievers, moderation, OCR, speech, image-gen), and "Test connection" 404'd on an arbitrary model, looking like a broken connection.

## Fixes
1. **Filter discovery to chat-capable models (the important one).** New pure `isChatLikelyModelId` (heuristic id filter, unit-tested). Discovery annotates each model with `chatLikely`; the import UI **default-selects only chat-capable, not-yet-registered** models and marks the rest **non-chat** (still selectable if intended). Keeps routing from ever defaulting to a non-chat model.
2. **Clearer "Test connection".** Prefers a chat-capable model, shows *which* model it tested, and a 404 now reads "model X not found on this provider (connection/auth look OK)" instead of a bare `upstream 404`.

Verified live earlier: `meta/llama-3.1-8b-instruct` and `openai/gpt-oss-20b` return OK through the NVIDIA connection; the earlier 404 was just an arbitrary/non-chat test model.

## Verify
- `smoke:import` 13/13 (adds chat-likely cases); esbuild JSX on Models.jsx.
- Live: Discover on NVIDIA → non-chat models show unchecked + "non-chat" badge; Test connection reports the tested model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)