### PR TITLE
test: server unit + integration suite + test strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Lint server
         run: npm run lint
 
+      - name: Test server (unit + integration)
+        run: npm run test:server
+
       - name: Install web dependencies
         run: npm --prefix web ci
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,58 @@
+# Test Strategy
+
+## Four Layers
+
+| Layer | What goes here | Runner | CI? |
+|---|---|---|---|
+| **Unit** | Pure functions, no I/O | `node:test` / `pytest` | ✅ Yes |
+| **Integration** | Express routes + in-memory MongoDB | `node:test` + `supertest` + `mongodb-memory-server` | ✅ Yes |
+| **Client** | SDK methods against a mock HTTP server | `node:test` / `pytest` | ✅ Yes |
+| **Smoke** | End-to-end against a live gateway | Manual `node server/scripts/smoke-*.js` | ❌ Manual only |
+
+## Running Tests
+
+```bash
+# Server unit tests (fast, no I/O)
+npm run test:server:unit
+
+# Server integration tests (in-memory MongoDB, ~4s)
+npm run test:server:integration
+
+# Full server suite
+npm run test:server
+
+# JS client tests
+npm --prefix clients/js test
+
+# Python client tests
+cd clients/python && python -m pytest -q
+```
+
+## Test Locations
+
+| File | What it tests |
+|---|---|
+| `server/test/unit/csv.test.js` | `csvCell()` — all quoting/escaping branches |
+| `server/test/unit/aiPolicy.test.js` | `goalWeight()` — cost/quality/balanced modes |
+| `server/test/unit/capEngine.test.js` | `shouldWarn()` — threshold boundaries |
+| `server/test/unit/buildMatch.test.js` | `buildMatch()` — filter-to-MongoDB-match mapping |
+| `server/test/integration/requestsExport.test.js` | `GET /api/requests/export` — CSV streaming, filters, headers |
+| `server/test/integration/timeseries.test.js` | `GET /api/analytics/timeseries` — bucketing, sorting, filters |
+| `clients/js/test/client.test.js` | JS SDK — all client methods including cache token passthrough |
+| `clients/python/tests/test_client.py` | Python SDK — all client methods including cache token mapping |
+
+## Rules for Every PR
+
+1. **New API route** → integration test covering: happy path, empty state, at least one filter param.
+2. **New pure utility function** → unit tests covering all branches.
+3. **New SDK response field** → passthrough test in both JS and Python client suites.
+4. **No live provider keys** in any automated test. Tests requiring real providers → smoke scripts only.
+5. **Server tests run in CI before Docker build.** A failing test blocks merge.
+6. **No new test frameworks.** Server and JS client use `node:test`; Python client uses `pytest`.
+
+## What is NOT Tested Here (Yet)
+
+- **React UI components** — no Vitest setup; validated manually via the dev server.
+- **MongoDB aggregation math** — integration tests verify shape and row count; exact numeric precision is out of scope.
+- **Auth middleware** — covered indirectly by client tests that send `Authorization` headers.
+- **Smoke scripts** — manual pre-release validation only; never run in CI.

--- a/clients/js/test/client.test.js
+++ b/clients/js/test/client.test.js
@@ -261,3 +261,22 @@ test("asLangChainModel: invoke returns an AIMessage-shaped result; stream yields
   for await (const chunk of model.stream("again")) streamed += chunk.content;
   assert.equal(streamed, OK_RESPONSE.text);
 });
+
+test("chat: passes through cachedReadTokens and cacheWriteTokens in usage", async (t) => {
+  const { baseUrl } = await mockGateway(t, () => ({
+    ...OK_RESPONSE,
+    usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15, cachedReadTokens: 3, cacheWriteTokens: 1 },
+  }));
+  const client = createClient({ baseUrl });
+  const res = await client.chat({ messages: [{ role: "user", content: "hi" }] });
+  assert.equal(res.usage.cachedReadTokens, 3);
+  assert.equal(res.usage.cacheWriteTokens, 1);
+});
+
+test("chat: usage without cache fields → cachedReadTokens and cacheWriteTokens are undefined", async (t) => {
+  const { baseUrl } = await mockGateway(t);
+  const client = createClient({ baseUrl });
+  const res = await client.chat({ messages: [{ role: "user", content: "hi" }] });
+  assert.equal(res.usage.cachedReadTokens, undefined);
+  assert.equal(res.usage.cacheWriteTokens, undefined);
+});

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -304,3 +304,25 @@ def test_as_langchain_model_shapes(gateway):
         assert msg3.content == OK_RESPONSE["text"]
 
     asyncio.run(amain())
+
+
+def test_chat_usage_cache_fields(gateway):
+    gw = gateway(
+        lambda m, p, b, n: (200, {
+            **OK_RESPONSE,
+            "usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15,
+                      "cachedReadTokens": 3, "cacheWriteTokens": 1},
+        }, 0)
+    )
+    karya = create_client(gw.base_url)
+    res = karya.chat(messages=[{"role": "user", "content": "hi"}])
+    assert res.usage.cached_read_tokens == 3
+    assert res.usage.cache_write_tokens == 1
+
+
+def test_chat_usage_cache_fields_absent(gateway):
+    gw = gateway()
+    karya = create_client(gw.base_url)
+    res = karya.chat(messages=[{"role": "user", "content": "hi"}])
+    assert res.usage.cached_read_tokens == 0
+    assert res.usage.cache_write_tokens == 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,8 @@
         "concurrently": "^10.0.3",
         "eslint": "^10.5.0",
         "globals": "^17.7.0",
+        "mongodb-memory-server": "^11.2.0",
+        "supertest": "^7.2.2",
         "vitepress": "^1.6.4"
       },
       "engines": {
@@ -1616,6 +1618,19 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodable/entities": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
@@ -1627,6 +1642,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.0",
@@ -2600,6 +2625,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -2669,6 +2704,45 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -2677,6 +2751,104 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.3.tgz",
+      "integrity": "sha512-fF4Q7QsyKVF5Rj0qvI8BgUNjqzC2JvQlpTaPLjVJVxYVUX5Zr9un+y3w1HmA4nNKdFmRBT8z/WmrjvXzXVerKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
       }
     },
     "node_modules/base64-js": {
@@ -2812,6 +2984,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ccount": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
@@ -2873,6 +3058,19 @@
         "node": ">=20"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -2882,6 +3080,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/concurrently": {
@@ -2948,6 +3163,13 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/copy-anything": {
       "version": "4.0.5",
@@ -3028,6 +3250,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3059,6 +3291,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dotenv": {
@@ -3154,6 +3397,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3404,6 +3663,16 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/express": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
@@ -3454,6 +3723,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3465,6 +3741,13 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3524,6 +3807,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3570,6 +3871,85 @@
       "license": "MIT",
       "dependencies": {
         "tabbable": "^6.4.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -3724,6 +4104,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
@@ -3810,6 +4206,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -4047,6 +4457,32 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/mark.js": {
       "version": "8.11.1",
       "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
@@ -4110,6 +4546,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/micromark-util-character": {
@@ -4205,6 +4651,19 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
@@ -4320,6 +4779,45 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/mongodb-memory-server": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-11.2.0.tgz",
+      "integrity": "sha512-506AD8qvClVx8Raw/WhAUUWBgIXPyi856iC01aa5vAzHmn6WOXC6ulvudkTF7oTMzJxkyA0A84VpD4BpyfqJ9w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "mongodb-memory-server-core": "11.2.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-11.2.0.tgz",
+      "integrity": "sha512-vOoDtn0JiLrHvZY81Rp/UtKXXK0rtJHZGZFVnccvJwYitPLNspO0Ty0grqFQOe7iAET8+GI4zAQcphg+R3vxQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-mutex": "^0.5.0",
+        "camelcase": "^6.3.0",
+        "debug": "^4.4.3",
+        "find-cache-dir": "^3.3.2",
+        "follow-redirects": "^1.16.0",
+        "https-proxy-agent": "^7.0.6",
+        "mongodb": "^7.2.0",
+        "new-find-package-json": "^2.0.0",
+        "semver": "^7.7.3",
+        "tar-stream": "^3.1.8",
+        "tslib": "^2.8.1",
+        "yauzl": "^3.3.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/mongoose": {
       "version": "9.7.2",
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.7.2.tgz",
@@ -4407,6 +4905,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/new-find-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
+      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=12.22.0"
       }
     },
     "node_modules/object-assign": {
@@ -4580,6 +5091,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -4634,6 +5155,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
@@ -4647,6 +5175,75 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.15",
@@ -4894,6 +5491,19 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
@@ -5135,6 +5745,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
@@ -5184,6 +5806,27 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/superjson": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
@@ -5195,6 +5838,21 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {
@@ -5216,6 +5874,39 @@
       "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -5706,6 +6397,19 @@
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,10 @@
     "lint": "eslint server/src",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
-    "docs:preview": "vitepress preview docs"
+    "docs:preview": "vitepress preview docs",
+    "test:server:unit": "node --test server/test/unit/*.test.js",
+    "test:server:integration": "node --test server/test/integration/*.test.js",
+    "test:server": "node --test 'server/test/**/*.test.js'"
   },
   "dependencies": {
     "@langchain/anthropic": "^1.5.1",
@@ -56,6 +59,8 @@
     "concurrently": "^10.0.3",
     "eslint": "^10.5.0",
     "globals": "^17.7.0",
+    "mongodb-memory-server": "^11.2.0",
+    "supertest": "^7.2.2",
     "vitepress": "^1.6.4"
   }
 }

--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -34,6 +34,7 @@ const { summarizeEvalPairs } = require("../eval/logic");
 const secrets = require("../security/secrets");
 const { config, KNOWN_PROVIDERS } = require("../config");
 const { classifyModelImport, isChatLikelyModelId } = require("../providers/importLogic");
+const { csvCell } = require("../utils/csv");
 
 const router = express.Router();
 
@@ -588,12 +589,6 @@ router.get("/requests/export", async (req, res, next) => {
       "promptTokens", "completionTokens", "totalTokens", "totalCost",
       "latencyMs", "status", "cacheHit", "difficulty", "difficultyScore",
     ];
-    function csvCell(v) {
-      if (v == null) return "";
-      if (v instanceof Date) return v.toISOString();
-      const s = String(v);
-      return (s.includes(",") || s.includes('"') || s.includes("\n")) ? `"${s.replace(/"/g, '""')}"` : s;
-    }
     res.setHeader("Content-Type", "text/csv; charset=utf-8");
     res.setHeader("Content-Disposition", 'attachment; filename="requests.csv"');
     res.write(COLS.join(",") + "\n");

--- a/server/src/routing/aiPolicy.js
+++ b/server/src/routing/aiPolicy.js
@@ -431,4 +431,4 @@ async function describe() {
   };
 }
 
-module.exports = { getEffective, lookup, resolveModel, setAssignments, regenerate, computeAssignments: _computeAssignments, simulate, describe, invalidate, CAPABILITY_VERSION };
+module.exports = { getEffective, lookup, resolveModel, setAssignments, regenerate, computeAssignments: _computeAssignments, simulate, describe, invalidate, CAPABILITY_VERSION, _goalWeight: goalWeight };

--- a/server/src/routing/capEngine.js
+++ b/server/src/routing/capEngine.js
@@ -43,7 +43,7 @@ async function _breachedEnforcing() {
     } else {
       // Near-threshold warning: fire before the cap is actually breached so users can act.
       const warnAt = cap.warningThreshold ?? 0.8;
-      if (warnAt > 0 && spent / cap.limit >= warnAt) {
+      if (shouldWarn(spent, cap.limit, warnAt)) {
         setImmediate(() => notifier.notify("cap_warning", {
           key: `warn:${cap._id}`,
           dimension: cap.dimension || "global",
@@ -85,4 +85,9 @@ function describeScope(cap) {
   return cap.dimension ? `${cap.dimension} "${cap.value}"` : "global spend";
 }
 
-module.exports = { enforcement, invalidate, describeScope, windowStart };
+// Pure predicate — exported for unit testing.
+function shouldWarn(spent, limit, warnAt) {
+  return warnAt > 0 && spent < limit && spent / limit >= warnAt;
+}
+
+module.exports = { enforcement, invalidate, describeScope, windowStart, _shouldWarn: shouldWarn };

--- a/server/src/utils/csv.js
+++ b/server/src/utils/csv.js
@@ -1,0 +1,11 @@
+// Minimal CSV cell serialiser — handles quoting, escaping, null/Date coercion.
+function csvCell(v) {
+  if (v == null) return "";
+  if (v instanceof Date) return v.toISOString();
+  const s = String(v);
+  return (s.includes(",") || s.includes('"') || s.includes("\n"))
+    ? `"${s.replace(/"/g, '""')}"`
+    : s;
+}
+
+module.exports = { csvCell };

--- a/server/test/integration/requestsExport.test.js
+++ b/server/test/integration/requestsExport.test.js
@@ -1,0 +1,101 @@
+"use strict";
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+const mongoose = require("mongoose");
+const express = require("express");
+const supertest = require("supertest");
+
+// Suppress dotenv warnings — no .env needed for tests.
+process.env.ARBR_ADMIN_KEY = "";
+
+const RequestRecord = require("../../src/models/RequestRecord");
+const apiRoutes = require("../../src/api/routes");
+
+let mongod;
+let agent;
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api", apiRoutes);
+  return app;
+}
+
+before(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  agent = supertest(buildApp());
+});
+
+after(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+beforeEach(async () => {
+  await RequestRecord.deleteMany({});
+});
+
+function seedRecord(overrides = {}) {
+  return RequestRecord.create({
+    requestId: `req-${Math.random().toString(36).slice(2)}`,
+    timestamp: new Date("2024-03-15T10:00:00.000Z"),
+    application: "test-app",
+    provider: "openai",
+    model: "gpt-4o-mini",
+    status: "success",
+    totalCost: 0.001,
+    ...overrides,
+  });
+}
+
+test("no records → 200 with header row only", async () => {
+  const res = await agent.get("/api/requests/export");
+  assert.equal(res.status, 200);
+  assert.match(res.headers["content-type"], /text\/csv/);
+  const lines = res.text.trim().split("\n");
+  assert.equal(lines.length, 1, "only header row");
+});
+
+test("3 seed records → header + 3 data rows", async () => {
+  await seedRecord();
+  await seedRecord();
+  await seedRecord();
+  const res = await agent.get("/api/requests/export");
+  assert.equal(res.status, 200);
+  const lines = res.text.trim().split("\n");
+  assert.equal(lines.length, 4, "header + 3 rows");
+});
+
+test("application field with comma is quoted in CSV", async () => {
+  await seedRecord({ application: "acme, inc" });
+  const res = await agent.get("/api/requests/export");
+  assert.ok(res.text.includes('"acme, inc"'), "comma-containing value is quoted");
+});
+
+test("?application= filter returns only matching rows", async () => {
+  await seedRecord({ application: "app-a" });
+  await seedRecord({ application: "app-b" });
+  await seedRecord({ application: "app-a" });
+  const res = await agent.get("/api/requests/export?application=app-a");
+  assert.equal(res.status, 200);
+  const lines = res.text.trim().split("\n");
+  assert.equal(lines.length, 3, "header + 2 matching rows");
+});
+
+test("Content-Disposition header is set for attachment download", async () => {
+  const res = await agent.get("/api/requests/export");
+  assert.match(res.headers["content-disposition"], /attachment/);
+  assert.match(res.headers["content-disposition"], /requests\.csv/);
+});
+
+test("header row contains the expected 21 columns", async () => {
+  const res = await agent.get("/api/requests/export");
+  const header = res.text.split("\n")[0];
+  const cols = header.split(",");
+  assert.equal(cols.length, 21, "21 columns in header");
+  assert.ok(cols.includes("timestamp"), "timestamp column present");
+  assert.ok(cols.includes("requestId"), "requestId column present");
+  assert.ok(cols.includes("totalCost"), "totalCost column present");
+});

--- a/server/test/integration/timeseries.test.js
+++ b/server/test/integration/timeseries.test.js
@@ -1,0 +1,108 @@
+"use strict";
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+const mongoose = require("mongoose");
+const express = require("express");
+const supertest = require("supertest");
+
+process.env.ARBR_ADMIN_KEY = "";
+
+const RequestRecord = require("../../src/models/RequestRecord");
+const apiRoutes = require("../../src/api/routes");
+
+let mongod;
+let agent;
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api", apiRoutes);
+  return app;
+}
+
+before(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  agent = supertest(buildApp());
+});
+
+after(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+beforeEach(async () => {
+  await RequestRecord.deleteMany({});
+});
+
+function seedRecord(overrides = {}) {
+  return RequestRecord.create({
+    requestId: `req-${Math.random().toString(36).slice(2)}`,
+    timestamp: new Date("2024-03-15T10:00:00.000Z"),
+    application: "test-app",
+    provider: "openai",
+    model: "gpt-4o-mini",
+    status: "success",
+    totalCost: 0.001,
+    ...overrides,
+  });
+}
+
+test("no records → 200 with empty array", async () => {
+  const res = await agent.get("/api/analytics/timeseries");
+  assert.equal(res.status, 200);
+  assert.deepEqual(res.body, []);
+});
+
+test("records on 3 different days → 3 rows sorted ascending", async () => {
+  await seedRecord({ timestamp: new Date("2024-03-01T12:00:00Z") });
+  await seedRecord({ timestamp: new Date("2024-03-03T12:00:00Z") });
+  await seedRecord({ timestamp: new Date("2024-03-02T12:00:00Z") });
+  const res = await agent.get("/api/analytics/timeseries");
+  assert.equal(res.status, 200);
+  assert.equal(res.body.length, 3);
+  assert.equal(res.body[0].date, "2024-03-01");
+  assert.equal(res.body[1].date, "2024-03-02");
+  assert.equal(res.body[2].date, "2024-03-03");
+});
+
+test("each row has expected shape: date, requests, cost, failures", async () => {
+  await seedRecord({ timestamp: new Date("2024-03-15T10:00:00Z"), totalCost: 0.005 });
+  const res = await agent.get("/api/analytics/timeseries");
+  const row = res.body[0];
+  assert.ok("date" in row, "date key present");
+  assert.ok("requests" in row, "requests key present");
+  assert.ok("cost" in row, "cost key present");
+  assert.ok("failures" in row, "failures key present");
+});
+
+test("?bucket=day produces YYYY-MM-DD date format", async () => {
+  await seedRecord({ timestamp: new Date("2024-03-15T10:00:00Z") });
+  const res = await agent.get("/api/analytics/timeseries?bucket=day");
+  assert.match(res.body[0].date, /^\d{4}-\d{2}-\d{2}$/);
+});
+
+test("?bucket=hour produces YYYY-MM-DDTHH date format", async () => {
+  await seedRecord({ timestamp: new Date("2024-03-15T10:00:00Z") });
+  const res = await agent.get("/api/analytics/timeseries?bucket=hour");
+  assert.match(res.body[0].date, /^\d{4}-\d{2}-\d{2}T\d{2}$/);
+});
+
+test("?from= filter limits returned range", async () => {
+  await seedRecord({ timestamp: new Date("2024-03-01T12:00:00Z") });
+  await seedRecord({ timestamp: new Date("2024-03-15T12:00:00Z") });
+  const res = await agent.get("/api/analytics/timeseries?from=2024-03-10T00:00:00Z");
+  assert.equal(res.body.length, 1);
+  assert.equal(res.body[0].date, "2024-03-15");
+});
+
+test("failure status records are counted in failures field", async () => {
+  await seedRecord({ timestamp: new Date("2024-03-15T10:00:00Z"), status: "success" });
+  await seedRecord({ timestamp: new Date("2024-03-15T11:00:00Z"), status: "failure" });
+  await seedRecord({ timestamp: new Date("2024-03-15T12:00:00Z"), status: "failure" });
+  const res = await agent.get("/api/analytics/timeseries");
+  assert.equal(res.body.length, 1);
+  assert.equal(res.body[0].requests, 3);
+  assert.equal(res.body[0].failures, 2);
+});

--- a/server/test/unit/aiPolicy.test.js
+++ b/server/test/unit/aiPolicy.test.js
@@ -1,0 +1,31 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { _goalWeight } = require("../../src/routing/aiPolicy");
+
+test('goal="cost" always returns 0.30', () => {
+  assert.equal(_goalWeight("cost"), 0.30);
+  assert.equal(_goalWeight("cost", "premium"), 0.30);
+});
+
+test('goal="quality" always returns 0.05', () => {
+  assert.equal(_goalWeight("quality"), 0.05);
+  assert.equal(_goalWeight("quality", "light"), 0.05);
+});
+
+test('goal="balanced" + tier "light" returns 0.20', () => {
+  assert.equal(_goalWeight("balanced", "light"), 0.20);
+});
+
+test('goal="balanced" + tier "premium" returns 0.10', () => {
+  assert.equal(_goalWeight("balanced", "premium"), 0.10);
+});
+
+test('goal="balanced" + unknown tier returns 0.25 fallback', () => {
+  assert.equal(_goalWeight("balanced", "unknown"), 0.25);
+});
+
+test("goal unset (undefined) behaves like balanced", () => {
+  assert.equal(_goalWeight(undefined, "light"), 0.20);
+  assert.equal(_goalWeight(undefined, "unknown"), 0.25);
+});

--- a/server/test/unit/buildMatch.test.js
+++ b/server/test/unit/buildMatch.test.js
@@ -1,0 +1,37 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { buildMatch } = require("../../src/analytics/aggregate");
+
+test("empty filter returns empty match object", () => {
+  assert.deepEqual(buildMatch({}), {});
+  assert.deepEqual(buildMatch(), {});
+});
+
+test("from/to builds timestamp range", () => {
+  const from = "2024-01-01T00:00:00.000Z";
+  const to = "2024-01-31T23:59:59.000Z";
+  const m = buildMatch({ from, to });
+  assert.ok(m.timestamp, "timestamp key present");
+  assert.equal(m.timestamp.$gte.toISOString(), from);
+  assert.equal(m.timestamp.$lte.toISOString(), to);
+});
+
+test("application filter is included in match", () => {
+  const m = buildMatch({ application: "my-app" });
+  assert.equal(m.application, "my-app");
+  assert.equal(m.timestamp, undefined);
+});
+
+test("unknown filter keys are ignored", () => {
+  const m = buildMatch({ foo: "bar", baz: 123 });
+  assert.equal(m.foo, undefined);
+  assert.equal(m.baz, undefined);
+});
+
+test("multiple known filters are all merged", () => {
+  const m = buildMatch({ application: "app1", provider: "openai", model: "gpt-4o" });
+  assert.equal(m.application, "app1");
+  assert.equal(m.provider, "openai");
+  assert.equal(m.model, "gpt-4o");
+});

--- a/server/test/unit/capEngine.test.js
+++ b/server/test/unit/capEngine.test.js
@@ -1,0 +1,29 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { _shouldWarn } = require("../../src/routing/capEngine");
+
+test("below threshold returns false", () => {
+  assert.equal(_shouldWarn(70, 100, 0.8), false);
+});
+
+test("at threshold exactly returns true", () => {
+  assert.equal(_shouldWarn(80, 100, 0.8), true);
+});
+
+test("above threshold but below limit returns true", () => {
+  assert.equal(_shouldWarn(90, 100, 0.8), true);
+});
+
+test("at limit (breached) returns false", () => {
+  assert.equal(_shouldWarn(100, 100, 0.8), false);
+});
+
+test("warnAt=0 disables warning", () => {
+  assert.equal(_shouldWarn(99, 100, 0), false);
+});
+
+test("default 80% threshold boundary", () => {
+  assert.equal(_shouldWarn(79, 100, 0.8), false);
+  assert.equal(_shouldWarn(80, 100, 0.8), true);
+});

--- a/server/test/unit/csv.test.js
+++ b/server/test/unit/csv.test.js
@@ -1,0 +1,38 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { csvCell } = require("../../src/utils/csv");
+
+test("plain string returned as-is", () => {
+  assert.equal(csvCell("hello"), "hello");
+});
+
+test("string with comma is quoted", () => {
+  assert.equal(csvCell("a,b"), '"a,b"');
+});
+
+test("string with double-quote is escaped", () => {
+  assert.equal(csvCell('say "hi"'), '"say ""hi"""');
+});
+
+test("string with newline is quoted", () => {
+  assert.equal(csvCell("line1\nline2"), '"line1\nline2"');
+});
+
+test("null returns empty string", () => {
+  assert.equal(csvCell(null), "");
+});
+
+test("undefined returns empty string", () => {
+  assert.equal(csvCell(undefined), "");
+});
+
+test("Date returns ISO string", () => {
+  const d = new Date("2024-01-15T10:00:00.000Z");
+  assert.equal(csvCell(d), "2024-01-15T10:00:00.000Z");
+});
+
+test("number returns string representation", () => {
+  assert.equal(csvCell(42), "42");
+  assert.equal(csvCell(3.14), "3.14");
+});


### PR DESCRIPTION
## Summary

- **25 server unit tests** for the four newly-extracted pure functions: `csvCell`, `goalWeight`, `shouldWarn`, `buildMatch`
- **13 integration tests** using real Express + in-memory MongoDB (`mongodb-memory-server` + `supertest`) for `GET /requests/export` and `GET /analytics/timeseries`
- **+2 client tests each** in JS and Python SDKs for `cachedReadTokens`/`cacheWriteTokens` passthrough
- `test:server:unit` / `test:server:integration` / `test:server` scripts added to root `package.json`
- CI runs `npm run test:server` before the Docker build step — failing tests now block merge
- `TESTING.md` at repo root documents the four-layer strategy and the per-PR rules

## Test results (all green locally)

```
Server unit:        25/25 pass
Server integration: 13/13 pass
JS client:          20/20 pass (was 18, +2)
Python client:      20/20 pass (was 18, +2)
```

## Test plan

- [ ] CI passes on this PR
- [ ] Review `TESTING.md` — does the strategy match how the team wants to work?
- [ ] Confirm `mongodb-memory-server` binary download completes in CI (first run downloads ~40 MB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)