### PR TITLE
feat(ops): gated, image-based, rollback-safe manual deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,41 @@ jobs:
       - name: Run tests
         run: python -m pytest -q
         working-directory: clients/python
+
+  # Publish a SHA-pinned image ONLY after the full test/lint/build gate passes on main.
+  # An image existing for a commit therefore means "CI green" — that is the deploy gate
+  # consumed by ops/deploy.sh. Nothing is deployed here; deploys stay manually triggered.
+  publish-image:
+    name: Publish image (green main)
+    runs-on: ubuntu-latest
+    needs: [build, python-sdk]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/project-arbr/arbr-control-plane
+          tags: |
+            type=sha,prefix=sha-,format=short
+            type=raw,value=main
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -1,0 +1,13 @@
+# Image-based deploy overlay — run the prebuilt, CI-published GHCR image instead of
+# building on the prod host. Used by ops/deploy.sh, composed after the base + gcp overlay:
+#
+#   ARBR_IMAGE_TAG=sha-abc123 docker compose \
+#     -f docker-compose.yml -f docker-compose.gcp.yml -f docker-compose.deploy.yml \
+#     pull app && ... up -d --no-build app
+#
+# The image only exists for a commit if CI (test+lint+build) passed for it, so pulling a
+# tag is inherently gated. ARBR_IMAGE_TAG defaults to the latest green main.
+services:
+  app:
+    image: ghcr.io/project-arbr/arbr-control-plane:${ARBR_IMAGE_TAG:-main}
+    pull_policy: always

--- a/docs/deployment-gcp.md
+++ b/docs/deployment-gcp.md
@@ -143,15 +143,35 @@ docker compose logs -f app
 # Restart the app container
 docker compose restart app
 
-# Update to a new version
-git pull
-docker compose -f docker-compose.yml -f docker-compose.prod.yml build app
-docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d app
-
 # Backup MongoDB
 docker compose exec mongo mongodump --out /tmp/backup
 docker cp $(docker compose ps -q mongo):/tmp/backup ./backup-$(date +%F)
 ```
+
+## Deploying a new version (gated, image-based)
+
+Deploys are **manually triggered** but gated and rollback-safe. CI builds and pushes a
+`ghcr.io/project-arbr/arbr-control-plane:sha-<short>` (and `:main`) image **only after** the
+full test/lint/build suite passes on `main` — so an image existing for a commit means it's
+green. `ops/deploy.sh` pulls that prebuilt image (no build on the prod host), health-checks,
+and auto-rolls-back on failure.
+
+```sh
+cd ~/arbr-ai-control-plane
+bash ops/deploy.sh            # deploy the latest green main
+bash ops/deploy.sh sha-1a2b3c4   # or pin to a specific commit / a vX.Y.Z tag
+```
+
+What it does: verifies the image exists (the green gate) → records the current tag →
+pulls + `up -d` the new image → polls `/health` for ~60s → **rolls back to the previous tag
+if unhealthy** → re-runs the LiteLLM model sync if the seed version changed (keeps pricing
+intact) → posts a success/rollback note to the governance webhook.
+
+> The old build-on-VM path (`git pull && docker compose build app && up -d app`) is
+> deprecated — it built on the prod host and had no rollback. Use `ops/deploy.sh`.
+>
+> Note: this still causes a brief container-recreate blip (no blue-green yet), and it is not
+> auto-triggered on merge — a human runs the command.
 
 ## Production checklist
 

--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Gated, image-based, rollback-safe manual deploy for arbr.gyde.ai.
+#
+# Pulls a CI-published GHCR image (image-exists ⇒ CI green = the gate), swaps the app
+# container to it, health-checks, and AUTO-ROLLS-BACK to the previous tag on failure.
+# Re-runs the LiteLLM sync if the model seed version changed (so pricing doesn't silently
+# regress), then notifies the governance webhook. No build happens on the prod host.
+#
+# Usage (on the VM):  bash ops/deploy.sh [TAG]     TAG defaults to "main" (latest green).
+#   e.g.  bash ops/deploy.sh sha-1a2b3c4     (pin to a specific commit)
+set -euo pipefail
+
+REPO="$HOME/arbr-ai-control-plane"
+IMAGE="ghcr.io/project-arbr/arbr-control-plane"
+COMPOSE="sudo docker compose -f docker-compose.yml -f docker-compose.gcp.yml -f docker-compose.deploy.yml"
+PREV_FILE="$HOME/.arbr-deploy-prev"
+HEALTH="http://localhost:4100/health"
+API="http://localhost:4100/api"
+TAG="${1:-main}"
+
+cd "$REPO"
+
+# Keep compose files + this script current (no build; pulls yaml/script only).
+git pull --ff-only || echo "!! git pull skipped (non-ff); continuing with local compose files"
+
+# 1. GATE: the image must exist. CI publishes it only after test+lint+build pass.
+echo "==> Verifying ${IMAGE}:${TAG} exists (= CI green)…"
+if ! sudo docker manifest inspect "${IMAGE}:${TAG}" >/dev/null 2>&1; then
+  echo "!! No image ${IMAGE}:${TAG} in GHCR — CI hasn't published it (tests failed / still running) or the tag is wrong. Aborting; nothing changed."
+  exit 1
+fi
+
+# Admin key from the running container (admin API is auth-gated). Used for seed check + notify.
+KEY="$($COMPOSE exec -T app printenv ARBR_ADMIN_KEY 2>/dev/null | tr -d '\r' || true)"
+AUTH=(); [ -n "$KEY" ] && AUTH=(-H "Authorization: Bearer $KEY")
+seed_of() { curl -s "${AUTH[@]}" "$API/about" 2>/dev/null | sed -n 's/.*"modelSeedVersion":\([0-9]*\).*/\1/p'; }
+notify() {  # $1 = message text
+  local url; url="$(curl -s "${AUTH[@]}" "$API/governance" 2>/dev/null | sed -n 's/.*"webhookUrl":"\([^"]*\)".*/\1/p')"
+  [ -n "$url" ] && curl -s -X POST "$url" -H "Content-Type: application/json" -d "{\"text\":\"$1\"}" >/dev/null 2>&1 || true
+}
+deploy() {  # $1 = tag
+  ARBR_IMAGE_TAG="$1" $COMPOSE pull app
+  ARBR_IMAGE_TAG="$1" $COMPOSE up -d --no-build app
+}
+
+SEED_BEFORE="$(seed_of || true)"
+PREV_TAG="$(cat "$PREV_FILE" 2>/dev/null || echo main)"
+echo "==> Current tag: ${PREV_TAG}  →  deploying: ${TAG}"
+
+# 2. DEPLOY.
+deploy "$TAG"
+
+# 3. HEALTH GATE: poll /health up to ~60s.
+ok=0
+for _ in $(seq 1 20); do
+  sleep 3
+  if curl -fsS "$HEALTH" >/dev/null 2>&1; then ok=1; break; fi
+done
+
+# 4. ROLLBACK on failure.
+if [ "$ok" != "1" ]; then
+  echo "!! Health check failed on ${TAG}. Rolling back to ${PREV_TAG}…"
+  deploy "$PREV_TAG"
+  notify "⚠️ Arbr deploy FAILED on ${TAG} — rolled back to ${PREV_TAG} (arbr.gyde.ai)."
+  echo "!! Rolled back to ${PREV_TAG}. Deploy aborted."
+  exit 1
+fi
+
+# 5. SUCCESS: record tag; re-run LiteLLM sync if the seed version changed.
+echo "$TAG" > "$PREV_FILE"
+SEED_AFTER="$(seed_of || true)"
+if [ -n "$SEED_AFTER" ] && [ "$SEED_BEFORE" != "$SEED_AFTER" ]; then
+  echo "==> Model seed ${SEED_BEFORE:-?} → ${SEED_AFTER}: re-running LiteLLM sync (pricing refresh)…"
+  curl -s -X POST "${AUTH[@]}" "$API/litellm/sync" >/dev/null 2>&1 || echo "!! LiteLLM sync call failed — run it manually."
+fi
+notify "✅ Arbr deployed ${TAG} to arbr.gyde.ai — healthy."
+echo "==> Done. Deployed ${TAG} (previous: ${PREV_TAG})."

--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -77,15 +77,19 @@ router.get("/status", async (_req, res, next) => {
   } catch (e) { next(e); }
 });
 
-router.get("/about", (_req, res) => {
-  const pkg = require("../../package.json");
-  res.json({
-    version: pkg.version,
-    name: pkg.name,
-    sdkJs: "0.2.0",
-    sdkPython: "0.2.0",
-    nodeVersion: process.version,
-  });
+router.get("/about", async (_req, res, next) => {
+  try {
+    const pkg = require("../../package.json");
+    const s = await Settings.get().catch(() => null);
+    res.json({
+      version: pkg.version,
+      name: pkg.name,
+      sdkJs: "0.2.0",
+      sdkPython: "0.2.0",
+      nodeVersion: process.version,
+      modelSeedVersion: s?.modelSeedVersion ?? null, // ops/deploy.sh uses this to detect a re-seed
+    });
+  } catch (e) { next(e); }
 });
 
 // ── cost caps (budgets) ──


### PR DESCRIPTION
## What
Answer to "is auto-deploy safe": the app/CI foundation is ready, but with no staging, a per-deploy restart blip, and no rollback, the safe move is a **manually-triggered but gated + rollback-safe** deploy on a **CI-published registry image** (not building on the prod host). This ships that.

## How it works
- **`ci.yml`**: on green `main` (job `needs: [build, python-sdk]`), publish `ghcr.io/project-arbr/arbr-control-plane:sha-<short>` + `:main`. Since the image is published **only after** test+lint+build pass, *an image existing for a commit is the green gate* — no separate check.
- **`docker-compose.deploy.yml`**: image overlay so the VM runs the pinned `ARBR_IMAGE_TAG` (no build on host).
- **`ops/deploy.sh`** (run on the VM): verify image exists (gate) → record current tag → pull + `up -d` → poll `/health` ~60s → **auto-rollback to previous tag on failure** → re-run LiteLLM sync if `modelSeedVersion` changed (prevents the silent pricing regression) → notify the governance webhook.
- **`/api/about`** now returns `modelSeedVersion` for the seed-change check.
- Docs updated; build-on-VM path deprecated.

## Not in scope (per decision)
Manual trigger only (no auto-on-merge / GH Actions→GCP OIDC), no blue-green (brief restart blip remains). This is the groundwork; full-auto is a small follow-on.

## Cutover (after merge)
1. Merge → CI publishes the first `sha-…`/`main` image.
2. On the VM: `cd ~/arbr-ai-control-plane && git pull && bash ops/deploy.sh main` → cuts over to image-based, health-checked.

## Verify
- Red CI publishes **no** image; green main publishes `sha-…`+`main`.
- `ops/deploy.sh` health-passes + records prev tag; a broken image → rollback fires + webhook notifies; a `SEED_VERSION` bump → LiteLLM sync auto-runs; no `docker build` on the VM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)