### PR TITLE
feat(bench): routing benchmark harness — LiveBench + Arena-Hard + SWE-bench (Phase 0–3)

### DIFF
--- a/bench/METHODOLOGY.md
+++ b/bench/METHODOLOGY.md
@@ -1,0 +1,42 @@
+# Benchmark methodology
+
+## What is measured
+Arbr is a **router**. For each benchmark we compute a **cost-vs-quality curve** across routers on the
+identical prompt set + identical model pool:
+
+- **x** = cost per query (USD), computed deterministically from token usage × the published price table
+  (`bench/config.js`), **not** read from billing.
+- **y** = quality (benchmark-native score over *scored* rows).
+
+**Headline metric** (matches RouteLLM's framing for comparability): *cost reduction at ≥95% of
+always-premium quality*, reported overall and **per task type** (Arbr's task-aware differentiator).
+Every Arbr routing decision also carries a reason (`routingDecision`/`taskType`) — an explainability
+axis baseline routers can't produce.
+
+## Routers compared (baselines)
+Same prompts, same pool, run side by side:
+- `always-premium` — upper bound on quality, upper bound on cost.
+- `always-light` — lower bound on cost, lower bound on quality.
+- `random` — seeded random pick (reproducible); the "routing adds nothing" control.
+- `routellm` — RouteLLM-OSS router (Phase 4 adapter) — the competitive head-to-head.
+- `arbr-auto` — Arbr's task-aware policy (send `model: "auto"`).
+
+The Arbr instance under test **must have its AI policy scoped to exactly the pool** so `arbr-auto` only
+routes among the priced models (otherwise rows come back `unpriced` and are flagged).
+
+## Quality scoring
+- **LiveBench**: objective categories (math / reasoning / data-analysis) scored by normalized final-answer
+  match (faithful to LiveBench's exact-answer scoring). Coding / language / instruction-following require
+  LiveBench's **official category graders** — an explicit integration point; until wired those rows are
+  `scored:false` and excluded from quality (never scored 0 by guess).
+- **Arena-Hard-Auto** (Phase 2): LLM-judged win-rate vs a reference, reusing the shadow-eval judge
+  (`server/src/eval/judge.js`); report confidence intervals (judge variance).
+- **SWE-bench Verified** (Phase 3): resolved-rate via the official Docker test harness; agentic, so the
+  agent's per-step calls route through Arbr.
+
+## Reproducibility & honesty (non-negotiable for publishing)
+- Publish the **model pool + per-1M prices**, dataset version, seed, and the harness itself.
+- Commit raw `results/*.jsonl` + `*.summary.json`.
+- Report **confidence intervals** on judged benchmarks; **report where Arbr loses**.
+- Prefer LiveBench / SWE-bench (contamination-resistant); note contamination risk on any MCQ set.
+- Costs are provider-price-dependent — a different pool/prices yields different numbers; that's disclosed.

--- a/bench/PLAN.md
+++ b/bench/PLAN.md
@@ -12,13 +12,15 @@ router within* these (keeps the head-to-head without adopting its saturated MMLU
 - **Phase 1 — LiveBench harness (this PR):** `runner.js` + `lib/{gateway,cost,router,summarize}.js` +
   `scorers/livebench.js` + `aggregate.js`. Deterministic objective scoring; per-category (→ task types);
   no LLM judge; lowest cost. `smoke:bench` covers the pure logic.
-- **Phase 2 — Arena-Hard-Auto:** `scorers/arenahard.js` (LLM-judge via `server/src/eval/judge.js`),
-  win-rate + confidence intervals.
+- **Phase 2 — Arena-Hard-Auto (done):** `scorers/arenahard.js` — pairwise LLM-judge via the gateway's
+  judge model, reusing `parseVerdict` from `server/src/eval/logic.js`; win/tie/loss vs the item's
+  reference answer. Confidence intervals to add when computing full-run numbers.
 - **Phase 3 — SWE-bench Verified:** `scorers/swebench.js` + agentic scaffold + official Docker harness;
   resolved-rate vs cost. Heaviest; phase last. (BFCL is a cheaper tool-routing stand-in if it slips.)
 - **Phase 4 — RouteLLM-OSS baseline + publish:** `baselines.js` RouteLLM adapter; commit raw results +
   summaries; the head-to-head curve.
 
 ## Status
-Phase 0 + Phase 1 scaffold built and syntax/logic-validated. Actual runs require Node 18 + real API
-keys (real cost) and a LiveBench dataset file — run on a box with keys, not in CI.
+Phases 0–2 built and syntax/logic-validated (`smoke:bench` 15/15). Sample fixtures under `fixtures/`
+let you exercise the full pipeline against a real Arbr with tiny cost. Full runs require Node 18 + real
+API keys (real cost) + the full datasets — run on a box with keys, not in CI. Phase 3 (SWE-bench) next.

--- a/bench/PLAN.md
+++ b/bench/PLAN.md
@@ -1,0 +1,24 @@
+# Benchmark roadmap
+
+Goal: publish credible, reproducible **router** benchmarks (cost-vs-quality) that back Arbr's
+positioning — explainable, task-aware, production routing — and answer RouteLLM's "2x" with a measured
+number on stronger, contamination-resistant benchmarks. See `METHODOLOGY.md`.
+
+Selected: **LiveBench**, **Arena-Hard-Auto**, **SWE-bench Verified**. RouteLLM-OSS stays as a *baseline
+router within* these (keeps the head-to-head without adopting its saturated MMLU/GSM8K set).
+
+## Phases (cheapest-first; each yields a publishable artifact)
+- **Phase 0 — spec + pool (done):** `PLAN.md`, `METHODOLOGY.md`, `config.js` (pool + prices).
+- **Phase 1 — LiveBench harness (this PR):** `runner.js` + `lib/{gateway,cost,router,summarize}.js` +
+  `scorers/livebench.js` + `aggregate.js`. Deterministic objective scoring; per-category (→ task types);
+  no LLM judge; lowest cost. `smoke:bench` covers the pure logic.
+- **Phase 2 — Arena-Hard-Auto:** `scorers/arenahard.js` (LLM-judge via `server/src/eval/judge.js`),
+  win-rate + confidence intervals.
+- **Phase 3 — SWE-bench Verified:** `scorers/swebench.js` + agentic scaffold + official Docker harness;
+  resolved-rate vs cost. Heaviest; phase last. (BFCL is a cheaper tool-routing stand-in if it slips.)
+- **Phase 4 — RouteLLM-OSS baseline + publish:** `baselines.js` RouteLLM adapter; commit raw results +
+  summaries; the head-to-head curve.
+
+## Status
+Phase 0 + Phase 1 scaffold built and syntax/logic-validated. Actual runs require Node 18 + real API
+keys (real cost) and a LiveBench dataset file — run on a box with keys, not in CI.

--- a/bench/README.md
+++ b/bench/README.md
@@ -24,7 +24,27 @@ RUN_TAG=smoke node bench/runner.js --dataset path/to/livebench.jsonl --limit 20
 node bench/aggregate.js bench/results/livebench-smoke.jsonl
 ```
 
-`npm run smoke:bench` validates the pure logic (cost, scoring, aggregation) with no network.
+## Test it quickly (no dataset download)
+
+- **Pure logic — no network/keys/cost:** `npm run smoke:bench` (cost, scoring, router, aggregation, arena win-mapping).
+- **End-to-end against a real Arbr — tiny cost:** committed sample fixtures exercise the whole pipeline
+  (route → score → cost → curve) without the full datasets:
+
+```sh
+export ARBR_BASE_URL="https://your-arbr-host/v1"  ARBR_API_KEY="ab_…"
+# LiveBench (5 objective items × baselines):
+RUN_TAG=fixt node bench/runner.js --benchmark livebench --dataset bench/fixtures/livebench.sample.jsonl
+node bench/aggregate.js bench/results/livebench-fixt.jsonl
+
+# Arena-Hard (judged → also set a judge model):
+export ARBR_JUDGE_MODEL="gpt-4o"
+RUN_TAG=fixt node bench/runner.js --benchmark arenahard --dataset bench/fixtures/arenahard.sample.jsonl
+node bench/aggregate.js bench/results/arenahard-fixt.jsonl
+```
+
+Expect `arbr-auto` to retain most of `always-premium`'s quality at a fraction of the cost, with a
+per-category line — that confirms routing attribution, scoring, and cost math end to end. Then swap in
+the full LiveBench / Arena-Hard datasets for real numbers.
 
 ## Honesty notes
 - The model pool + prices in `bench/config.js` are disclosed with every result; numbers don't

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,35 @@
+# Arbr routing benchmarks
+
+Arbr is a **router**, so these benchmarks don't produce a leaderboard score — they produce a
+**cost-vs-quality curve**: for a fixed quality bar, how much cost Arbr's task-aware routing saves vs
+baselines (always-premium, always-light, random, and RouteLLM-OSS). See `METHODOLOGY.md` for the rules
+and `PLAN.md` for the phased roadmap. Selected benchmarks: **LiveBench** (built), **Arena-Hard-Auto**,
+**SWE-bench Verified**.
+
+## Run LiveBench (Phase 1)
+
+Requires **Node 18+** and **real API keys** — every row is a live model call (costs money).
+
+```sh
+# 1. Point at an Arbr instance whose AI policy is scoped to the model pool in bench/config.js,
+#    with a gateway key for application "bench".
+export ARBR_BASE_URL="https://your-arbr-host/v1"
+export ARBR_API_KEY="ab_…"
+
+# 2. Get the LiveBench question set as jsonl (question_id, category, turns, ground_truth).
+#    Start small with --limit while validating.
+RUN_TAG=smoke node bench/runner.js --dataset path/to/livebench.jsonl --limit 20
+
+# 3. Aggregate → cost-vs-quality table + headline + summary.json
+node bench/aggregate.js bench/results/livebench-smoke.jsonl
+```
+
+`npm run smoke:bench` validates the pure logic (cost, scoring, aggregation) with no network.
+
+## Honesty notes
+- The model pool + prices in `bench/config.js` are disclosed with every result; numbers don't
+  generalize across pools/prices.
+- Objective LiveBench categories (math/reasoning/data) are scored here; coding/language/IF need
+  LiveBench's **official grader** (an explicit integration point — those rows are marked unscored, not
+  guessed) before publishing those categories.
+- Commit raw `results/*.jsonl` + `*.summary.json` for reproducibility. Report where Arbr loses.

--- a/bench/SWEBENCH.md
+++ b/bench/SWEBENCH.md
@@ -1,0 +1,50 @@
+# SWE-bench Verified (Phase 3)
+
+SWE-bench is **agentic and Docker-heavy**: solving an instance means an agent explores a repo, edits
+files, and runs tests; scoring means applying the patch and running the repo's test suite in a
+container. We deliberately **reuse the official pieces** and only add the Arbr integration:
+
+- **Patch generation:** an existing agent (e.g. [mini-SWE-agent] or SWE-agent) pointed at **Arbr's
+  OpenAI-compatible gateway** as its model endpoint. Each agent step is an Arbr request, so Arbr does
+  the routing and logs cost/served-model/decision. Run once per baseline (pin the model, or `auto` for
+  `arbr-auto`).
+- **Scoring:** the **official `swebench.harness.run_evaluation`** (Docker) applies patches and runs
+  tests, producing a report JSON. We do NOT reimplement this — the official harness is the credible
+  scorer.
+- **Arbr integration (this repo):** `bench/scorers/swebench.js` + `bench/swebench/from-report.js` turn
+  the official report + the baseline's total cost into standard bench rows, so `bench/aggregate.js`
+  yields the same **cost-vs-resolved** curve as the other benchmarks.
+
+## Pipeline (per baseline)
+```sh
+# 1. Generate predictions with an agent pointed at Arbr. Tag each baseline's traffic to its own
+#    application (e.g. bench-swe-arbr-auto) so cost is attributable in Arbr analytics.
+#    Configure the agent: base_url=$ARBR_BASE_URL, api_key=$ARBR_API_KEY, model=<pool model | "auto">.
+#    → produces predictions.jsonl (instance_id + model_patch).
+
+# 2. Official evaluation (Docker) → report json:
+python -m swebench.harness.run_evaluation \
+  --dataset_name princeton-nlp/SWE-bench_Verified \
+  --predictions_path predictions.arbr-auto.jsonl --run_id arbr-auto
+
+# 3. Read Arbr analytics for that baseline's total cost (its tagged application), then convert:
+node bench/swebench/from-report.js --report <run_id>.report.json --baseline arbr-auto --cost <USD> --tag v1
+
+# repeat 1–3 for always-premium / always-light / random / routellm, then:
+node bench/aggregate.js bench/results/swebench-v1.jsonl
+```
+
+## Quick pipeline check (no Docker/agent)
+```sh
+node bench/swebench/from-report.js --report bench/fixtures/swebench.report.sample.json --baseline arbr-auto --cost 10 --tag demo
+node bench/aggregate.js bench/results/swebench-demo.jsonl   # → 60% resolved, $2/instance
+```
+`npm run smoke:bench` covers `resolvedRate` + `rowsFromReport` with no I/O.
+
+## Notes
+- Total cost per baseline comes from Arbr's per-application analytics (agent runs are many calls) ÷
+  instances; disclose it alongside resolved-rate.
+- SWE-bench is the flagship for Arbr's **task-aware + tool-capable** routing, but it's the most
+  expensive to run (compute + API) — budget accordingly.
+
+[mini-SWE-agent]: https://github.com/SWE-agent/mini-swe-agent

--- a/bench/aggregate.js
+++ b/bench/aggregate.js
@@ -12,7 +12,8 @@ const s = summarize(rows);
 const pct = (n) => (n == null ? "  —  " : `${n.toFixed(1)}%`);
 const usd = (n) => `$${(Number(n) || 0).toFixed(4)}`;
 
-console.log(`\nLiveBench router comparison  (${rows.length} rows)\n`);
+const benchName = (rows[0] && rows[0].benchmark) || "benchmark";
+console.log(`\n${benchName} router comparison  (${rows.length} rows)\n`);
 console.log("baseline          quality   qRetained   $/query    cost%prem   scored  err  unpriced");
 for (const k of Object.keys(s)) {
   const b = s[k];

--- a/bench/aggregate.js
+++ b/bench/aggregate.js
@@ -1,0 +1,41 @@
+// Aggregate a raw results jsonl into the cost-vs-quality summary + headline numbers.
+//   node bench/aggregate.js bench/results/livebench-run.jsonl
+const fs = require("fs");
+const { summarize } = require("./lib/summarize");
+
+const file = process.argv[2];
+if (!file) { console.error("usage: node bench/aggregate.js <results.jsonl>"); process.exit(1); }
+
+const rows = fs.readFileSync(file, "utf8").trim().split("\n").filter(Boolean).map((l) => JSON.parse(l));
+const s = summarize(rows);
+
+const pct = (n) => (n == null ? "  —  " : `${n.toFixed(1)}%`);
+const usd = (n) => `$${(Number(n) || 0).toFixed(4)}`;
+
+console.log(`\nLiveBench router comparison  (${rows.length} rows)\n`);
+console.log("baseline          quality   qRetained   $/query    cost%prem   scored  err  unpriced");
+for (const k of Object.keys(s)) {
+  const b = s[k];
+  console.log(
+    `${k.padEnd(17)} ${b.quality == null ? "  —  " : (b.quality * 100).toFixed(1) + "%"}`.padEnd(28) +
+    `${pct(b.qualityRetainedPct)}`.padEnd(12) +
+    `${usd(b.costPerQuery)}`.padEnd(11) +
+    `${pct(b.costVsPremiumPct)}`.padEnd(11) +
+    `${b.scoredN}`.padEnd(8) + `${b.errors}`.padEnd(5) + `${b.unpriced}`
+  );
+}
+
+const arbr = s["arbr-auto"];
+if (arbr && arbr.qualityRetainedPct != null) {
+  console.log(
+    `\nHEADLINE: arbr-auto retained ${arbr.qualityRetainedPct.toFixed(1)}% of premium quality ` +
+    `at ${arbr.costVsPremiumPct != null ? arbr.costVsPremiumPct.toFixed(1) : "?"}% of premium cost.`
+  );
+  console.log("Per-category quality (arbr-auto):", JSON.stringify(arbr.byCategory));
+}
+if (Object.values(s).some((b) => b.unpriced > 0)) {
+  console.log("\n⚠ Some rows unpriced (served model not in bench/config.js prices) — scope Arbr's policy to the pool or add prices.");
+}
+
+fs.writeFileSync(file.replace(/\.jsonl$/, ".summary.json"), JSON.stringify(s, null, 2));
+console.log(`\nSummary → ${file.replace(/\.jsonl$/, ".summary.json")}`);

--- a/bench/config.js
+++ b/bench/config.js
@@ -1,0 +1,31 @@
+// Benchmark configuration. Everything price-dependent lives here and is published with results.
+// Arbr under test should have its AI policy scoped to exactly this model pool for a fair comparison
+// (so "arbr-auto" only ever routes among these), and Require-API-keys on with a key for `application: bench`.
+module.exports = {
+  gateway: {
+    baseURL: process.env.ARBR_BASE_URL || "http://localhost:4100/v1",
+    apiKey:  process.env.ARBR_API_KEY  || "none",
+  },
+
+  // The model pool the routers choose from, with per-1M-token USD prices (DISCLOSED in results).
+  // Cost is computed from these prices + usage — deterministic, not read back from billing.
+  pool: {
+    premium: "gpt-4o",
+    mid:     "us.amazon.nova-pro-v1:0",
+    light:   "gpt-4o-mini",
+  },
+  prices: {
+    // model id -> { in, out } USD per 1M tokens
+    "gpt-4o":                    { in: 2.50, out: 10.00 },
+    "us.amazon.nova-pro-v1:0":   { in: 0.80, out: 3.20 },
+    "gpt-4o-mini":               { in: 0.15, out: 0.60 },
+    // extend if you widen the pool (e.g. gemini-2.5-flash, deepseek-chat)
+  },
+
+  // Routers compared on every benchmark (same prompts, same pool).
+  // "routellm" is added in phase 4 (RouteLLM-OSS adapter).
+  baselines: ["always-premium", "always-light", "random", "arbr-auto"],
+
+  judgeModel: process.env.ARBR_JUDGE_MODEL || "gpt-4o", // Arena-Hard (phase 2)
+  seed: 42,
+};

--- a/bench/fixtures/arenahard.sample.jsonl
+++ b/bench/fixtures/arenahard.sample.jsonl
@@ -1,0 +1,3 @@
+{"question_id":"ah-1","category":"general","prompt":"Explain what a mutex is and when you would use one, with a concrete example.","reference_answer":"A mutex is a lock."}
+{"question_id":"ah-2","category":"general","prompt":"Write a clear, beginner-friendly explanation of how HTTPS keeps data private, including the role of certificates.","reference_answer":"HTTPS encrypts data."}
+{"question_id":"ah-3","category":"general","prompt":"Summarize the tradeoffs between SQL and NoSQL databases for a small startup, with a recommendation.","reference_answer":"SQL is relational, NoSQL is not. Pick one."}

--- a/bench/fixtures/livebench.sample.jsonl
+++ b/bench/fixtures/livebench.sample.jsonl
@@ -1,0 +1,5 @@
+{"question_id":"lb-math-1","category":"math","turns":["What is 17 * 23? Put the final answer in \\boxed{}."],"ground_truth":"391"}
+{"question_id":"lb-math-2","category":"math","turns":["Compute the sum of the first 10 positive integers. Put the final answer in \\boxed{}."],"ground_truth":"55"}
+{"question_id":"lb-math-3","category":"math","turns":["Solve 2x + 6 = 10 for x. Put the final answer in \\boxed{}."],"ground_truth":"2"}
+{"question_id":"lb-data-1","category":"data_analysis","turns":["Given the list [3, 1, 4, 1, 5], what is the median? Put the final answer in \\boxed{}."],"ground_truth":"3"}
+{"question_id":"lb-reason-1","category":"reasoning","turns":["All Bloops are Razzies and all Razzies are Lazzies. Are all Bloops Lazzies? End with 'Answer: yes' or 'Answer: no'."],"ground_truth":"yes"}

--- a/bench/fixtures/swebench.report.sample.json
+++ b/bench/fixtures/swebench.report.sample.json
@@ -1,0 +1,5 @@
+{
+  "total_instances": 5,
+  "resolved_ids": ["django__django-11001", "astropy__astropy-12907", "sympy__sympy-13480"],
+  "unresolved_ids": ["flask__flask-4045", "requests__requests-2317"]
+}

--- a/bench/lib/cost.js
+++ b/bench/lib/cost.js
@@ -1,0 +1,11 @@
+// Deterministic cost from usage + the published price table. Pure (unit-tested).
+function costUsd(model, usage, prices) {
+  const p = prices[model];
+  if (!p) return { usd: 0, priced: false }; // unknown model → flag so it's visible, not silently $0
+  const inTok = (usage && usage.prompt_tokens) || 0;
+  const outTok = (usage && usage.completion_tokens) || 0;
+  const usd = (inTok / 1e6) * p.in + (outTok / 1e6) * p.out;
+  return { usd, priced: true };
+}
+
+module.exports = { costUsd };

--- a/bench/lib/gateway.js
+++ b/bench/lib/gateway.js
@@ -1,0 +1,27 @@
+// Thin client to Arbr's OpenAI-compatible gateway. Returns the served model + routing decision
+// (from Arbr's X-Arbr-* response headers) so the harness can attribute cost and explain routing.
+// Requires Node 18+ (global fetch).
+async function complete(cfg, { model, messages, maxTokens = 1024, temperature = 0 }) {
+  const start = Date.now();
+  const res = await fetch(`${cfg.gateway.baseURL}/chat/completions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${cfg.gateway.apiKey}` },
+    body: JSON.stringify({ model, messages, max_tokens: maxTokens, temperature }),
+  });
+  const latencyMs = Date.now() - start;
+  const data = await res.json().catch(() => null);
+  if (!res.ok || !data) {
+    const msg = (data && data.error && data.error.message) || `upstream ${res.status}`;
+    throw new Error(msg);
+  }
+  return {
+    text: (data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content) || "",
+    servedModel: res.headers.get("x-arbr-model") || data.model || model,
+    routingDecision: res.headers.get("x-arbr-routing") || null,
+    taskType: res.headers.get("x-arbr-task-type") || null,
+    usage: data.usage || { prompt_tokens: 0, completion_tokens: 0 },
+    latencyMs,
+  };
+}
+
+module.exports = { complete };

--- a/bench/lib/router.js
+++ b/bench/lib/router.js
@@ -1,0 +1,23 @@
+// Maps a baseline name → the model string to request from the gateway for a given item.
+// "arbr-auto" sends "auto" so Arbr's own task-aware policy decides; the others pin a model
+// so we get a fixed reference curve. RouteLLM-OSS is a phase-4 adapter (returns its pick).
+//
+// `rand` is a seeded RNG (index-based) so "random" is reproducible.
+function modelFor(baseline, cfg, rand) {
+  const { premium, mid, light } = cfg.pool;
+  switch (baseline) {
+    case "always-premium": return premium;
+    case "always-light":   return light;
+    case "random":         return [premium, mid, light][Math.floor(rand() * 3)];
+    case "arbr-auto":      return "auto";
+    default: throw new Error(`unknown baseline: ${baseline}`);
+  }
+}
+
+// Deterministic per-(baseline,index) RNG so "random" reproduces across runs.
+function seededRand(seed, i) {
+  let x = (seed * 2654435761 + i * 40503) >>> 0;
+  return () => { x = (x * 1103515245 + 12345) >>> 0; return x / 0xffffffff; };
+}
+
+module.exports = { modelFor, seededRand };

--- a/bench/lib/summarize.js
+++ b/bench/lib/summarize.js
@@ -1,0 +1,37 @@
+// Pure aggregation of raw result rows → the cost-vs-quality summary (unit-tested).
+// quality = mean score over SCORED rows (unscored categories excluded, not counted as 0).
+// Derives, vs always-premium: quality retained % and cost %.
+function summarize(rows) {
+  const acc = {};
+  for (const r of rows) {
+    const b = acc[r.baseline] || (acc[r.baseline] = { n: 0, errors: 0, scoredN: 0, scoreSum: 0, costSum: 0, unpriced: 0, cat: {} });
+    b.n++;
+    if (r.error) { b.errors++; continue; }
+    if (r.priced === false) b.unpriced++;
+    b.costSum += Number(r.costUsd) || 0;
+    if (r.scored) {
+      b.scoredN++; b.scoreSum += Number(r.score) || 0;
+      const c = b.cat[r.category] || (b.cat[r.category] = { n: 0, sum: 0 });
+      c.n++; c.sum += Number(r.score) || 0;
+    }
+  }
+  const out = {};
+  for (const k of Object.keys(acc)) {
+    const b = acc[k];
+    out[k] = {
+      baseline: k, n: b.n, errors: b.errors, scoredN: b.scoredN, unpriced: b.unpriced,
+      quality: b.scoredN ? b.scoreSum / b.scoredN : null,
+      totalCost: b.costSum,
+      costPerQuery: b.n ? b.costSum / b.n : 0,
+      byCategory: Object.fromEntries(Object.keys(b.cat).map((cat) => [cat, b.cat[cat].n ? b.cat[cat].sum / b.cat[cat].n : null])),
+    };
+  }
+  const prem = out["always-premium"];
+  for (const k of Object.keys(out)) {
+    if (prem && prem.quality) out[k].qualityRetainedPct = out[k].quality != null ? (out[k].quality / prem.quality) * 100 : null;
+    if (prem && prem.costPerQuery > 0) out[k].costVsPremiumPct = (out[k].costPerQuery / prem.costPerQuery) * 100;
+  }
+  return out;
+}
+
+module.exports = { summarize };

--- a/bench/runner.js
+++ b/bench/runner.js
@@ -1,7 +1,8 @@
-// Phase-1 runner: route each LiveBench item through every baseline via Arbr's gateway, score it,
-// and write raw rows to bench/results/. Aggregate them with `node bench/aggregate.js <file>`.
+// Benchmark runner: route each item through every baseline via Arbr's gateway, score it, and write
+// raw rows to bench/results/. Aggregate with `node bench/aggregate.js <file>`.
 //
-//   ARBR_BASE_URL=... ARBR_API_KEY=... node bench/runner.js --dataset livebench.jsonl [--limit 50]
+//   ARBR_BASE_URL=... ARBR_API_KEY=... node bench/runner.js --benchmark livebench --dataset file.jsonl [--limit 50]
+//   (--benchmark: livebench | arenahard;  default livebench)
 //
 // Requires Node 18+ (global fetch) and REAL API keys — every row is a live model call (costs money).
 const fs = require("fs");
@@ -11,36 +12,46 @@ const { complete } = require("./lib/gateway");
 const { costUsd } = require("./lib/cost");
 const { modelFor, seededRand } = require("./lib/router");
 const livebench = require("./scorers/livebench");
+const arenahard = require("./scorers/arenahard");
+
+const SCORERS = { livebench: 1, arenahard: 1 };
 
 function arg(name, def) {
   const i = process.argv.indexOf(`--${name}`);
   return i !== -1 ? process.argv[i + 1] : def;
 }
 
+// Uniform dispatch: arenahard is async (judged via the gateway); livebench is sync exact-answer.
+async function scoreRow(benchmark, item, output) {
+  return benchmark === "arenahard" ? arenahard.score(cfg, item, output) : livebench.score(item, output);
+}
+
 async function main() {
+  const benchmark = arg("benchmark", "livebench");
+  if (!SCORERS[benchmark]) { console.error(`unknown --benchmark ${benchmark} (livebench|arenahard)`); process.exit(1); }
   const datasetPath = arg("dataset");
-  if (!datasetPath) { console.error("--dataset <livebench.jsonl> is required"); process.exit(1); }
+  if (!datasetPath) { console.error("--dataset <file.jsonl> is required"); process.exit(1); }
   const limit = Number(arg("limit", "0")) || 0;
 
   let items = fs.readFileSync(datasetPath, "utf8").trim().split("\n").filter(Boolean).map((l) => JSON.parse(l));
   if (limit) items = items.slice(0, limit);
 
-  const outPath = path.join(__dirname, "results", `livebench-${process.env.RUN_TAG || "run"}.jsonl`);
+  const outPath = path.join(__dirname, "results", `${benchmark}-${process.env.RUN_TAG || "run"}.jsonl`);
   const out = fs.createWriteStream(outPath, { flags: "w" });
-  console.log(`Running ${items.length} items × ${cfg.baselines.length} baselines → ${outPath}`);
+  console.log(`[${benchmark}] running ${items.length} items × ${cfg.baselines.length} baselines → ${outPath}`);
 
   for (let i = 0; i < items.length; i++) {
     const item = items[i];
-    const prompt = Array.isArray(item.turns) ? item.turns[0] : item.turns || item.prompt;
+    const prompt = (Array.isArray(item.turns) ? item.turns[0] : item.turns) || item.prompt;
     const messages = [{ role: "user", content: prompt }];
     const rand = seededRand(cfg.seed, i);
 
     for (const baseline of cfg.baselines) {
       const model = modelFor(baseline, cfg, rand);
-      const row = { benchmark: "livebench", questionId: item.question_id, category: item.category, baseline, requested: model };
+      const row = { benchmark, questionId: item.question_id, category: item.category || "general", baseline, requested: model };
       try {
-        const r = await complete(cfg, { messages });
-        const s = livebench.score(item, r.text);
+        const r = await complete(cfg, { model, messages });
+        const s = await scoreRow(benchmark, item, r.text);
         const c = costUsd(r.servedModel, r.usage, cfg.prices);
         Object.assign(row, {
           servedModel: r.servedModel, routingDecision: r.routingDecision, taskType: r.taskType,

--- a/bench/runner.js
+++ b/bench/runner.js
@@ -1,0 +1,61 @@
+// Phase-1 runner: route each LiveBench item through every baseline via Arbr's gateway, score it,
+// and write raw rows to bench/results/. Aggregate them with `node bench/aggregate.js <file>`.
+//
+//   ARBR_BASE_URL=... ARBR_API_KEY=... node bench/runner.js --dataset livebench.jsonl [--limit 50]
+//
+// Requires Node 18+ (global fetch) and REAL API keys — every row is a live model call (costs money).
+const fs = require("fs");
+const path = require("path");
+const cfg = require("./config");
+const { complete } = require("./lib/gateway");
+const { costUsd } = require("./lib/cost");
+const { modelFor, seededRand } = require("./lib/router");
+const livebench = require("./scorers/livebench");
+
+function arg(name, def) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 ? process.argv[i + 1] : def;
+}
+
+async function main() {
+  const datasetPath = arg("dataset");
+  if (!datasetPath) { console.error("--dataset <livebench.jsonl> is required"); process.exit(1); }
+  const limit = Number(arg("limit", "0")) || 0;
+
+  let items = fs.readFileSync(datasetPath, "utf8").trim().split("\n").filter(Boolean).map((l) => JSON.parse(l));
+  if (limit) items = items.slice(0, limit);
+
+  const outPath = path.join(__dirname, "results", `livebench-${process.env.RUN_TAG || "run"}.jsonl`);
+  const out = fs.createWriteStream(outPath, { flags: "w" });
+  console.log(`Running ${items.length} items × ${cfg.baselines.length} baselines → ${outPath}`);
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    const prompt = Array.isArray(item.turns) ? item.turns[0] : item.turns || item.prompt;
+    const messages = [{ role: "user", content: prompt }];
+    const rand = seededRand(cfg.seed, i);
+
+    for (const baseline of cfg.baselines) {
+      const model = modelFor(baseline, cfg, rand);
+      const row = { benchmark: "livebench", questionId: item.question_id, category: item.category, baseline, requested: model };
+      try {
+        const r = await complete(cfg, { messages });
+        const s = livebench.score(item, r.text);
+        const c = costUsd(r.servedModel, r.usage, cfg.prices);
+        Object.assign(row, {
+          servedModel: r.servedModel, routingDecision: r.routingDecision, taskType: r.taskType,
+          scored: s.scored, score: s.score, scoreMethod: s.method,
+          costUsd: c.usd, priced: c.priced, latencyMs: r.latencyMs,
+          promptTokens: r.usage.prompt_tokens || 0, completionTokens: r.usage.completion_tokens || 0,
+        });
+      } catch (e) {
+        Object.assign(row, { error: String(e.message || e) });
+      }
+      out.write(JSON.stringify(row) + "\n");
+    }
+    if ((i + 1) % 10 === 0) console.log(`  …${i + 1}/${items.length}`);
+  }
+  out.end(() => console.log(`Done. Aggregate: node bench/aggregate.js ${outPath}`));
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/bench/scorers/arenahard.js
+++ b/bench/scorers/arenahard.js
@@ -1,0 +1,36 @@
+// Arena-Hard-Auto scorer: LLM-judged pairwise win-rate. Each router's answer (candidate = B) is judged
+// against the item's reference answer (A) by the gateway's judge model; win=1, tie=0.5, loss=0.
+// Reuses the shadow-eval verdict parser (server/src/eval/logic.js — pure) so verdict handling matches #54.
+const { parseVerdict } = require("../../server/src/eval/logic");
+const { complete } = require("../lib/gateway");
+
+// Pure: candidate-vs-reference verdict → win score (unit-tested).
+function winFromVerdict(verdict) {
+  return verdict === "better" ? 1 : verdict === "equal" ? 0.5 : 0;
+}
+
+function judgePrompt(prompt, reference, candidate) {
+  return [
+    "You are impartially judging two assistant answers to the SAME user prompt. Decide which better",
+    "answers it (correctness, depth, instruction-following). Be strict and position-unbiased.",
+    "", "USER PROMPT:", String(prompt || "").slice(0, 4000),
+    "", "ANSWER A (reference):", String(reference || "").slice(0, 6000),
+    "", "ANSWER B (candidate):", String(candidate || "").slice(0, 6000),
+    "", 'Reply with ONLY JSON: {"winner": "A" | "B" | "tie", "reason": "<one sentence>"}',
+  ].join("\n");
+}
+
+// Async: judge the candidate output against the item's reference answer via cfg.judgeModel.
+async function score(cfg, item, output) {
+  const prompt = item.prompt || (Array.isArray(item.turns) ? item.turns[0] : item.turns);
+  const reference = item.reference_answer || item.baseline_answer || "";
+  if (!reference) return { scored: false, score: null, method: "no-reference-answer" };
+  const r = await complete(cfg, {
+    model: cfg.judgeModel, temperature: 0,
+    messages: [{ role: "user", content: judgePrompt(prompt, reference, output) }],
+  });
+  const v = parseVerdict(r.text); // { verdict: better|worse|equal }
+  return { scored: true, score: winFromVerdict(v.verdict), method: `arena-judge:${v.verdict}` };
+}
+
+module.exports = { score, winFromVerdict, judgePrompt };

--- a/bench/scorers/livebench.js
+++ b/bench/scorers/livebench.js
@@ -1,0 +1,38 @@
+// LiveBench scorer.
+//
+// LiveBench ships per-category graders; for objective categories (math / reasoning / data-analysis)
+// the ground truth is a scalar answer, so we extract the model's final answer and normalize-match —
+// faithful to LiveBench's exact-answer scoring for those. Coding / language / instruction-following
+// need LiveBench's OFFICIAL category graders (test execution, edit-distance, IF-checkers); those are
+// left as an explicit integration point and are NOT silently scored here (they return scored:false so
+// aggregate excludes them until the official grader is wired). This keeps published numbers honest.
+const OBJECTIVE_CATEGORIES = new Set(["math", "reasoning", "data_analysis"]);
+
+function normalize(s) {
+  return String(s || "").toLowerCase().replace(/\$|\\boxed\{|\}|,|\s+/g, "").trim();
+}
+
+// Pull the model's final answer: \boxed{...}, "answer: X", or the last non-empty line.
+function extractAnswer(text) {
+  const t = String(text || "");
+  const boxed = t.match(/\\boxed\{([^}]*)\}/);
+  if (boxed) return boxed[1];
+  const ans = t.match(/(?:final answer|answer)\s*[:=]\s*(.+)/i);
+  if (ans) return ans[1].split("\n")[0];
+  const lines = t.trim().split("\n").filter((l) => l.trim());
+  return lines.length ? lines[lines.length - 1] : "";
+}
+
+// item: { category, ground_truth, ... } from the LiveBench dataset. output: model text.
+// Returns { scored, score (0..1|null), method }.
+function score(item, output) {
+  const cat = item.category;
+  if (!OBJECTIVE_CATEGORIES.has(cat)) {
+    return { scored: false, score: null, method: `official-grader-required:${cat}` };
+  }
+  const got = normalize(extractAnswer(output));
+  const gt = normalize(item.ground_truth);
+  return { scored: true, score: got && got === gt ? 1 : 0, method: "exact-answer" };
+}
+
+module.exports = { score, OBJECTIVE_CATEGORIES };

--- a/bench/scorers/swebench.js
+++ b/bench/scorers/swebench.js
@@ -1,0 +1,38 @@
+// SWE-bench Verified integration.
+//
+// We do NOT reimplement patch application / test execution — the OFFICIAL SWE-bench harness
+// (Docker-per-repo) is the credible scorer and reimplementing it would be less trustworthy. Instead we
+// read the official evaluation *report* and convert it into the harness's standard benchmark rows, so
+// bench/aggregate.js produces the cost-vs-resolved curve like the other benchmarks. Patch generation is
+// done by an existing agent pointed at Arbr's gateway (see bench/SWEBENCH.md).
+function parseReport(report) {
+  const resolvedIds = report.resolved_ids || report.resolvedIds || [];
+  const unresolvedIds = report.unresolved_ids || report.unresolvedIds || [];
+  const attemptedIds =
+    report.submitted_ids || report.completed_ids ||
+    (resolvedIds.length || unresolvedIds.length ? [...resolvedIds, ...unresolvedIds] : []);
+  return { resolvedIds, attemptedIds };
+}
+
+// { resolved, attempted, rate } for a single baseline's official report.
+function resolvedRate(report) {
+  const { resolvedIds, attemptedIds } = parseReport(report);
+  const attempted = attemptedIds.length;
+  return { resolved: resolvedIds.length, attempted, rate: attempted ? resolvedIds.length / attempted : null };
+}
+
+// One standard bench row per attempted instance (score 1 if resolved). cost = totalCost / instances
+// (agentic runs are metered per-baseline via Arbr, not per-instance). Feeds bench/aggregate.js unchanged.
+function rowsFromReport(report, { baseline, totalCost = 0 }) {
+  const { resolvedIds, attemptedIds } = parseReport(report);
+  const resolved = new Set(resolvedIds);
+  const n = attemptedIds.length || 1;
+  const per = totalCost / n;
+  return attemptedIds.map((id) => ({
+    benchmark: "swebench", questionId: id, category: "coding", baseline,
+    scored: true, score: resolved.has(id) ? 1 : 0,
+    costUsd: per, priced: totalCost > 0,
+  }));
+}
+
+module.exports = { parseReport, resolvedRate, rowsFromReport };

--- a/bench/swebench/from-report.js
+++ b/bench/swebench/from-report.js
@@ -1,0 +1,25 @@
+// Convert an OFFICIAL SWE-bench evaluation report into standard benchmark rows (one per instance),
+// appending per baseline. Then aggregate with bench/aggregate.js like any other benchmark.
+//   node bench/swebench/from-report.js --report <official-report.json> --baseline arbr-auto --cost 12.34 [--tag run]
+// Run once per baseline; --cost is that baseline run's total USD (from Arbr analytics for its tagged app).
+const fs = require("fs");
+const path = require("path");
+const { rowsFromReport } = require("../scorers/swebench");
+
+function arg(n, d) { const i = process.argv.indexOf(`--${n}`); return i !== -1 ? process.argv[i + 1] : d; }
+
+const reportPath = arg("report");
+const baseline = arg("baseline");
+const cost = Number(arg("cost", "0")) || 0;
+const tag = arg("tag", "run");
+if (!reportPath || !baseline) {
+  console.error("usage: --report <official-report.json> --baseline <name> [--cost USD] [--tag t]");
+  process.exit(1);
+}
+
+const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+const rows = rowsFromReport(report, { baseline, totalCost: cost });
+const out = path.join(__dirname, "..", "results", `swebench-${tag}.jsonl`);
+fs.appendFileSync(out, rows.map((r) => JSON.stringify(r)).join("\n") + "\n");
+console.log(`Appended ${rows.length} rows (baseline=${baseline}, cost=$${cost}) → ${out}`);
+console.log(`When all baselines are in: node bench/aggregate.js ${out}`);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "smoke:maxtokens": "node server/scripts/maxtokens-smoke.js",
     "smoke:eval": "node server/scripts/eval-smoke.js",
     "smoke:import": "node server/scripts/import-smoke.js",
+    "smoke:bench": "node server/scripts/bench-smoke.js",
     "lint": "eslint server/src",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",

--- a/server/scripts/bench-smoke.js
+++ b/server/scripts/bench-smoke.js
@@ -4,6 +4,7 @@ const { summarize } = require("../../bench/lib/summarize");
 const { seededRand } = require("../../bench/lib/router");
 const livebench = require("../../bench/scorers/livebench");
 const arena = require("../../bench/scorers/arenahard");
+const swe = require("../../bench/scorers/swebench");
 
 let pass = 0, fail = 0;
 const eq = (got, exp, msg) => {
@@ -47,6 +48,17 @@ approx(s["always-premium"].costPerQuery, 0.10, "premium cost/query");
 eq(arena.winFromVerdict("better"), 1, "candidate better → win 1");
 eq(arena.winFromVerdict("equal"), 0.5, "tie → 0.5");
 eq(arena.winFromVerdict("worse"), 0, "candidate worse → 0");
+
+// 6. SWE-bench: read official report → resolved-rate + standard rows for aggregate.
+const sweReport = { total_instances: 5, resolved_ids: ["a", "b", "c"], unresolved_ids: ["d", "e"] };
+eq(swe.resolvedRate(sweReport).resolved, 3, "swe resolved count");
+approx(swe.resolvedRate(sweReport).rate, 0.6, "swe resolved rate 3/5");
+const sweRows = swe.rowsFromReport(sweReport, { baseline: "arbr-auto", totalCost: 10 });
+eq(sweRows.length, 5, "swe rows = attempted instances");
+eq(sweRows.filter((r) => r.score === 1).length, 3, "swe resolved rows scored 1");
+approx(sweRows[0].costUsd, 2, "swe cost/instance = total/5");
+// And they aggregate through the SAME summarize() → 60% quality:
+approx(summarize(sweRows)["arbr-auto"].quality, 0.6, "swe rows aggregate to 0.6 resolved-rate");
 
 console.log(`${pass}/${pass + fail} passed`);
 process.exit(fail ? 1 : 0);

--- a/server/scripts/bench-smoke.js
+++ b/server/scripts/bench-smoke.js
@@ -3,6 +3,7 @@ const { costUsd } = require("../../bench/lib/cost");
 const { summarize } = require("../../bench/lib/summarize");
 const { seededRand } = require("../../bench/lib/router");
 const livebench = require("../../bench/scorers/livebench");
+const arena = require("../../bench/scorers/arenahard");
 
 let pass = 0, fail = 0;
 const eq = (got, exp, msg) => {
@@ -41,6 +42,11 @@ eq(s["arbr-auto"].errors, 1, "arbr error counted");
 approx(s["arbr-auto"].qualityRetainedPct, 50, "arbr retained 50% of premium quality");
 approx(s["arbr-auto"].costPerQuery, 0.015, "arbr cost/query over 4 rows incl error");
 approx(s["always-premium"].costPerQuery, 0.10, "premium cost/query");
+
+// 5. Arena-Hard win mapping (candidate=B vs reference=A): better→win, tie→0.5, worse→0.
+eq(arena.winFromVerdict("better"), 1, "candidate better → win 1");
+eq(arena.winFromVerdict("equal"), 0.5, "tie → 0.5");
+eq(arena.winFromVerdict("worse"), 0, "candidate worse → 0");
 
 console.log(`${pass}/${pass + fail} passed`);
 process.exit(fail ? 1 : 0);

--- a/server/scripts/bench-smoke.js
+++ b/server/scripts/bench-smoke.js
@@ -1,0 +1,46 @@
+// Pure-logic smoke for the benchmark harness (no network / no keys). Run: npm run smoke:bench
+const { costUsd } = require("../../bench/lib/cost");
+const { summarize } = require("../../bench/lib/summarize");
+const { seededRand } = require("../../bench/lib/router");
+const livebench = require("../../bench/scorers/livebench");
+
+let pass = 0, fail = 0;
+const eq = (got, exp, msg) => {
+  const g = JSON.stringify(got), e = JSON.stringify(exp);
+  if (g === e) { pass++; } else { fail++; console.log(`FAIL: ${msg} — got ${g}, expected ${e}`); }
+};
+const approx = (got, exp, msg) => eq(Number(got.toFixed(4)), Number(exp.toFixed(4)), msg);
+
+const PRICES = { "gpt-4o": { in: 2.5, out: 10 }, "gpt-4o-mini": { in: 0.15, out: 0.6 } };
+
+// 1. cost = tokens × price; unknown model flagged.
+approx(costUsd("gpt-4o", { prompt_tokens: 1e6, completion_tokens: 1e6 }, PRICES).usd, 12.5, "gpt-4o cost");
+eq(costUsd("mystery", { prompt_tokens: 1000 }, PRICES).priced, false, "unknown model → unpriced flag");
+
+// 2. LiveBench objective scoring; non-objective categories not silently scored.
+eq(livebench.score({ category: "math", ground_truth: "42" }, "reasoning...\n\\boxed{42}").score, 1, "boxed match → 1");
+eq(livebench.score({ category: "math", ground_truth: "42" }, "the answer is 41").score, 0, "wrong → 0");
+eq(livebench.score({ category: "coding", ground_truth: "x" }, "def f(): ...").scored, false, "coding → needs official grader");
+
+// 3. seeded RNG is deterministic (reproducible "random" baseline).
+eq(seededRand(42, 3)(), seededRand(42, 3)(), "seededRand reproducible");
+
+// 4. summarize: quality over scored rows, cost/query, and vs-premium derivations.
+const rows = [
+  { baseline: "always-premium", category: "math", scored: true, score: 1, costUsd: 0.10, priced: true },
+  { baseline: "always-premium", category: "math", scored: true, score: 1, costUsd: 0.10, priced: true },
+  { baseline: "arbr-auto",      category: "math", scored: true, score: 1, costUsd: 0.02, priced: true },
+  { baseline: "arbr-auto",      category: "math", scored: true, score: 0, costUsd: 0.02, priced: true },
+  { baseline: "arbr-auto",      category: "coding", scored: false, score: null, costUsd: 0.02, priced: true }, // excluded from quality
+  { baseline: "arbr-auto",      category: "math", error: "boom" },
+];
+const s = summarize(rows);
+eq(s["always-premium"].quality, 1, "premium quality = 1.0");
+eq(s["arbr-auto"].quality, 0.5, "arbr quality = 1/2 scored (coding excluded)");
+eq(s["arbr-auto"].errors, 1, "arbr error counted");
+approx(s["arbr-auto"].qualityRetainedPct, 50, "arbr retained 50% of premium quality");
+approx(s["arbr-auto"].costPerQuery, 0.015, "arbr cost/query over 4 rows incl error");
+approx(s["always-premium"].costPerQuery, 0.10, "premium cost/query");
+
+console.log(`${pass}/${pass + fail} passed`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## What
Phase 0 + Phase 1 of the routing benchmark program. Arbr is a **router**, so this measures a **cost-vs-quality curve** (not a leaderboard score): for a fixed quality bar, how much cost Arbr's task-aware routing saves vs baselines. Headline metric matches RouteLLM's framing ("cost reduction at ≥95% of premium quality") plus a per-task-type breakdown and per-decision explainability — things RouteLLM can't produce.

Selected benchmarks: **LiveBench** (this PR), **Arena-Hard-Auto** (Phase 2), **SWE-bench Verified** (Phase 3). RouteLLM-OSS stays as a baseline router within them.

## In this PR
- `bench/PLAN.md`, `METHODOLOGY.md`, `README.md` — the spec, disclosure + reproducibility rules.
- `bench/config.js` — model pool + per-1M prices (disclosed with results).
- `bench/lib/` — gateway client (reads `X-Arbr-*` for served model + routing decision), deterministic cost, seeded router, pure `summarize()`.
- `bench/scorers/livebench.js` — objective categories scored (math/reasoning/data); coding/language/IF left to LiveBench's **official grader** (marked unscored, not guessed — keeps numbers honest).
- `bench/runner.js` + `aggregate.js` — run → score → raw jsonl → cost-vs-quality table + headline.
- `smoke:bench` (12/12), no network.

## Honesty / scope
- Model pool + prices disclosed; results are price-dependent.
- Objective LiveBench scoring only until the official grader is wired for the rest.
- Runs need Node 18 + **real API keys (real cost)** + a LiveBench dataset — done on a box with keys, not CI. This PR is the harness, not results.

## Verify
`npm run smoke:bench` → 12/12. `node --check` clean on all `bench/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)