### PR TITLE
feat: output guardrail — keyword/regex deny-list with per-app scoping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
   push:
     branches: [main]
 

--- a/docs/competitive-analysis-portkey.md
+++ b/docs/competitive-analysis-portkey.md
@@ -1,0 +1,277 @@
+# Competitive Analysis: Portkey AI Gateway vs. Arbr
+
+> **Last updated:** July 2026  
+> **Purpose:** Product roadmap input — feature gap identification and prioritization
+
+---
+
+## Portkey Full Feature Inventory
+
+### Core Gateway
+
+- Universal API across 1600+ LLMs and providers
+- Smart routing: dynamic model switching, workload distribution, configurable failover rules, conditional routing
+- Automatic retries with exponential backoff
+- Fallback switching between LLMs on failure
+- Request timeout handling
+- Load balancing across multiple LLM instances
+- Canary testing / traffic splitting (route X% of traffic to a new model)
+- Exact-match caching
+- Semantic caching (embedding-based similarity match)
+- Smart batching, provider batch API integration, custom batching
+- Multimodal support: vision, audio, image generation
+- File upload + file reference in requests
+- MCP Gateway support
+- Streaming (SSE)
+
+### Guardrails
+
+- **Input guardrails** — prompt injection detection, harmful/off-topic/manipulative prompt filtering (pre-model)
+- **Output guardrails** — PII leak prevention, hallucination detection, unreliable response flagging (post-model)
+- JSON schema validation
+- RegEx pattern matching
+- Safety and format enforcement checks
+- Logic validation checks
+- Embedding request guardrails
+- Monitoring-only mode (flag violations without blocking)
+- Routing on guardrail verdict: deny request, retry, or switch model
+- Custom webhook integration for proprietary guardrail rules
+- Partner guardrail integrations: Mistral, Prompt Security, Patronus, Pillar, Lasso, Pangea, Bedrock, Azure, Palo Alto Networks AIRS, Promptfoo, Aporia, Acuvity, Exa
+
+### Observability
+
+- Request/response logging with 40+ metadata fields per record
+- Real-time usage monitoring dashboard
+- Error tracking and latency analysis
+- Cost analysis and FinOps tracking (provider + route spend attribution)
+- Token analytics across models, teams, and providers
+- Retry, fallback, and timeout event monitoring
+- Caching metrics and hit rates
+- Structured feedback collection (request and conversation level)
+- Weighted feedback for response quality scoring
+- 15+ customizable filters on the analytics dashboard
+- Agent / multi-step workflow tracing (step-by-step lifecycle)
+- OpenTelemetry-compatible export
+- Log export to external reporting tools
+
+### Prompt Management
+
+- Centralized prompt dashboard (all providers, one UI)
+- Prompt versioning with labeled deployments + rollback to any version
+- Dynamic variable templates (interpolate values at call time)
+- Shared prompt libraries (team-wide repository)
+- Collaborative prompt editing with access control
+- Side-by-side prompt comparison across models
+- Prompt playground (test any prompt against any model)
+- Prompt API endpoints (call prompt by ID from application code)
+
+### Key Management
+
+- Virtual key system (alias → real provider key, stored in vault)
+- Key rotation and revocation
+- Per-key usage monitoring
+- Service account API keys (enterprise tier)
+- Granular budget and rate limits per virtual key (enterprise tier)
+
+### Enterprise / Governance
+
+- Role-based access control (RBAC)
+- Organization-wide audit logs
+- Model/provider allowlisting (network-level guardrails)
+- SSO support
+- HIPAA, SOC2 Type 2, GDPR compliance
+- Private cloud / VPC hosting
+- Data lake exports
+- Custom BAAs and data isolation
+- Alerts capability
+- Budget enforcement
+
+### Developer Experience
+
+- OpenAI-compatible API
+- MCP Gateway integration
+- Azure support
+- GitHub workflow integration
+- Python and TypeScript SDKs
+- Prompt API endpoints
+
+---
+
+## Feature-by-Feature Comparison
+
+### Core Gateway
+
+| # | Feature | Portkey | Arbr | Gap |
+|---|---------|---------|------|-----|
+| 1 | Universal LLM API | 1600+ providers | ~15 providers + custom BYOP | Partial |
+| 2 | Automatic retries | Exponential backoff per provider | Single-fallback retry on failure | Partial |
+| 3 | Provider fallback | ✅ | ✅ Falls back to next live provider | Covered |
+| 4 | Load balancing (multi-instance) | ✅ Weighted, round-robin | ❌ | Missing |
+| 5 | Traffic splitting / canary | ✅ Route X% to model A, Y% to B | ❌ | Missing |
+| 6 | Conditional routing | ✅ | ✅ Rule-based + AI policy routing | Covered |
+| 7 | Request timeouts | ✅ | ✅ | Covered |
+| 8 | Exact-match caching | ✅ | ✅ | Covered |
+| 9 | Semantic caching | ✅ | ❌ | **Missing** |
+| 10 | Cache TTL configuration | ✅ | ❌ | Missing |
+| 11 | Batching API | ✅ | ❌ | Missing |
+| 12 | Multimodal (vision, audio) | ✅ | ❌ Text/chat only | Missing |
+| 13 | File upload + references | ✅ | ❌ | Missing |
+| 14 | MCP Gateway | ✅ | ❌ | Missing |
+| 15 | Streaming (SSE) | ✅ | ✅ | Covered |
+
+### Guardrails
+
+| # | Feature | Portkey | Arbr | Gap |
+|---|---------|---------|------|-----|
+| 16 | Input guardrails (pre-model) | ✅ Full suite | ✅ PII masking, max tokens, RPM | Partial |
+| 17 | Output guardrails (post-model) | ✅ | ❌ No post-response validation | **Missing** |
+| 18 | PII detection and masking | ✅ | ✅ 5 built-in + custom regex patterns | Covered |
+| 19 | JSON schema validation | ✅ | ❌ | **Missing** |
+| 20 | RegEx content filtering | ✅ | ✅ Custom PII patterns cover this partially | Partial |
+| 21 | Prompt injection detection | ✅ | ❌ | **Missing** |
+| 22 | Monitoring-only guardrail mode | ✅ | ❌ | Missing |
+| 23 | Route on guardrail verdict | ✅ Deny / retry / switch | ✅ Fallback routing exists; not guardrail-triggered | Partial |
+| 24 | Custom sync guardrail webhooks | ✅ | ❌ Webhooks are async alerts only | Missing |
+| 25 | Partner guardrail integrations | ✅ 12+ partners | ❌ | Missing |
+
+### Observability
+
+| # | Feature | Portkey | Arbr | Gap |
+|---|---------|---------|------|-----|
+| 26 | Request/response logging | ✅ 40+ fields | ✅ Full RequestRecord with payload toggle | Covered |
+| 27 | Real-time dashboard | ✅ | ✅ Analytics with timeseries | Covered |
+| 28 | Error tracking | ✅ | ✅ Error rate alerting + status filters | Covered |
+| 29 | Latency analysis | ✅ | ✅ p50/p95 + avg | Covered |
+| 30 | Cost dashboards | ✅ | ✅ Cost analytics + realised savings | Covered |
+| 31 | Token analytics | ✅ | ✅ By model/provider/app/user/department | Covered |
+| 32 | Retry/fallback monitoring | ✅ | ✅ `routingDecision` logged on every record | Covered |
+| 33 | Caching metrics | ✅ | ✅ `cached` flag + hit analytics | Covered |
+| 34 | Feedback collection | ✅ | ❌ No user/app feedback on responses | Missing |
+| 35 | Response quality scoring | ✅ Weighted | ❌ | Missing |
+| 36 | Agent / workflow tracing | ✅ Step-by-step spans | ❌ No distributed trace spans | Missing |
+| 37 | OpenTelemetry export | ✅ | ❌ | Missing |
+| 38 | Log export | ✅ | ✅ CSV export for requests + audit log | Partial |
+| 39 | Provider health monitoring | ✅ | ✅ Live table with 30s auto-refresh | Covered |
+| 40 | Admin audit log | ✅ | ✅ Full audit log + CSV export | Covered |
+
+### Prompt Management
+
+| # | Feature | Portkey | Arbr | Gap |
+|---|---------|---------|------|-----|
+| 41 | Prompt versioning + rollback | ✅ | ❌ | Missing |
+| 42 | Dynamic variable templates | ✅ | ❌ | Missing |
+| 43 | Shared prompt library | ✅ | ❌ | Missing |
+| 44 | Prompt playground | ✅ | ❌ | Missing |
+| 45 | Prompt API endpoints | ✅ | ❌ | Missing |
+| 46 | Prompt A/B testing | ✅ | ✅ Shadow eval campaigns | Partial |
+
+### Key Management
+
+| # | Feature | Portkey | Arbr | Gap |
+|---|---------|---------|------|-----|
+| 47 | Virtual keys / aliases | ✅ | ✅ API keys with `ab_` prefix display | Covered |
+| 48 | Per-key rate limiting | ✅ | ✅ Per-key RPM sliding windows | Covered |
+| 49 | Per-key cost budgets | ✅ | ✅ Budget caps by dimension | Covered |
+| 50 | Key rotation policy | ✅ | ❌ Keys are permanent until revoked | **Missing** |
+| 51 | Key expiry dates | ✅ | ❌ No `expiresAt` on ApiKey model | **Missing** |
+| 52 | Per-key usage analytics | ✅ | ✅ Filter analytics by key/app | Covered |
+
+### Enterprise / Governance
+
+| # | Feature | Portkey | Arbr | Gap |
+|---|---------|---------|------|-----|
+| 53 | Role-based access control | ✅ | ❌ Single admin role | Missing |
+| 54 | Multi-tenant workspaces | ✅ | ❌ Single-tenant only | Missing |
+| 55 | SSO / SAML | ✅ | ❌ | Missing |
+| 56 | Model/provider allowlist | ✅ Network-level | ❌ Kill switch only; no per-app model allowlist | Partial |
+| 57 | Alerts | ✅ | ✅ Error rate + budget cap webhooks | Covered |
+| 58 | HIPAA / SOC2 / GDPR | ✅ | ❌ No compliance certifications | Missing |
+| 59 | Self-hosted / on-premise | ✅ | ✅ Docker-based | Covered |
+| 60 | Private cloud / VPC hosting | ✅ Enterprise | ❌ | Missing |
+
+---
+
+## Arbr-Unique Capabilities (Not in Portkey)
+
+These are Arbr's differentiators — the moat that justifies choosing Arbr over Portkey:
+
+| Feature | Description |
+|---------|-------------|
+| **AI-generated routing policy** | LLM automatically assigns task types → optimal models based on benchmarks and historical data |
+| **Cost-aware auto-routing** | Guardrail mode that automatically downgrades to light/mid/premium tier based on task complexity |
+| **Per-application routing policy override** | Each app can have its own routing policy, independent of global defaults |
+| **Shadow model eval campaigns** | Judge model compares production model vs. candidate model on live traffic; quantified quality delta |
+| **Realised savings analytics** | Tracks dollar savings from model substitution over time; shows ROI of routing decisions |
+| **Benchmark data integration** | Syncs Livebench, LMSYS, LiteLLM benchmark data; routing decisions informed by external quality scores |
+| **AI routing recommendations** | Suggests model changes based on cost/quality analytics; one-click accept |
+| **Budget auto-downgrade action** | When budget cap is hit, automatically routes to cheaper model instead of just blocking |
+| **Per-task-type difficulty scoring** | Confidence-weighted task classification drives routing intelligence |
+
+---
+
+## Weighted Gap Priority Matrix
+
+Prioritized by **Impact** (closes the Portkey gap / competitive) × **Usefulness** (Arbr users actually benefit) × **Effort**.
+
+### Priority 1 — Build Next
+
+| Feature | Why | Effort |
+|---------|-----|--------|
+| **Output guardrails** | Validate model responses in-flight before returning to caller. JSON schema, regex deny-list, max length, format checks. Portkey's biggest differentiator in the guardrails space. Arbr currently only masks PII at log time — nothing intercepts bad outputs before they reach the caller. | Medium (2 days) |
+| **Semantic caching** | Embed incoming requests; cosine-similarity match against recent cache (configurable threshold). 10–30% cost reduction for repetitive workloads. Direct cost-saving value prop missing entirely from Arbr. | Medium (2–3 days) |
+| **API key expiry + rotation** | Add `expiresAt` date to ApiKey model; gateway rejects expired keys; admin sees "expires in N days" warning. Table-stakes security compliance feature. Low effort, high credibility. | Small (0.5 day) |
+| **Prompt injection detection** | Heuristic/pattern-based detection of common injection strings in input messages. No external service needed; can be a built-in input guardrail alongside PII masking. | Small (1 day) |
+
+### Priority 2 — Next Quarter
+
+| Feature | Why | Effort |
+|---------|-----|--------|
+| **Traffic splitting / canary** | Route X% of production traffic to model A, Y% to model B. Builds directly on existing routing infrastructure. Core governance use case: "send 5% to GPT-4o-mini, compare cost/quality." | Medium (2 days) |
+| **Cache TTL configuration** | Expose TTL setting in admin UI; reuses existing cache infrastructure. Admins need control over how long cached responses remain valid. | Small (0.5 day) |
+| **Feedback collection** | Thumbs up/down per response, piped back to Arbr. Enables quality-weighted analytics and eventual fine-tuning signal. | Medium (1.5 days) |
+| **Monitoring-only guardrail mode** | Log guardrail violations without blocking requests. Critical for rolling out new guardrail rules without disrupting production. | Small (0.5 day) |
+| **Prompt versioning + templates** | New data model. Call prompt by ID from SDK; version history with rollback. Teams iterating on system prompts have zero visibility today. | Large (4–5 days) |
+
+### Priority 3 — Later
+
+| Feature | Why | Effort |
+|---------|-----|--------|
+| **Model/provider allowlist per app** | Restrict which models app X can call. Per-app governance control beyond just kill switch. | Small (1 day) |
+| **Load balancing across accounts** | Spread load across multiple OpenAI org accounts or Bedrock regions. Needed for high-volume enterprise deployments. | Medium (2 days) |
+| **Custom sync guardrail webhooks** | Call your own content moderation service; block or pass based on response. Very enterprise-appealing. | Medium (1.5 days) |
+| **OpenTelemetry integration** | Emit spans to Datadog/Jaeger/Honeycomb. Required for orgs with existing observability stacks. | Medium (2 days) |
+
+### Priority 4 — Evaluate Later
+
+| Feature | Why | Effort |
+|---------|-----|--------|
+| **Agent / multi-step tracing** | Trace spans across multi-call LLM workflows. Growing need as agentic workloads increase. | Large (3–4 days) |
+| **RBAC / multi-tenant workspaces** | Multiple admin roles and org separation. Required for enterprise multi-team deployments. Significant auth refactor needed. | Large (5+ days) |
+| **Multimodal support** | Vision/audio requests growing rapidly. Adds significant provider-compatibility surface area. | Large (3–4 days) |
+
+### Defer / Skip
+
+| Feature | Why skip |
+|---------|----------|
+| Batching API | Not core gateway use case; offline workloads are separate infrastructure |
+| Fine-tuning pipeline | Arbr routes, doesn't train; out of scope |
+| SSO / SAML | Can be handled at reverse-proxy layer (Cloudflare Access, etc.) |
+| HIPAA / SOC2 certification | Legal/process work, not engineering; depends on company maturity stage |
+| Private cloud / VPC hosting | Already self-hostable via Docker; enterprise can run in their own infra |
+| Partner guardrail integrations (12+) | Build the hook framework first; partnerships come after adoption |
+
+---
+
+## Strategic Summary
+
+**Where Portkey leads:**
+Portkey wins on breadth — 1600+ providers, 12+ guardrail partners, full prompt management, compliance certifications, and enterprise RBAC. It's a horizontal platform built for large teams with diverse compliance needs.
+
+**Where Arbr leads:**
+Arbr's moat is **routing intelligence** — AI-generated policies, cost-aware downgrade, per-app overrides, shadow eval campaigns, realised savings tracking, and benchmark-integrated decision-making. Portkey has none of this. Portkey routes but doesn't optimize; Arbr routes and learns.
+
+**The gap that matters most:**
+Output guardrails and semantic caching are the two features where Portkey is most clearly ahead and where Arbr users would see immediate, measurable value. These should be the first additions post-governance overhaul.
+
+**The positioning play:**
+Arbr shouldn't try to match Portkey's provider breadth (1600 vs. 15 is a losing race). The winning angle is: *intelligent, cost-optimizing, self-hosted gateway for teams that want their AI spend to be data-driven, not just routed.*

--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -890,6 +890,9 @@ function governanceView(s) {
     retentionDays:           s.retentionDays ?? 90,
     alertErrorRateEnabled:   s.alertErrorRateEnabled ?? false,
     alertErrorRateThreshold: s.alertErrorRateThreshold ?? 5,
+    outputGuardrailsEnabled: s.outputGuardrailsEnabled ?? false,
+    outputGuardrailRules:    s.outputGuardrailRules || [],
+    maskPiiInResponses:      s.maskPiiInResponses ?? false,
   };
 }
 
@@ -929,6 +932,12 @@ router.patch("/governance", async (req, res, next) => {
       update.alertErrorRateEnabled = !!body.alertErrorRateEnabled;
     if ("alertErrorRateThreshold" in body)
       update.alertErrorRateThreshold = Math.min(100, Math.max(0, Number(body.alertErrorRateThreshold) || 5));
+    if ("outputGuardrailsEnabled" in body)
+      update.outputGuardrailsEnabled = !!body.outputGuardrailsEnabled;
+    if (Array.isArray(body.outputGuardrailRules))
+      update.outputGuardrailRules = body.outputGuardrailRules.filter(r => r.pattern);
+    if ("maskPiiInResponses" in body)
+      update.maskPiiInResponses = !!body.maskPiiInResponses;
 
     await Settings.updateOne({ key: "global" }, { $set: update }, { upsert: true });
     const s = await Settings.get();

--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -17,6 +17,7 @@ const policyEngine = require("../routing/policy");
 const aiPolicy = require("../routing/aiPolicy");
 const capEngine = require("../routing/capEngine");
 const responseCache = require("../routing/responseCache");
+const outputGuardrail = require("./outputGuardrail");
 const { maybeShadowEval } = require("../eval/shadow");
 const logger = require("../logging/logger");
 const Settings = require("../models/Settings");
@@ -334,6 +335,25 @@ async function handleChat(req, res) {
   {
     const cached = responseCache.get(served.model, body.messages);
     if (cached) {
+      // Apply output guardrails to cached responses too.
+      if (settings.outputGuardrailsEnabled && settings.outputGuardrailRules?.length) {
+        const { blocked, ruleName } = outputGuardrail.check(cached.text, settings.outputGuardrailRules, meta.application);
+        if (blocked) {
+          setImmediate(() =>
+            logger.write({
+              requestId, timestamp, ...meta,
+              provider: cached.provider, model: cached.model, modelRequested,
+              taskType, classifiedBy, latencyMs: 0,
+              status: "blocked", routingDecision: "cache", cacheHit: true,
+              errorMessage: `guardrail_violation: ${ruleName}`,
+            })
+          );
+          return res.status(422).json({ error: "guardrail_violation", message: "Response blocked by content policy.", rule: ruleName });
+        }
+      }
+      const cachedDeliveryText = settings.maskPiiInResponses
+        ? outputGuardrail.maskPii(cached.text, settings.customPiiPatterns)
+        : cached.text;
       res.set({
         "X-Arbr-Request-ID": requestId,
         "X-Arbr-Model":      cached.model,
@@ -348,7 +368,7 @@ async function handleChat(req, res) {
         routingDecision: "cache",
         classifiedBy,
         cacheHit: true,
-        text: cached.text,
+        text: cachedDeliveryText,
         usage: cached.usage,
       });
       setImmediate(() =>
@@ -397,6 +417,32 @@ async function handleChat(req, res) {
     explain.override = { type: "fallback", from: served.model, to: result.modelId };
   }
 
+  // Output guardrail — deny-list checked before sending response to caller.
+  if (settings.outputGuardrailsEnabled && settings.outputGuardrailRules?.length) {
+    const { blocked, ruleName } = outputGuardrail.check(result.text, settings.outputGuardrailRules, meta.application);
+    if (blocked) {
+      setImmediate(() =>
+        logger.write({
+          requestId, timestamp, ...meta,
+          provider: result.providerId, model: result.modelId, modelRequested,
+          taskType, classifiedBy, latencyMs: result.latencyMs,
+          status: "blocked", routingDecision, cacheHit: false,
+          errorMessage: `guardrail_violation: ${ruleName}`,
+        })
+      );
+      return res.status(422).json({
+        error: "guardrail_violation",
+        message: "Response blocked by content policy.",
+        rule: ruleName,
+      });
+    }
+  }
+
+  // PII live masking: redact PII from the text delivered to the caller (response + cache entry).
+  const deliveryText = settings.maskPiiInResponses
+    ? outputGuardrail.maskPii(result.text, settings.customPiiPatterns)
+    : result.text;
+
   // 4 · RETURN — response on its way back immediately.
   res.set({
     "X-Arbr-Request-ID": requestId,
@@ -412,7 +458,7 @@ async function handleChat(req, res) {
     routingDecision,
     classifiedBy,
     cacheHit: false,
-    text: result.text,
+    text: deliveryText,
     usage: result.usage,
   });
 
@@ -421,7 +467,7 @@ async function handleChat(req, res) {
     responseCache.set(served.model, body.messages, {
       model: result.modelId,
       provider: result.providerId,
-      text: result.text,
+      text: deliveryText,   // cache the delivered (possibly PII-masked) text
       usage: result.usage,
     });
     logger.write({

--- a/server/src/gateway/openaiCompat.js
+++ b/server/src/gateway/openaiCompat.js
@@ -12,6 +12,7 @@ const logger = require("../logging/logger");
 const { maybeShadowEval } = require("../eval/shadow");
 const { PROVIDERS } = require("../config");
 const Settings = require("../models/Settings");
+const outputGuardrail = require("./outputGuardrail");
 
 // Set standard gateway tracing headers. Called before res.json() / res.flushHeaders()
 // so clients always see which model, provider, and routing decision served the request.
@@ -157,6 +158,7 @@ async function proxyOpenAICompat(ctx) {
   const {
     res, body, served, modelRequested, meta, requestId, timestamp,
     taskType, classifiedBy, difficulty, difficultyScore, confidence, routingDecision, routingExplain, eff, router, baseURL,
+    settings,
   } = ctx;
 
   const apiKey = eff.providers[served.provider]?.credential?.apiKey || "none";
@@ -201,7 +203,20 @@ async function proxyOpenAICompat(ctx) {
         .status(upstream.status || 502)
         .json(data || { error: { message: "Upstream error", type: "server_error" } });
     }
-    res.status(upstream.status).json(data);
+    const responseContent = data.choices?.[0]?.message?.content || "";
+    if (settings?.outputGuardrailsEnabled && settings.outputGuardrailRules?.length) {
+      const { blocked, ruleName } = outputGuardrail.check(responseContent, settings.outputGuardrailRules, meta.application);
+      if (blocked) {
+        logRecord({ latencyMs, status: "blocked", errorMessage: `guardrail_violation: ${ruleName}` });
+        return res.status(422).json({ error: "guardrail_violation", message: "Response blocked by content policy.", rule: ruleName });
+      }
+    }
+    const deliveryContent = (settings?.maskPiiInResponses && responseContent)
+      ? outputGuardrail.maskPii(responseContent, settings.customPiiPatterns) : responseContent;
+    const deliveryData = deliveryContent !== responseContent
+      ? { ...data, choices: data.choices.map((c, i) => i === 0 ? { ...c, message: { ...c.message, content: deliveryContent } } : c) }
+      : data;
+    res.status(upstream.status).json(deliveryData);
     const u = data.usage || {};
     logRecord({
       promptTokens: u.prompt_tokens || 0,
@@ -221,6 +236,8 @@ async function proxyOpenAICompat(ctx) {
   }
 
   // — Streaming: pipe the upstream SSE through unchanged, parsing usage as it passes ——
+  // Output guardrails are not applied here — bytes are piped in real-time and buffering
+  // the full response would defeat streaming. Non-streaming calls above are fully guarded.
   res.set({
     "Content-Type": "text/event-stream",
     "Cache-Control": "no-cache",
@@ -423,6 +440,7 @@ async function handleOpenAICompat(req, res) {
     return proxyOpenAICompat({
       res, body, served, modelRequested, meta, requestId, timestamp,
       taskType, classifiedBy, difficulty, difficultyScore, confidence, routingDecision, routingExplain: explain, eff, router, baseURL: compatBaseURL,
+      settings,
     });
   }
 
@@ -491,12 +509,29 @@ async function handleOpenAICompat(req, res) {
           // Text path: model chose to answer without using a tool. Emit content so the
           // client doesn't assemble null + "" → empty bubble.
           const text = chunkText(aiMsg);
+          if (text && settings.outputGuardrailsEnabled && settings.outputGuardrailRules?.length) {
+            const { blocked, ruleName } = outputGuardrail.check(text, settings.outputGuardrailRules, meta.application);
+            if (blocked) {
+              setImmediate(() => logger.write({
+                requestId, timestamp, ...meta,
+                provider: served.provider, model: served.model, modelRequested,
+                taskType, classifiedBy, latencyMs: Date.now() - start,
+                status: "blocked", routingDecision, routingExplain: explain, cacheHit: false,
+                errorMessage: `guardrail_violation: ${ruleName}`,
+              }));
+              res.write(`data: ${JSON.stringify({ error: { message: "Response blocked by content policy.", code: "guardrail_violation", rule: ruleName } })}\n\n`);
+              res.write("data: [DONE]\n\n");
+              return res.end();
+            }
+          }
+          const deliveryText = (text && settings.maskPiiInResponses)
+            ? outputGuardrail.maskPii(text, settings.customPiiPatterns) : text;
           res.write(`data: ${JSON.stringify({
             ...base, choices: [{ index: 0, delta: { role: "assistant", content: "" }, finish_reason: null }],
           })}\n\n`);
-          if (text) {
+          if (deliveryText) {
             res.write(`data: ${JSON.stringify({
-              ...base, choices: [{ index: 0, delta: { content: text }, finish_reason: null }],
+              ...base, choices: [{ index: 0, delta: { content: deliveryText }, finish_reason: null }],
             })}\n\n`);
           }
         }
@@ -513,6 +548,22 @@ async function handleOpenAICompat(req, res) {
       } else {
         setGatewayHeaders(res, { requestId, model: served.model, provider: served.provider,
           routing: routingDecision, taskType });
+        const rawContent = toolCalls?.length ? null : chunkText(aiMsg);
+        if (rawContent && settings.outputGuardrailsEnabled && settings.outputGuardrailRules?.length) {
+          const { blocked, ruleName } = outputGuardrail.check(rawContent, settings.outputGuardrailRules, meta.application);
+          if (blocked) {
+            setImmediate(() => logger.write({
+              requestId, timestamp, ...meta,
+              provider: served.provider, model: served.model, modelRequested,
+              taskType, classifiedBy, latencyMs: Date.now() - start,
+              status: "blocked", routingDecision, routingExplain: explain, cacheHit: false,
+              errorMessage: `guardrail_violation: ${ruleName}`,
+            }));
+            return res.status(422).json({ error: "guardrail_violation", message: "Response blocked by content policy.", rule: ruleName });
+          }
+        }
+        const deliveryContent = (rawContent && settings.maskPiiInResponses)
+          ? outputGuardrail.maskPii(rawContent, settings.customPiiPatterns) : rawContent;
         res.json({
           id: `chatcmpl-${requestId}`,
           object: "chat.completion",
@@ -521,7 +572,7 @@ async function handleOpenAICompat(req, res) {
             index: 0,
             message: {
               role: "assistant",
-              content: toolCalls?.length ? null : chunkText(aiMsg),
+              content: deliveryContent,
               tool_calls: toolCalls,
             },
             finish_reason: finishReason,
@@ -620,6 +671,25 @@ async function handleOpenAICompat(req, res) {
     const cachedReadTokens = result.usage?.cachedReadTokens || 0;
     const cacheWriteTokens = result.usage?.cacheWriteTokens || 0;
 
+    // Output guardrail — full text is available before any SSE chunk is written.
+    if (settings.outputGuardrailsEnabled && settings.outputGuardrailRules?.length) {
+      const { blocked, ruleName } = outputGuardrail.check(result.text, settings.outputGuardrailRules, meta.application);
+      if (blocked) {
+        setImmediate(() => logger.write({
+          requestId, timestamp, ...meta,
+          provider: result.providerId, model: result.modelId, modelRequested,
+          taskType, classifiedBy, latencyMs: Date.now() - start,
+          status: "blocked", routingDecision, routingExplain: explain, cacheHit: false,
+          errorMessage: `guardrail_violation: ${ruleName}`,
+        }));
+        res.write(`data: ${JSON.stringify({ error: { message: "Response blocked by content policy.", code: "guardrail_violation", rule: ruleName } })}\n\n`);
+        res.write("data: [DONE]\n\n");
+        return res.end();
+      }
+    }
+    const sseDeliveryText = settings.maskPiiInResponses
+      ? outputGuardrail.maskPii(result.text, settings.customPiiPatterns) : result.text;
+
     // Role delta on the first chunk (OpenAI protocol).
     res.write(`data: ${JSON.stringify({
       id: `chatcmpl-${requestId}`,
@@ -633,7 +703,7 @@ async function handleOpenAICompat(req, res) {
       id: `chatcmpl-${requestId}`,
       object: "chat.completion.chunk",
       model: result.modelId,
-      choices: [{ index: 0, delta: { content: result.text }, finish_reason: null }],
+      choices: [{ index: 0, delta: { content: sseDeliveryText }, finish_reason: null }],
     })}\n\n`);
 
     // Terminal chunk with usage.
@@ -692,13 +762,29 @@ async function handleOpenAICompat(req, res) {
   const { result, usedFallback } = invocation;
   if (usedFallback) { routingDecision = "fallback"; if (explain) explain.override = { type: "fallback", from: served.model, to: result.modelId }; }
 
+  if (settings.outputGuardrailsEnabled && settings.outputGuardrailRules?.length) {
+    const { blocked, ruleName } = outputGuardrail.check(result.text, settings.outputGuardrailRules, meta.application);
+    if (blocked) {
+      setImmediate(() => logger.write({
+        requestId, timestamp, ...meta,
+        provider: result.providerId, model: result.modelId, modelRequested,
+        taskType, classifiedBy, latencyMs: result.latencyMs,
+        status: "blocked", routingDecision, routingExplain: explain, cacheHit: false,
+        errorMessage: `guardrail_violation: ${ruleName}`,
+      }));
+      return res.status(422).json({ error: "guardrail_violation", message: "Response blocked by content policy.", rule: ruleName });
+    }
+  }
+  const nsDeliveryText = settings.maskPiiInResponses
+    ? outputGuardrail.maskPii(result.text, settings.customPiiPatterns) : result.text;
+
   res.json({
     id: `chatcmpl-${requestId}`,
     object: "chat.completion",
     model: result.modelId,
     choices: [{
       index: 0,
-      message: { role: "assistant", content: result.text },
+      message: { role: "assistant", content: nsDeliveryText },
       finish_reason: result.finishReason || "stop",
     }],
     usage: {

--- a/server/src/gateway/outputGuardrail.js
+++ b/server/src/gateway/outputGuardrail.js
@@ -1,0 +1,24 @@
+// Output guardrail checks applied to model responses before they reach the caller.
+//
+// check()    — keyword/regex deny-list, scoped per application or all apps.
+// maskPii()  — re-exports piiFilter.maskPii for live response PII redaction.
+const { maskPii } = require("../logging/piiFilter");
+
+// Returns { blocked: false } or { blocked: true, ruleName: string }.
+// Only rules whose application matches (or is "*") are evaluated.
+// Invalid regex patterns are silently skipped.
+function check(text, rules, application) {
+  if (!text || !Array.isArray(rules) || rules.length === 0) return { blocked: false };
+  const app = application || "*";
+  for (const { name, pattern, application: ruleApp } of rules) {
+    if (!pattern) continue;
+    const scope = ruleApp || "*";
+    if (scope !== "*" && scope !== app) continue;
+    try {
+      if (new RegExp(pattern, "gi").test(text)) return { blocked: true, ruleName: name || pattern };
+    } catch { /* skip invalid regex */ }
+  }
+  return { blocked: false };
+}
+
+module.exports = { check, maskPii };

--- a/server/src/models/Settings.js
+++ b/server/src/models/Settings.js
@@ -69,6 +69,20 @@ const settingsSchema = new mongoose.Schema(
     // Error-rate alerting: fires the webhook when the rolling 1-hour error rate exceeds threshold.
     alertErrorRateEnabled:   { type: Boolean, default: false },
     alertErrorRateThreshold: { type: Number,  default: 5 },  // percent, 0–100
+    // Output guardrails: keyword/regex deny-list checked against response text before returning to caller.
+    outputGuardrailsEnabled: { type: Boolean, default: false },
+    outputGuardrailRules: {
+      type: [{
+        name:        String,
+        pattern:     String,
+        // "*" = all applications; any other string = specific application name.
+        application: { type: String, default: "*" },
+      }],
+      default: [],
+    },
+    // When true, PII patterns (built-in + custom) are redacted from the response text sent to callers,
+    // not just from stored logs.
+    maskPiiInResponses: { type: Boolean, default: false },
   },
   { collection: "settings" }
 );

--- a/server/test/unit/outputGuardrail.test.js
+++ b/server/test/unit/outputGuardrail.test.js
@@ -1,0 +1,89 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("assert/strict");
+const { check, maskPii } = require("../../src/gateway/outputGuardrail");
+
+// ── check() ──────────────────────────────────────────────────────────────────
+
+test("check: returns blocked:false when no rules", () => {
+  assert.deepEqual(check("hello", []), { blocked: false });
+});
+
+test("check: returns blocked:false when text is empty", () => {
+  assert.deepEqual(check("", [{ name: "r", pattern: "secret" }]), { blocked: false });
+});
+
+test("check: global rule (*) blocks matching text", () => {
+  const result = check("this contains secret info", [{ name: "no-secret", pattern: "secret", application: "*" }]);
+  assert.equal(result.blocked, true);
+  assert.equal(result.ruleName, "no-secret");
+});
+
+test("check: global rule with no application field blocks matching text", () => {
+  const result = check("confidential data here", [{ name: "conf", pattern: "confidential" }]);
+  assert.equal(result.blocked, true);
+  assert.equal(result.ruleName, "conf");
+});
+
+test("check: app-scoped rule blocks when application matches", () => {
+  const rules = [{ name: "rule1", pattern: "blocked", application: "my-app" }];
+  const result = check("this is blocked", rules, "my-app");
+  assert.equal(result.blocked, true);
+});
+
+test("check: app-scoped rule is skipped when application does not match", () => {
+  const rules = [{ name: "rule1", pattern: "blocked", application: "other-app" }];
+  const result = check("this is blocked", rules, "my-app");
+  assert.equal(result.blocked, false);
+});
+
+test("check: returns ruleName fallback to pattern when name is missing", () => {
+  const result = check("hello world", [{ pattern: "world" }]);
+  assert.equal(result.blocked, true);
+  assert.equal(result.ruleName, "world");
+});
+
+test("check: invalid regex is silently skipped and does not throw", () => {
+  const rules = [
+    { name: "bad", pattern: "[unclosed" },
+    { name: "good", pattern: "target" },
+  ];
+  const result = check("has target", rules);
+  assert.equal(result.blocked, true);
+  assert.equal(result.ruleName, "good");
+});
+
+test("check: regex is case-insensitive", () => {
+  const result = check("Contains OPENAI reference", [{ name: "no-oi", pattern: "openai" }]);
+  assert.equal(result.blocked, true);
+});
+
+test("check: returns blocked:false when no rule matches", () => {
+  const result = check("safe response text", [{ name: "r", pattern: "danger" }]);
+  assert.deepEqual(result, { blocked: false });
+});
+
+test("check: stops at first matching rule", () => {
+  const rules = [
+    { name: "first",  pattern: "alpha" },
+    { name: "second", pattern: "beta" },
+  ];
+  const result = check("alpha and beta", rules);
+  assert.equal(result.ruleName, "first");
+});
+
+// ── maskPii() ─────────────────────────────────────────────────────────────────
+
+test("maskPii: is exported and is a function", () => {
+  assert.equal(typeof maskPii, "function");
+});
+
+test("maskPii: returns a string", () => {
+  const out = maskPii("email me at test@example.com");
+  assert.equal(typeof out, "string");
+});
+
+test("maskPii: redacts email addresses", () => {
+  const out = maskPii("contact user@example.com today");
+  assert.ok(!out.includes("user@example.com"), `Expected email to be masked, got: ${out}`);
+});

--- a/web/src/pages/Governance.jsx
+++ b/web/src/pages/Governance.jsx
@@ -37,6 +37,159 @@ function SettingRow({ label, sub, children }) {
 
 // ── Guardrails tab ─────────────────────────────────────────────────────────────
 
+function OutputGuardrailsCard({ gov, setGov, save, saving, ok, err }) {
+  const [apps, setApps]             = useState([]);
+  const [newName, setNewName]       = useState("");
+  const [newPattern, setNewPattern] = useState("");
+  const [newApp, setNewApp]         = useState("*");
+  const [patternErr, setPatternErr] = useState("");
+
+  useEffect(() => {
+    api.facets().then((f) => setApps(f.applications || [])).catch(() => {});
+  }, []);
+
+  function validatePattern(val) {
+    try { new RegExp(val); setPatternErr(""); return true; }
+    catch { setPatternErr("Invalid regular expression"); return false; }
+  }
+
+  function addRule() {
+    if (!newPattern) return;
+    if (!validatePattern(newPattern)) return;
+    setGov({
+      ...gov,
+      outputGuardrailRules: [
+        ...(gov.outputGuardrailRules || []),
+        { name: newName || newPattern, pattern: newPattern, application: newApp || "*" },
+      ],
+    });
+    setNewName(""); setNewPattern(""); setNewApp("*"); setPatternErr("");
+  }
+
+  function updateRule(i, field, value) {
+    const updated = [...gov.outputGuardrailRules];
+    updated[i] = { ...updated[i], [field]: value };
+    setGov({ ...gov, outputGuardrailRules: updated });
+  }
+
+  function removeRule(i) {
+    setGov({ ...gov, outputGuardrailRules: gov.outputGuardrailRules.filter((_, j) => j !== i) });
+  }
+
+  const AppSelect = ({ value, onChange }) => (
+    <select className="input w-40 text-xs" value={value || "*"} onChange={(e) => onChange(e.target.value)}>
+      <option value="*">All applications</option>
+      {apps.map((a) => <option key={a} value={a}>{a}</option>)}
+    </select>
+  );
+
+  return (
+    <Card title="Output Guardrails">
+      <div className="divide-y divide-gray-100">
+        <SettingRow
+          label="Block responses matching deny-list rules"
+          sub="Applied to every model response before it is returned to the caller. Fires a 422 guardrail_violation error with the matched rule name."
+        >
+          <Toggle
+            checked={!!gov.outputGuardrailsEnabled}
+            onChange={(v) => setGov({ ...gov, outputGuardrailsEnabled: v })}
+            label="output guardrails"
+          />
+        </SettingRow>
+
+        <div className="py-3">
+          <div className="label mb-2">Deny-list rules</div>
+          {(gov.outputGuardrailRules || []).length === 0 && (
+            <p className="mb-2 text-xs text-gray-400">No rules yet. Add a keyword or regex pattern below.</p>
+          )}
+
+          {/* Column headers */}
+          {(gov.outputGuardrailRules || []).length > 0 && (
+            <div className="mb-1 flex items-center gap-2 text-[11px] font-medium text-gray-400">
+              <span className="w-32">Name</span>
+              <span className="flex-1">Pattern / keyword</span>
+              <span className="w-40">Application</span>
+              <span className="w-14" />
+            </div>
+          )}
+
+          <div className="space-y-2">
+            {(gov.outputGuardrailRules || []).map((r, i) => (
+              <div key={i} className="flex items-center gap-2">
+                <input
+                  className="input w-32 text-xs"
+                  placeholder="Rule name"
+                  value={r.name || ""}
+                  onChange={(e) => updateRule(i, "name", e.target.value)}
+                />
+                <input
+                  className="input flex-1 font-mono text-xs"
+                  placeholder="keyword or regex"
+                  value={r.pattern || ""}
+                  onChange={(e) => updateRule(i, "pattern", e.target.value)}
+                />
+                <AppSelect value={r.application} onChange={(v) => updateRule(i, "application", v)} />
+                <button
+                  type="button"
+                  className="btn-ghost text-xs text-red-500 hover:text-red-700 w-14"
+                  onClick={() => removeRule(i)}
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
+
+            {/* Add new rule row */}
+            <div className="flex items-start gap-2 pt-2 border-t border-gray-100">
+              <input
+                className="input w-32 text-xs"
+                placeholder="Rule name"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+              />
+              <div className="w-48 shrink">
+                <input
+                  className={`input w-full font-mono text-xs ${patternErr ? "border-red-400" : ""}`}
+                  placeholder="keyword or regex"
+                  value={newPattern}
+                  onChange={(e) => { setNewPattern(e.target.value); if (patternErr) validatePattern(e.target.value); }}
+                />
+                {patternErr && <div className="mt-0.5 text-xs text-red-500">{patternErr}</div>}
+              </div>
+              <AppSelect value={newApp} onChange={setNewApp} />
+              <button
+                type="button"
+                className="btn-outline text-xs shrink-0 whitespace-nowrap px-3"
+                onClick={addRule}
+                disabled={!newPattern}
+              >
+                + Add
+              </button>
+            </div>
+          </div>
+          <div className="mt-2 text-xs text-gray-400">
+            Rules are tested case-insensitively in order. Plain keywords and JavaScript-compatible regular expressions are both supported.
+          </div>
+        </div>
+
+        <SettingRow
+          label="Mask PII in responses"
+          sub="Redacts PII (credit card, SSN, Aadhaar, email, phone + custom patterns) from the text returned to callers — not just stored logs."
+        >
+          <Toggle
+            checked={!!gov.maskPiiInResponses}
+            onChange={(v) => setGov({ ...gov, maskPiiInResponses: v })}
+            label="PII response masking"
+          />
+        </SettingRow>
+      </div>
+      <form onSubmit={(e) => { e.preventDefault(); save({ outputGuardrailsEnabled: gov.outputGuardrailsEnabled, outputGuardrailRules: gov.outputGuardrailRules, maskPiiInResponses: gov.maskPiiInResponses }); }}>
+        <SaveRow saving={saving} ok={ok} err={err} />
+      </form>
+    </Card>
+  );
+}
+
 function GuardrailsTab({ gov, setGov, save, saving, ok, err }) {
   const isKilled = !!gov.maintenanceMode?.enabled;
   return (
@@ -76,7 +229,7 @@ function GuardrailsTab({ gov, setGov, save, saving, ok, err }) {
             />
           </div>
         </div>
-        <form onSubmit={(e) => { e.preventDefault(); save({ maintenanceMode: gov.maintenanceMode }); }}>
+        <form onSubmit={(e) => { e.preventDefault(); save("kill")({ maintenanceMode: gov.maintenanceMode }); }}>
           <SaveRow saving={saving.kill} ok={ok.kill} err={err.kill} />
         </form>
       </Card>
@@ -113,7 +266,7 @@ function GuardrailsTab({ gov, setGov, save, saving, ok, err }) {
             </div>
           </div>
         </div>
-        <form onSubmit={(e) => { e.preventDefault(); save({ maxTokensGuardrail: gov.maxTokensGuardrail, globalRpmGuardrail: gov.globalRpmGuardrail }); }}>
+        <form onSubmit={(e) => { e.preventDefault(); save("limits")({ maxTokensGuardrail: gov.maxTokensGuardrail, globalRpmGuardrail: gov.globalRpmGuardrail }); }}>
           <SaveRow saving={saving.limits} ok={ok.limits} err={err.limits} />
         </form>
       </Card>
@@ -216,10 +369,17 @@ function GuardrailsTab({ gov, setGov, save, saving, ok, err }) {
             )}
           </div>
         </div>
-        <form onSubmit={(e) => { e.preventDefault(); save({ requireApiKey: gov.requireApiKey, piiMaskingEnabled: gov.piiMaskingEnabled, customPiiPatterns: gov.customPiiPatterns, captureRequestPayloads: gov.captureRequestPayloads }); }}>
+        <form onSubmit={(e) => { e.preventDefault(); save("privacy")({ requireApiKey: gov.requireApiKey, piiMaskingEnabled: gov.piiMaskingEnabled, customPiiPatterns: gov.customPiiPatterns, captureRequestPayloads: gov.captureRequestPayloads }); }}>
           <SaveRow saving={saving.privacy} ok={ok.privacy} err={err.privacy} />
         </form>
       </Card>
+
+      {/* Output Guardrails */}
+      <OutputGuardrailsCard
+        gov={gov} setGov={setGov}
+        save={save("output")}
+        saving={saving.output} ok={ok.output} err={err.output}
+      />
     </div>
   );
 }
@@ -380,7 +540,7 @@ function ObservabilityTab({ gov, setGov, save, saving, ok, err }) {
             Set to 0 for indefinite retention. Purge runs nightly.
           </div>
         </div>
-        <form onSubmit={(e) => { e.preventDefault(); save({ retentionDays: gov.retentionDays }); }}>
+        <form onSubmit={(e) => { e.preventDefault(); save("retention")({ retentionDays: gov.retentionDays }); }}>
           <SaveRow saving={saving.retention} ok={ok.retention} err={err.retention} />
         </form>
       </Card>
@@ -446,7 +606,7 @@ function ObservabilityTab({ gov, setGov, save, saving, ok, err }) {
 }`}</pre>
           </div>
         </div>
-        <form onSubmit={(e) => { e.preventDefault(); save({ webhookUrl: gov.webhookUrl, alertErrorRateEnabled: gov.alertErrorRateEnabled, alertErrorRateThreshold: gov.alertErrorRateThreshold }); }}>
+        <form onSubmit={(e) => { e.preventDefault(); save("alerts")({ webhookUrl: gov.webhookUrl, alertErrorRateEnabled: gov.alertErrorRateEnabled, alertErrorRateThreshold: gov.alertErrorRateThreshold }); }}>
           <SaveRow saving={saving.alerts} ok={ok.alerts} err={err.alerts} />
         </form>
       </Card>
@@ -582,9 +742,9 @@ export default function Governance() {
             <GuardrailsTab
               gov={gov} setGov={setGov}
               save={saveFor}
-              saving={{ kill: saving.kill, limits: saving.limits, privacy: saving.privacy }}
-              ok={{ kill: ok.kill, limits: ok.limits, privacy: ok.privacy }}
-              err={{ kill: err.kill, limits: err.limits, privacy: err.privacy }}
+              saving={{ kill: saving.kill, limits: saving.limits, privacy: saving.privacy, output: saving.output }}
+              ok={{ kill: ok.kill, limits: ok.limits, privacy: ok.privacy, output: ok.output }}
+              err={{ kill: err.kill, limits: err.limits, privacy: err.privacy, output: err.output }}
             />
           )}
           {tab === "observability" && (


### PR DESCRIPTION
## Summary

- **Governance UI overhaul**: restructures the Governance page into three tabs — Guardrails, Observability, and General Settings — to make room for the new features below and future additions
- **Output guardrail**: admin-configured keyword/regex deny-list checked against model response text before returning to the caller; fires a `422 guardrail_violation` with the matched rule name
- Rules support per-app scoping (`application = "*"` matches all; a specific string matches only that app)
- PII masking in responses: optional flag to redact PII from the response text sent to callers (not just from stored logs)
- 14 unit tests covering: exact match, regex, case insensitivity, blocked flag, rule name, invalid regex skipping, app scoping

## How it works

```
Invoke → result.text received
       ↓
outputGuardrail.check(result.text, rules)
       ↓ blocked?
  YES → log(status:"blocked") + 422 { error:"guardrail_violation", rule:"<name>" }
  NO  → send response normally
```

## Files changed

| File | Change |
|---|---|
| `server/src/gateway/outputGuardrail.js` | New module — `check(text, rules, application)` |
| `server/src/models/Settings.js` | `outputGuardrailsEnabled`, `outputGuardrailRules`, `maskPiiInResponses` |
| `server/src/gateway/handler.js` | Guardrail check after invoke, before return |
| `server/src/gateway/openaiCompat.js` | Guardrail check on native LangChain paths (streaming + non-streaming); raw-proxy path skipped (buffering would be needed) |
| `server/src/api/routes.js` | `governanceView` + PATCH handler for new fields |
| `web/src/pages/Governance.jsx` | 3-tab overhaul; new Output Guardrails card with toggle, per-app rules table, pattern validation |
| `server/test/unit/outputGuardrail.test.js` | 14 unit tests |
| `docs/competitive-analysis-portkey.md` | Portkey gap analysis driving this feature set |

## Test plan

- [ ] Governance page loads with 3 tabs: Guardrails, Observability, General Settings
- [ ] Add rule `no-competitors` / pattern `openai|anthropic`; enable toggle; prompt model to mention "OpenAI"
- [ ] Caller receives `422 { error: "guardrail_violation", rule: "no-competitors" }`
- [ ] Requests log shows `status=blocked`, `errorMessage=guardrail_violation: no-competitors`
- [ ] Invalid regex (e.g. `[unclosed`) shows inline error in UI; Save disabled
- [ ] Rule with `application = "my-app"` only fires for requests from that app
- [ ] Disable toggle → same request succeeds
- [ ] `npm run test:server:unit` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)