### PR TITLE
docs(architecture): document real semantics of budgets, cache, streaming, PII, fallback

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -108,3 +108,42 @@ docs/               VitePress documentation site
 - **Catalog sync** — `litellm/sync.js` imports the full LiteLLM model catalog; `livebench`
   and `lmsys` add benchmark scores. These are on-demand (the dashboard "Sync Models" button
   → `POST /api/benchmarks/sync`), not run on boot.
+
+## Operational semantics and known limitations
+
+Being precise about what the enforcement and optimization paths actually guarantee, so
+nobody mistakes a demo-grade mechanism for a hardened one. Several of these are deliberate
+single-instance tradeoffs; they matter most if you run multiple replicas or high burst
+traffic.
+
+- **Budgets are a soft cap, not a hard real-time limit.** `routing/capEngine.js` recomputes
+  breach status at most every ~30s (`TTL_MS = 30_000`) via a Mongo aggregation, then serves
+  the hot path from an in-memory cache. Under a burst within that window, or across multiple
+  processes (the cache is per-process, uncoordinated), spend can overshoot the cap before a
+  block/downgrade takes effect. Only the `global`, `application`, and `provider` dimensions
+  are enforced at the gateway; other dimensions surface in the UI but are not enforced.
+- **Response cache is exact-match and ephemeral.** `routing/responseCache.js` keys on
+  `sha256(model + serialized messages)`, holds at most 5,000 entries in-memory with a
+  10-minute TTL, and evicts oldest-first. It does not persist across restarts, is not shared
+  across replicas, and does no semantic/near-duplicate matching. It demonstrates the
+  duplicate-request saving; it is not a durable caching tier.
+- **Output guardrails do not apply to streamed responses.** On the OpenAI-compatible
+  streaming path (`gateway/openaiCompat.js`), upstream SSE bytes are relayed to the caller
+  unchanged (buffering would defeat streaming). Output content guardrails and response
+  transforms therefore apply to non-streaming responses only. The input-side max-tokens
+  clamp still applies to both. If you rely on output guardrails, disable streaming for those
+  routes.
+- **PII masking is log-time, not pre-model.** `logging/piiFilter.js` masks `messages` /
+  `responseText` when the `RequestRecord` is written, so it protects what is *stored*. It
+  does not prevent prompts or responses from reaching the provider; it is log redaction, not
+  data-loss prevention.
+- **Fallback can cross provider boundaries.** On a provider error,
+  `gateway/handler.js` (`invokeWithFallback`) retries the remaining live providers using
+  their default models. This preserves availability but can silently change the vendor,
+  region/data-residency, safety profile, and output format of a response. Scoping fallback
+  to the same provider or an explicit allowlist is tracked in
+  [#77](https://github.com/project-arbr/arbr-control-plane/issues/77).
+- **Recommendations price substitution, not quality.** `recommend/engine.js` re-prices the
+  same tokens on a cheaper model; it does not measure whether the cheaper model answers as
+  well. Eval-backed savings (quality held at X% before a downgrade is recommended) is tracked
+  in [#76](https://github.com/project-arbr/arbr-control-plane/issues/76).


### PR DESCRIPTION
Adds an "Operational semantics and known limitations" section to `ARCHITECTURE.md`, prompted by an external core-code review. **Docs only, no behavior change.**

The review's core point was fair: budgets, cache, streaming guardrails, PII masking, and fallback are demo-grade or narrowly scoped, but the docs read as if they were hardened. This states plainly what each path guarantees:

- **Budgets** are a soft cap (~30s recompute, per-process in-memory, can overshoot on burst or across replicas; only global/application/provider dimensions enforced).
- **Response cache** is exact-match, in-memory, 10-min TTL, 5k entries, not persisted or shared across replicas.
- **Output guardrails** do not apply to streamed responses (raw SSE relay); the input max-tokens clamp still does.
- **PII masking** is log-time redaction, not pre-model DLP.
- **Fallback** can cross provider/region/output-format boundaries (scoping tracked in #77).
- **Recommendations** price substitution, not measured quality (eval-backed savings tracked in #76).

Follow-ups split into issues so they get a real discussion rather than a silent change:
- #76 eval-backed savings (the highest-leverage core fix)
- #77 scoped provider fallback (a default change with breakage risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
