### PR TITLE
fix(ops): honour deploy TAG under sudo so rollback actually works

### DIFF
--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -12,7 +12,8 @@ set -euo pipefail
 
 REPO="$HOME/arbr-ai-control-plane"
 IMAGE="ghcr.io/project-arbr/arbr-control-plane"
-COMPOSE="sudo docker compose -f docker-compose.yml -f docker-compose.gcp.yml -f docker-compose.deploy.yml"
+COMPOSE_FILES="-f docker-compose.yml -f docker-compose.gcp.yml -f docker-compose.deploy.yml"
+COMPOSE="sudo docker compose $COMPOSE_FILES"
 PREV_FILE="$HOME/.arbr-deploy-prev"
 HEALTH="http://localhost:4100/health"
 API="http://localhost:4100/api"
@@ -39,8 +40,12 @@ notify() {  # $1 = message text
   [ -n "$url" ] && curl -s -X POST "$url" -H "Content-Type: application/json" -d "{\"text\":\"$1\"}" >/dev/null 2>&1 || true
 }
 deploy() {  # $1 = tag
-  ARBR_IMAGE_TAG="$1" $COMPOSE pull app
-  ARBR_IMAGE_TAG="$1" $COMPOSE up -d --no-build app
+  # ARBR_IMAGE_TAG must be set INSIDE the sudo'd process. `VAR=x sudo …` sets it on sudo's
+  # own environment, which env_reset then strips, so compose falls back to the `:-main`
+  # default — silently ignoring $1 and, worse, "rolling back" to :main instead of $PREV_TAG.
+  # `sudo env VAR=x …` sets it for the child compose process, so the tag is honoured.
+  sudo env ARBR_IMAGE_TAG="$1" docker compose $COMPOSE_FILES pull app
+  sudo env ARBR_IMAGE_TAG="$1" docker compose $COMPOSE_FILES up -d --no-build app
 }
 
 SEED_BEFORE="$(seed_of || true)"


### PR DESCRIPTION
## Problem
`ops/deploy.sh` set the image tag as `ARBR_IMAGE_TAG=x sudo docker compose …`, which puts the variable on **sudo's own** environment. sudo's `env_reset` strips it before exec, so `docker compose` never saw it and always used the `${ARBR_IMAGE_TAG:-main}` default.

Consequences:
- The `TAG` argument was silently ignored: you could not pin to a `sha-<commit>` or deploy any non-`main` tag.
- **Auto-rollback was broken.** On a failed health check the script re-pulled `:main` (the just-deployed bad image) instead of `$PREV_TAG`, so the script's headline safety guarantee did not hold.

Observed on the 2026-07-05 deploy: passing `sha-44a6a90` still pulled `:main` (harmless only because they resolved to the same digest at the time).

## Fix
Set the variable inside the sudo'd process via `sudo env VAR=x docker compose …`, so compose interpolation sees it. The compose `-f` flags are factored into `COMPOSE_FILES` to avoid duplicating the file list.

## Impact
No behaviour change on the happy path (deploying `main`). Restores correct tag pinning and makes rollback target the real previous tag.

## Testing
- `bash -n ops/deploy.sh` passes.
- Suggested live check on the VM: deploy a specific `sha-<commit>`, then confirm the running container's `org.opencontainers.image.revision` matches that commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
