### PR TITLE
feat(eval): Phase 3 — canary rollout + auto-rollback

### DIFF
--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -40,6 +40,8 @@ const evalReplay = require("../eval/replay");
 const evalThresholds = require("../eval/thresholds");
 const { sameFamily } = require("../eval/rubricJudge");
 const { tierForTask } = require("../classify/classifier");
+const RoutingExperiment = require("../models/RoutingExperiment");
+const canaryEngine = require("../routing/canaryEngine");
 const secrets = require("../security/secrets");
 const { config, KNOWN_PROVIDERS } = require("../config");
 const { classifyModelImport, isChatLikelyModelId } = require("../providers/importLogic");
@@ -769,6 +771,115 @@ router.get("/evals/runs/:id/results", async (req, res, next) => {
       (b.criticalFailure - a.criticalFailure) ||
       ((order[a.judgeVerdict] ?? 3) - (order[b.judgeVerdict] ?? 3)));
     res.json(results);
+  } catch (e) { next(e); }
+});
+
+// Clamp/normalize canary guardrail inputs to sane numbers (falls back to defaults).
+function sanitizeGuardrails(g) {
+  const d = { maxErrorRateIncrease: 0.02, maxLatencyRegressionPct: 0.25, maxWorseRate: 0.10, minCostSavingPct: 0.10 };
+  if (!g || typeof g !== "object") return d;
+  const num = (v, def) => (v != null && !isNaN(Number(v)) ? Number(v) : def);
+  return {
+    maxErrorRateIncrease: num(g.maxErrorRateIncrease, d.maxErrorRateIncrease),
+    maxLatencyRegressionPct: num(g.maxLatencyRegressionPct, d.maxLatencyRegressionPct),
+    maxWorseRate: num(g.maxWorseRate, d.maxWorseRate),
+    minCostSavingPct: num(g.minCostSavingPct, d.minCostSavingPct),
+  };
+}
+
+// ── Routing experiments (canary rollout, Phase 3) ─────────────────────────────
+router.get("/routing-experiments", async (req, res, next) => {
+  try {
+    const q = req.query.status ? { status: req.query.status } : {};
+    res.json(await RoutingExperiment.find(q).sort({ createdAt: -1 }).lean());
+  } catch (e) { next(e); }
+});
+router.get("/routing-experiments/:id", async (req, res, next) => {
+  try {
+    const exp = await RoutingExperiment.findById(req.params.id).lean().catch(() => null);
+    if (!exp) return res.status(404).json({ error: "not found" });
+    res.json(exp);
+  } catch (e) { next(e); }
+});
+
+// Create a canary from a passed recommendation (only auto-routed traffic is affected).
+router.post("/recommendations/:id/create-canary", async (req, res, next) => {
+  try {
+    const rec = await Recommendation.findById(req.params.id);
+    if (!rec) return res.status(404).json({ error: "not found" });
+    const b = req.body || {};
+    const offlineRun = rec.evalRunId ? await EvalRun.findById(rec.evalRunId).lean().catch(() => null) : null;
+    const gate = evalThresholds.canActivateShadow(offlineRun, b.override); // same "passed offline or override" bar
+    if (!gate.allowed) return res.status(409).json({ error: "eval_required", message: gate.reason });
+
+    const exp = await RoutingExperiment.create({
+      evalRunId: rec.evalRunId || null, recommendationId: rec._id, shadowCampaignId: rec.shadowCampaignId || null,
+      scope: { application: b.application || rec.application || null, workflow: b.workflow || null, taskType: rec.taskType || null },
+      baselineModel: rec.currentModel, candidateModel: rec.suggestedModel,
+      rolloutPct: b.rolloutPct != null ? Math.min(100, Math.max(0, Number(b.rolloutPct))) : 10,
+      guardrails: sanitizeGuardrails(b.guardrails),
+      metricsWindowMinutes: b.metricsWindowMinutes != null ? Math.max(5, Number(b.metricsWindowMinutes)) : 60,
+      status: "active", createdBy: "console", approvedBy: b.approvedBy || null,
+    });
+    rec.experimentId = exp._id;
+    await rec.save();
+    canaryEngine.invalidate();
+    setImmediate(() => logAction("canary.create", "routingExperiment", String(exp._id), { recommendationId: String(rec._id), rolloutPct: exp.rolloutPct }));
+    res.status(201).json(exp);
+  } catch (e) { next(e); }
+});
+
+router.patch("/routing-experiments/:id", async (req, res, next) => {
+  try {
+    const b = req.body || {};
+    const update = {};
+    if (b.rolloutPct != null) update.rolloutPct = Math.min(100, Math.max(0, Number(b.rolloutPct)));
+    if (b.status && ["active", "paused"].includes(b.status)) update.status = b.status; // rollback/promote have their own routes
+    if (b.guardrails) update.guardrails = sanitizeGuardrails(b.guardrails);
+    if (b.metricsWindowMinutes != null) update.metricsWindowMinutes = Math.max(5, Number(b.metricsWindowMinutes));
+    const exp = await RoutingExperiment.findByIdAndUpdate(req.params.id, { $set: update }, { new: true }).lean();
+    if (!exp) return res.status(404).json({ error: "not found" });
+    canaryEngine.invalidate();
+    setImmediate(() => logAction("canary.update", "routingExperiment", req.params.id, update));
+    res.json(exp);
+  } catch (e) { next(e); }
+});
+
+// Manual rollback — stop diverting traffic; the candidate is abandoned but logs are kept.
+router.post("/routing-experiments/:id/rollback", async (req, res, next) => {
+  try {
+    const reason = (req.body && req.body.reason) || "manual rollback";
+    const exp = await RoutingExperiment.findByIdAndUpdate(
+      req.params.id, { $set: { status: "rolled_back", rollbackReason: reason } }, { new: true }
+    ).lean();
+    if (!exp) return res.status(404).json({ error: "not found" });
+    canaryEngine.invalidate();
+    setImmediate(() => logAction("canary.rollback", "routingExperiment", req.params.id, { reason }));
+    res.json(exp);
+  } catch (e) { next(e); }
+});
+
+// Promote — go to 100% by creating an ENABLED, reversible rule and marking the rec accepted.
+router.post("/routing-experiments/:id/promote", async (req, res, next) => {
+  try {
+    const exp = await RoutingExperiment.findById(req.params.id);
+    if (!exp) return res.status(404).json({ error: "not found" });
+    if (exp.status === "rolled_back") return res.status(409).json({ error: "rolled_back", message: "cannot promote a rolled-back experiment" });
+    const cm = pricing.getModel(exp.candidateModel);
+    const rule = await Rule.create({
+      condition: { taskType: exp.scope?.taskType || null, application: exp.scope?.application || null, workflow: exp.scope?.workflow || null },
+      target: { provider: cm ? cm.provider : undefined, model: exp.candidateModel },
+      enabled: true, createdBy: "console",
+      sourceRecommendation: exp.recommendationId || null,
+      note: `promoted canary ${exp.baselineModel} → ${exp.candidateModel}`,
+    });
+    exp.status = "promoted"; exp.rolloutPct = 100; exp.ruleId = rule._id; exp.approvedBy = (req.body && req.body.approvedBy) || exp.approvedBy;
+    await exp.save();
+    if (exp.recommendationId) await Recommendation.findByIdAndUpdate(exp.recommendationId, { status: "accepted" });
+    ruleEngine.invalidate();
+    canaryEngine.invalidate();
+    setImmediate(() => logAction("canary.promote", "routingExperiment", String(exp._id), { ruleId: String(rule._id), candidateModel: exp.candidateModel }));
+    res.json({ experiment: exp, rule });
   } catch (e) { next(e); }
 });
 

--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -816,6 +816,7 @@ router.post("/recommendations/:id/create-canary", async (req, res, next) => {
       evalRunId: rec.evalRunId || null, recommendationId: rec._id, shadowCampaignId: rec.shadowCampaignId || null,
       scope: { application: b.application || rec.application || null, workflow: b.workflow || null, taskType: rec.taskType || null },
       baselineModel: rec.currentModel, candidateModel: rec.suggestedModel,
+      candidateProvider: rec.suggestedProvider || pricing.getModel(rec.suggestedModel)?.provider || null,
       rolloutPct: b.rolloutPct != null ? Math.min(100, Math.max(0, Number(b.rolloutPct))) : 10,
       guardrails: sanitizeGuardrails(b.guardrails),
       metricsWindowMinutes: b.metricsWindowMinutes != null ? Math.max(5, Number(b.metricsWindowMinutes)) : 60,
@@ -865,10 +866,11 @@ router.post("/routing-experiments/:id/promote", async (req, res, next) => {
     const exp = await RoutingExperiment.findById(req.params.id);
     if (!exp) return res.status(404).json({ error: "not found" });
     if (exp.status === "rolled_back") return res.status(409).json({ error: "rolled_back", message: "cannot promote a rolled-back experiment" });
-    const cm = pricing.getModel(exp.candidateModel);
+    const provider = exp.candidateProvider || pricing.getModel(exp.candidateModel)?.provider;
+    if (!provider) return res.status(422).json({ error: "no_provider", message: "cannot determine the candidate's provider; set candidateProvider on the experiment." });
     const rule = await Rule.create({
       condition: { taskType: exp.scope?.taskType || null, application: exp.scope?.application || null, workflow: exp.scope?.workflow || null },
-      target: { provider: cm ? cm.provider : undefined, model: exp.candidateModel },
+      target: { provider, model: exp.candidateModel },
       enabled: true, createdBy: "console",
       sourceRecommendation: exp.recommendationId || null,
       note: `promoted canary ${exp.baselineModel} → ${exp.candidateModel}`,

--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -177,15 +177,17 @@ async function resolveRoute(body, { router, eff, application, workflow, userId =
   if (autoMode) {
     const canary = await canaryEngine.selectCanary({ application, workflow, taskType, servedModel: served.model, userId });
     if (canary) {
-      const cm = pricing.getModel(canary.toModel);
-      if (cm && eff.liveIds.includes(cm.provider)) {
+      // Prefer the registered model's provider; fall back to the experiment's stored provider
+      // so an unregistered candidate can still be canaried.
+      const provider = pricing.getModel(canary.toModel)?.provider || canary.experiment.candidateProvider;
+      if (provider && eff.liveIds.includes(provider)) {
         explain.canary = {
           experimentId: String(canary.experiment._id),
           evalRunId: canary.experiment.evalRunId ? String(canary.experiment.evalRunId) : null,
           fromModel: served.model, toModel: canary.toModel, rolloutPct: canary.experiment.rolloutPct,
         };
         explain.override = { type: "canary", from: served.model, to: canary.toModel };
-        served = { provider: cm.provider, model: canary.toModel };
+        served = { provider, model: canary.toModel };
         routingDecision = "canary";
       }
     }

--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -15,6 +15,7 @@ const ruleEngine = require("../routing/ruleEngine");
 const autoRouter = require("../routing/autoRouter");
 const policyEngine = require("../routing/policy");
 const aiPolicy = require("../routing/aiPolicy");
+const canaryEngine = require("../routing/canaryEngine");
 const capEngine = require("../routing/capEngine");
 const responseCache = require("../routing/responseCache");
 const outputGuardrail = require("./outputGuardrail");
@@ -94,7 +95,7 @@ async function invokeWithFallback(router, eff, { provider, model, messages, temp
 // Shared routing resolution: classify task + decide served {provider, model}.
 // Returns { served, routingDecision, taskType, classifiedBy, cls }.
 // Callers are responsible for budget enforcement (it may short-circuit the response).
-async function resolveRoute(body, { router, eff, application, workflow, appConfig = {}, appDbConfig = null }) {
+async function resolveRoute(body, { router, eff, application, workflow, userId = null, appConfig = {}, appDbConfig = null }) {
   const routingMode = await ruleEngine.getRoutingMode();
   const explicit = resolveExplicit(body, eff);
   const autoMode = !explicit;
@@ -170,6 +171,26 @@ async function resolveRoute(body, { router, eff, application, workflow, appConfi
       }
     }
   }
+  // Eval-approved canary: divert a deterministic fraction of AUTO-routed traffic to a candidate
+  // model. Pinned (explicit) models are never touched. Fail-open — selectCanary swallows its own
+  // errors, and allowed-model / opt-out checks below still apply to the canary target.
+  if (autoMode) {
+    const canary = await canaryEngine.selectCanary({ application, workflow, taskType, servedModel: served.model, userId });
+    if (canary) {
+      const cm = pricing.getModel(canary.toModel);
+      if (cm && eff.liveIds.includes(cm.provider)) {
+        explain.canary = {
+          experimentId: String(canary.experiment._id),
+          evalRunId: canary.experiment.evalRunId ? String(canary.experiment.evalRunId) : null,
+          fromModel: served.model, toModel: canary.toModel, rolloutPct: canary.experiment.rolloutPct,
+        };
+        explain.override = { type: "canary", from: served.model, to: canary.toModel };
+        served = { provider: cm.provider, model: canary.toModel };
+        routingDecision = "canary";
+      }
+    }
+  }
+
   explain.classificationUsed =
     explain.basis === "ai" || explain.basis === "auto" ||
     (explain.basis === "rule" && !!explain.rule?.condition?.taskType);
@@ -270,7 +291,7 @@ async function handleChat(req, res) {
   let served, routingDecision, taskType, classifiedBy, cls, difficulty, difficultyScore, confidence, explain;
   try {
     ({ served, routingDecision, taskType, classifiedBy, cls, difficulty, difficultyScore, confidence, explain } =
-      await resolveRoute(body, { router, eff, application: meta.application, workflow: meta.workflow, appConfig, appDbConfig: appCfg }));
+      await resolveRoute(body, { router, eff, application: meta.application, workflow: meta.workflow, userId: meta.userId, appConfig, appDbConfig: appCfg }));
   } catch (err) {
     if (err.code === "model_not_allowed") {
       return res.status(403).json({ error: err.message, code: "model_not_allowed" });

--- a/server/src/gateway/openaiCompat.js
+++ b/server/src/gateway/openaiCompat.js
@@ -357,7 +357,7 @@ async function handleOpenAICompat(req, res) {
   let served, routingDecision, taskType, classifiedBy, difficulty, difficultyScore, confidence, explain;
   try {
     ({ served, routingDecision, taskType, classifiedBy, difficulty, difficultyScore, confidence, explain } =
-      await resolveRoute(normalized, { router, eff, application: meta.application, workflow: meta.workflow, appConfig, appDbConfig: appCfg }));
+      await resolveRoute(normalized, { router, eff, application: meta.application, workflow: meta.workflow, userId: meta.userId, appConfig, appDbConfig: appCfg }));
   } catch (err) {
     if (err.code === "model_not_allowed") {
       return res.status(403).json({ error: { message: err.message, type: "invalid_request_error", code: "model_not_allowed" } });

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -11,6 +11,7 @@ const { handleChat } = require("./gateway/handler");
 const { handleOpenAICompat } = require("./gateway/openaiCompat");
 const { purgeOldRecords } = require("./maintenance/purge");
 const errorAlertMonitor = require("./routing/errorAlertMonitor");
+const canaryMonitor = require("./routing/canaryMonitor");
 const { supportsTools } = require("./gateway/capabilities");
 const auth = require("./gateway/auth");
 const adminAuth = require("./api/adminAuth");
@@ -125,6 +126,10 @@ async function start() {
   // Error-rate alerting: checks rolling 1-hour error rate every 5 min and fires
   // the governance webhook when the threshold is exceeded.
   errorAlertMonitor.start();
+
+  // Canary auto-rollback: every 5 min, roll back any active routing experiment that
+  // breaches its guardrails (error rate, latency, cost saving, shadow worse-rate).
+  canaryMonitor.start();
 
   app.listen(config.port, config.host, () => {
     console.log("\n" + describe() + "\n");

--- a/server/src/models/Recommendation.js
+++ b/server/src/models/Recommendation.js
@@ -39,6 +39,7 @@ const recommendationSchema = new mongoose.Schema(
     evalDatasetId: { type: mongoose.Schema.Types.ObjectId, ref: "EvalDataset", default: null },
     evalRunId: { type: mongoose.Schema.Types.ObjectId, ref: "EvalRun", default: null },
     shadowCampaignId: { type: mongoose.Schema.Types.ObjectId, ref: "EvalCampaign", default: null }, // Phase 2
+    experimentId: { type: mongoose.Schema.Types.ObjectId, ref: "RoutingExperiment", default: null }, // Phase 3 canary
     qualitySummary: { type: mongoose.Schema.Types.Mixed, default: null }, // last run's summary
     override: {
       reason: { type: String, default: null },

--- a/server/src/models/RequestRecord.js
+++ b/server/src/models/RequestRecord.js
@@ -44,7 +44,7 @@ const requestRecordSchema = new mongoose.Schema(
     // routing transparency
     routingDecision: {
       type: String,
-      enum: ["passthrough", "explicit", "rule", "auto", "ai", "budget", "cache", "fallback"],
+      enum: ["passthrough", "explicit", "rule", "auto", "ai", "budget", "cache", "fallback", "canary"],
       default: "passthrough",
       index: true,
     },

--- a/server/src/models/RoutingExperiment.js
+++ b/server/src/models/RoutingExperiment.js
@@ -1,0 +1,44 @@
+// A controlled canary rollout of an eval-passed candidate model. Only created from a passed
+// EvalRun. The gateway routes a deterministic percentage of AUTO-routed traffic (pinned models
+// are never touched) to the candidate; a monitor auto-rolls-back on guardrail breach, and an
+// admin can promote it to an enabled Rule. See routing/canaryEngine + routing/canaryMonitor.
+const mongoose = require("mongoose");
+
+const routingExperimentSchema = new mongoose.Schema(
+  {
+    evalRunId: { type: mongoose.Schema.Types.ObjectId, ref: "EvalRun", default: null },
+    recommendationId: { type: mongoose.Schema.Types.ObjectId, ref: "Recommendation", default: null, index: true },
+    shadowCampaignId: { type: mongoose.Schema.Types.ObjectId, ref: "EvalCampaign", default: null }, // for a live worse-rate signal
+    ruleId: { type: mongoose.Schema.Types.ObjectId, ref: "Rule", default: null }, // set on promotion
+
+    scope: {
+      application: { type: String, default: null, index: true },
+      workflow: { type: String, default: null },
+      taskType: { type: String, default: null },
+    },
+    baselineModel: { type: String, required: true },  // the model canary traffic is diverted FROM
+    candidateModel: { type: String, required: true }, // routed TO for the canary fraction
+    rolloutPct: { type: Number, default: 10, min: 0, max: 100 },
+
+    status: { type: String, enum: ["draft", "active", "paused", "rolled_back", "promoted"], default: "draft", index: true },
+
+    // Auto-rollback fires if any of these is breached over the metrics window.
+    guardrails: {
+      maxErrorRateIncrease: { type: Number, default: 0.02 },   // candidate error rate minus baseline (absolute)
+      maxLatencyRegressionPct: { type: Number, default: 0.25 }, // p95 candidate vs baseline
+      maxWorseRate: { type: Number, default: 0.10 },            // from the linked shadow campaign, if any
+      minCostSavingPct: { type: Number, default: 0.10 },        // candidate must still save at least this
+    },
+    metricsWindowMinutes: { type: Number, default: 60 },
+    minSampleForRollback: { type: Number, default: 20 }, // don't judge on a handful of requests
+
+    createdBy: { type: String, default: "console" },
+    approvedBy: { type: String, default: null },
+    rollbackReason: { type: String, default: null },
+    lastMonitoredAt: { type: Date, default: null },
+    lastMetrics: { type: mongoose.Schema.Types.Mixed, default: null },
+  },
+  { collection: "routing_experiments", timestamps: true }
+);
+
+module.exports = mongoose.model("RoutingExperiment", routingExperimentSchema);

--- a/server/src/models/RoutingExperiment.js
+++ b/server/src/models/RoutingExperiment.js
@@ -18,6 +18,7 @@ const routingExperimentSchema = new mongoose.Schema(
     },
     baselineModel: { type: String, required: true },  // the model canary traffic is diverted FROM
     candidateModel: { type: String, required: true }, // routed TO for the canary fraction
+    candidateProvider: { type: String, default: null }, // provider for the candidate (may be unregistered in the pricing table)
     rolloutPct: { type: Number, default: 10, min: 0, max: 100 },
 
     status: { type: String, enum: ["draft", "active", "paused", "rolled_back", "promoted"], default: "draft", index: true },

--- a/server/src/routing/canaryEngine.js
+++ b/server/src/routing/canaryEngine.js
@@ -1,0 +1,53 @@
+// Hot-path canary selection. Decides whether an AUTO-routed request should be diverted to an
+// experiment's candidate model. Cached like the rule set; pure bucketing/matching are separated
+// and unit-tested. Every caller path is fail-open: any error here leaves normal routing intact.
+const crypto = require("crypto");
+const RoutingExperiment = require("../models/RoutingExperiment");
+
+const TTL_MS = 15_000;
+let _cache = { experiments: [], at: 0 };
+
+function invalidate() { _cache.at = 0; }
+
+async function activeExperiments() {
+  if (Date.now() - _cache.at < TTL_MS) return _cache.experiments;
+  const experiments = await RoutingExperiment.find({ status: "active" }).lean().catch(() => []);
+  _cache = { experiments, at: Date.now() };
+  return experiments;
+}
+
+// Deterministic 0-99 bucket for a (user, experiment) pair, so a given user is consistently in or
+// out of the canary. Falls back to a stable per-request-context key when userId is absent. Pure.
+function bucket(application, workflow, userId, experimentId) {
+  const key = `${application || ""}|${workflow || ""}|${userId || "anon"}|${experimentId || ""}`;
+  const hex = crypto.createHash("sha256").update(key).digest("hex").slice(0, 8);
+  return parseInt(hex, 16) % 100;
+}
+
+// Does an experiment apply to this request? Scope null field = any. The request's currently
+// served model must equal the experiment's baseline (that's what we divert from). Pure.
+function matchExperiment(exp, { application, workflow, taskType, servedModel }) {
+  if (!exp || exp.status !== "active") return false;
+  if (exp.baselineModel !== servedModel) return false;
+  const s = exp.scope || {};
+  if (s.application && s.application !== application) return false;
+  if (s.workflow && s.workflow !== workflow) return false;
+  if (s.taskType && String(s.taskType).toLowerCase() !== String(taskType || "").toLowerCase()) return false;
+  return true;
+}
+
+// Returns { experiment, toModel } when this request should be served by a candidate, else null.
+async function selectCanary(ctx) {
+  try {
+    const experiments = await activeExperiments();
+    for (const exp of experiments) {
+      if (!matchExperiment(exp, ctx)) continue;
+      if (bucket(ctx.application, ctx.workflow, ctx.userId, String(exp._id)) < (exp.rolloutPct || 0)) {
+        return { experiment: exp, toModel: exp.candidateModel };
+      }
+    }
+  } catch { /* fail-open */ }
+  return null;
+}
+
+module.exports = { selectCanary, activeExperiments, invalidate, bucket, matchExperiment };

--- a/server/src/routing/canaryMonitor.js
+++ b/server/src/routing/canaryMonitor.js
@@ -1,0 +1,112 @@
+// Auto-rollback monitor for active canary experiments. Every 5 minutes it recomputes each
+// experiment's live metrics over its window and rolls back on any guardrail breach. Pure
+// guardrail evaluation is separated for unit tests. Same single-process caveat as the budget
+// cache and errorAlertMonitor: it is a timer, not a hard real-time guarantee.
+const RequestRecord = require("../models/RequestRecord");
+const RoutingExperiment = require("../models/RoutingExperiment");
+const EvalPair = require("../models/EvalPair");
+const Settings = require("../models/Settings");
+const canaryEngine = require("./canaryEngine");
+
+const INTERVAL_MS = 5 * 60 * 1000;
+let _timer = null;
+
+function pct(n) { return n == null || isNaN(n) ? "n/a" : `${(n * 100).toFixed(1)}%`; }
+
+function p95(nums) {
+  if (!nums.length) return 0;
+  const s = [...nums].sort((a, b) => a - b);
+  return s[Math.min(s.length - 1, Math.floor(0.95 * s.length))];
+}
+
+// Decide rollback from computed metrics. Pure. Returns { breached, reasons, insufficient }.
+function evaluateGuardrails(m, g, minSample) {
+  if ((m.candTotal || 0) < (minSample || 0)) return { breached: false, reasons: [], insufficient: true };
+  const reasons = [];
+  const errInc = (m.candErrorRate || 0) - (m.baseErrorRate || 0);
+  if (g.maxErrorRateIncrease != null && errInc > g.maxErrorRateIncrease) {
+    reasons.push(`error rate +${pct(errInc)} vs baseline (max +${pct(g.maxErrorRateIncrease)})`);
+  }
+  if (g.maxLatencyRegressionPct != null && m.latencyRegressionPct != null && m.latencyRegressionPct > g.maxLatencyRegressionPct) {
+    reasons.push(`p95 latency regressed ${pct(m.latencyRegressionPct)} (max ${pct(g.maxLatencyRegressionPct)})`);
+  }
+  if (g.minCostSavingPct != null && m.costSavingPct != null && m.costSavingPct < g.minCostSavingPct) {
+    reasons.push(`cost saving ${pct(m.costSavingPct)} below floor ${pct(g.minCostSavingPct)}`);
+  }
+  if (g.maxWorseRate != null && m.worseRate != null && m.worseRate > g.maxWorseRate) {
+    reasons.push(`shadow worse-rate ${pct(m.worseRate)} exceeds ${pct(g.maxWorseRate)}`);
+  }
+  return { breached: reasons.length > 0, reasons, insufficient: false };
+}
+
+// Compute candidate-vs-baseline metrics for an experiment over its window.
+async function metricsFor(exp) {
+  const since = new Date(Date.now() - (exp.metricsWindowMinutes || 60) * 60000);
+  const scope = {};
+  if (exp.scope?.application) scope.application = exp.scope.application;
+  if (exp.scope?.workflow) scope.workflow = exp.scope.workflow;
+  if (exp.scope?.taskType) scope.taskType = exp.scope.taskType;
+  const proj = { status: 1, totalCost: 1, latencyMs: 1 };
+
+  const cand = await RequestRecord.find({ ...scope, timestamp: { $gte: since }, routingDecision: "canary", model: exp.candidateModel }, proj).lean();
+  const base = await RequestRecord.find({ ...scope, timestamp: { $gte: since }, routingDecision: { $ne: "canary" }, model: exp.baselineModel }, proj).lean();
+
+  const stats = (rows) => {
+    const total = rows.length;
+    const failures = rows.filter((r) => r.status === "failure").length;
+    const ok = rows.filter((r) => r.status === "success");
+    const avgCost = ok.length ? ok.reduce((a, r) => a + (r.totalCost || 0), 0) / ok.length : 0;
+    return { total, errorRate: total ? failures / total : 0, avgCost, p95: p95(ok.map((r) => r.latencyMs || 0)) };
+  };
+  const c = stats(cand), b = stats(base);
+
+  let worseRate = null;
+  if (exp.shadowCampaignId) {
+    const judged = await EvalPair.find({ campaignId: exp.shadowCampaignId, verdict: { $ne: null } }, { verdict: 1 }).lean();
+    if (judged.length) worseRate = judged.filter((p) => p.verdict === "worse").length / judged.length;
+  }
+  return {
+    candTotal: c.total, baseTotal: b.total,
+    candErrorRate: c.errorRate, baseErrorRate: b.errorRate,
+    latencyRegressionPct: b.p95 > 0 ? (c.p95 - b.p95) / b.p95 : null,
+    costSavingPct: b.avgCost > 0 ? (b.avgCost - c.avgCost) / b.avgCost : null,
+    worseRate,
+  };
+}
+
+async function rollback(exp, reasons) {
+  await RoutingExperiment.updateOne({ _id: exp._id }, { $set: {
+    status: "rolled_back", rollbackReason: reasons.join("; "), lastMonitoredAt: new Date(),
+  } });
+  canaryEngine.invalidate();
+  const s = await Settings.get().catch(() => null);
+  if (s?.webhookUrl) {
+    fetch(s.webhookUrl, {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ event: "canary_rolled_back", experimentId: String(exp._id),
+        candidateModel: exp.candidateModel, baselineModel: exp.baselineModel, reasons }),
+      signal: AbortSignal.timeout(5000),
+    }).catch(() => {});
+  }
+}
+
+async function check() {
+  try {
+    const experiments = await RoutingExperiment.find({ status: "active" }).lean();
+    for (const exp of experiments) {
+      const m = await metricsFor(exp);
+      const verdict = evaluateGuardrails(m, exp.guardrails || {}, exp.minSampleForRollback);
+      await RoutingExperiment.updateOne({ _id: exp._id }, { $set: { lastMonitoredAt: new Date(), lastMetrics: m } });
+      if (verdict.breached) await rollback(exp, verdict.reasons);
+    }
+  } catch { /* must not crash the process */ }
+}
+
+function start() {
+  if (_timer) return;
+  _timer = setInterval(check, INTERVAL_MS);
+  if (_timer.unref) _timer.unref();
+}
+function stop() { if (_timer) { clearInterval(_timer); _timer = null; } }
+
+module.exports = { start, stop, check, evaluateGuardrails, metricsFor };

--- a/server/test/integration/evalCanary.test.js
+++ b/server/test/integration/evalCanary.test.js
@@ -1,0 +1,83 @@
+"use strict";
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+const mongoose = require("mongoose");
+const express = require("express");
+const supertest = require("supertest");
+
+process.env.ARBR_ADMIN_KEY = "";
+
+const Recommendation = require("../../src/models/Recommendation");
+const EvalRun = require("../../src/models/EvalRun");
+const EvalDataset = require("../../src/models/EvalDataset");
+const RoutingExperiment = require("../../src/models/RoutingExperiment");
+const Rule = require("../../src/models/Rule");
+const apiRoutes = require("../../src/api/routes");
+
+let mongod, agent;
+const buildApp = () => { const a = express(); a.use(express.json()); a.use("/api", apiRoutes); return a; };
+
+const makeRec = () => Recommendation.create({
+  title: "t", reason: "r", taskType: "classification", currentModel: "gpt-4o",
+  suggestedModel: "gpt-4o-mini", suggestedProvider: "openai", dedupeKey: `k-${Math.random()}`,
+});
+async function pass(rec) {
+  const ds = await EvalDataset.create({ recommendationId: rec._id, status: "ready", riskTier: "low" });
+  const run = await EvalRun.create({ recommendationId: rec._id, datasetId: ds._id, status: "passed", candidateModel: "gpt-4o-mini", baselineModel: "gpt-4o" });
+  rec.evalRunId = run._id; rec.evalStatus = "passed"; await rec.save();
+}
+
+before(async () => { mongod = await MongoMemoryServer.create(); await mongoose.connect(mongod.getUri()); agent = supertest(buildApp()); });
+after(async () => { await mongoose.disconnect(); await mongod.stop(); });
+beforeEach(async () => { await Promise.all([Recommendation.deleteMany({}), EvalRun.deleteMany({}), EvalDataset.deleteMany({}), RoutingExperiment.deleteMany({}), Rule.deleteMany({})]); });
+
+test("create-canary is blocked without a passed eval", async () => {
+  const rec = await makeRec();
+  const res = await agent.post(`/api/recommendations/${rec._id}/create-canary`).send({ application: "support-chat" });
+  assert.equal(res.status, 409);
+});
+
+test("create-canary makes an active experiment scoped to the rec", async () => {
+  const rec = await makeRec();
+  await pass(rec);
+  const res = await agent.post(`/api/recommendations/${rec._id}/create-canary`).send({ application: "support-chat", rolloutPct: 15 });
+  assert.equal(res.status, 201);
+  assert.equal(res.body.status, "active");
+  assert.equal(res.body.rolloutPct, 15);
+  assert.equal(res.body.baselineModel, "gpt-4o");
+  assert.equal(res.body.candidateModel, "gpt-4o-mini");
+  assert.equal(res.body.scope.taskType, "classification");
+  const updated = await Recommendation.findById(rec._id);
+  assert.ok(updated.experimentId);
+});
+
+test("rollback sets status rolled_back with a reason", async () => {
+  const exp = await RoutingExperiment.create({ baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", status: "active" });
+  const res = await agent.post(`/api/routing-experiments/${exp._id}/rollback`).send({ reason: "spike" });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.status, "rolled_back");
+  assert.equal(res.body.rollbackReason, "spike");
+});
+
+test("promote creates an enabled rule and marks the rec accepted", async () => {
+  const rec = await makeRec();
+  const exp = await RoutingExperiment.create({
+    recommendationId: rec._id, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini",
+    scope: { taskType: "classification", application: "support-chat" }, status: "active",
+  });
+  const res = await agent.post(`/api/routing-experiments/${exp._id}/promote`).send({ approvedBy: "prasanna" });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.experiment.status, "promoted");
+  assert.equal(res.body.experiment.rolloutPct, 100);
+  assert.equal(res.body.rule.enabled, true);
+  assert.equal(res.body.rule.target.model, "gpt-4o-mini");
+  const updatedRec = await Recommendation.findById(rec._id);
+  assert.equal(updatedRec.status, "accepted");
+});
+
+test("cannot promote a rolled-back experiment", async () => {
+  const exp = await RoutingExperiment.create({ baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", status: "rolled_back" });
+  const res = await agent.post(`/api/routing-experiments/${exp._id}/promote`).send({});
+  assert.equal(res.status, 409);
+});

--- a/server/test/integration/evalCanary.test.js
+++ b/server/test/integration/evalCanary.test.js
@@ -63,7 +63,7 @@ test("rollback sets status rolled_back with a reason", async () => {
 test("promote creates an enabled rule and marks the rec accepted", async () => {
   const rec = await makeRec();
   const exp = await RoutingExperiment.create({
-    recommendationId: rec._id, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini",
+    recommendationId: rec._id, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", candidateProvider: "openai",
     scope: { taskType: "classification", application: "support-chat" }, status: "active",
   });
   const res = await agent.post(`/api/routing-experiments/${exp._id}/promote`).send({ approvedBy: "prasanna" });
@@ -71,6 +71,7 @@ test("promote creates an enabled rule and marks the rec accepted", async () => {
   assert.equal(res.body.experiment.status, "promoted");
   assert.equal(res.body.experiment.rolloutPct, 100);
   assert.equal(res.body.rule.enabled, true);
+  assert.equal(res.body.rule.target.provider, "openai"); // provider comes from candidateProvider, not the registry
   assert.equal(res.body.rule.target.model, "gpt-4o-mini");
   const updatedRec = await Recommendation.findById(rec._id);
   assert.equal(updatedRec.status, "accepted");

--- a/server/test/unit/evalCanary.test.js
+++ b/server/test/unit/evalCanary.test.js
@@ -1,0 +1,62 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { bucket, matchExperiment } = require("../../src/routing/canaryEngine");
+const { evaluateGuardrails } = require("../../src/routing/canaryMonitor");
+
+test("bucket is deterministic and in [0,100)", () => {
+  const a = bucket("app", "wf", "user-1", "exp-1");
+  const b = bucket("app", "wf", "user-1", "exp-1");
+  assert.equal(a, b);
+  assert.ok(a >= 0 && a < 100);
+});
+
+test("bucket varies by user and by experiment", () => {
+  const base = bucket("app", "wf", "user-1", "exp-1");
+  assert.notEqual(base, bucket("app", "wf", "user-2", "exp-1")); // different user
+  assert.notEqual(base, bucket("app", "wf", "user-1", "exp-2")); // different experiment
+});
+
+test("bucket distributes roughly uniformly (in-canary count near rolloutPct)", () => {
+  let inCanary = 0;
+  for (let i = 0; i < 1000; i++) if (bucket("app", "wf", `u${i}`, "exp") < 10) inCanary++;
+  assert.ok(inCanary > 60 && inCanary < 140, `expected ~100, got ${inCanary}`); // 10% of 1000
+});
+
+test("matchExperiment requires active status and matching baseline", () => {
+  const exp = { status: "active", baselineModel: "gpt-4o", scope: { application: "a", taskType: "classification" } };
+  assert.equal(matchExperiment(exp, { application: "a", taskType: "classification", servedModel: "gpt-4o" }), true);
+  assert.equal(matchExperiment(exp, { application: "a", taskType: "classification", servedModel: "gpt-4o-mini" }), false); // baseline mismatch
+  assert.equal(matchExperiment(exp, { application: "b", taskType: "classification", servedModel: "gpt-4o" }), false); // app mismatch
+  assert.equal(matchExperiment({ ...exp, status: "paused" }, { application: "a", taskType: "classification", servedModel: "gpt-4o" }), false);
+});
+
+test("matchExperiment treats null scope fields as any", () => {
+  const exp = { status: "active", baselineModel: "gpt-4o", scope: {} };
+  assert.equal(matchExperiment(exp, { application: "anything", workflow: "x", taskType: "y", servedModel: "gpt-4o" }), true);
+});
+
+test("evaluateGuardrails skips when sample is too small", () => {
+  const v = evaluateGuardrails({ candTotal: 3, candErrorRate: 1 }, { maxErrorRateIncrease: 0.02 }, 20);
+  assert.equal(v.breached, false);
+  assert.equal(v.insufficient, true);
+});
+
+test("evaluateGuardrails breaches on error-rate increase", () => {
+  const v = evaluateGuardrails({ candTotal: 100, candErrorRate: 0.10, baseErrorRate: 0.02 }, { maxErrorRateIncrease: 0.02 }, 20);
+  assert.equal(v.breached, true);
+  assert.ok(v.reasons[0].includes("error rate"));
+});
+
+test("evaluateGuardrails breaches on latency, cost-saving, and worse-rate", () => {
+  const g = { maxLatencyRegressionPct: 0.25, minCostSavingPct: 0.10, maxWorseRate: 0.10 };
+  assert.equal(evaluateGuardrails({ candTotal: 50, latencyRegressionPct: 0.5 }, g, 20).breached, true);
+  assert.equal(evaluateGuardrails({ candTotal: 50, costSavingPct: 0.02 }, g, 20).breached, true);
+  assert.equal(evaluateGuardrails({ candTotal: 50, worseRate: 0.3 }, g, 20).breached, true);
+});
+
+test("evaluateGuardrails passes a healthy candidate", () => {
+  const m = { candTotal: 100, candErrorRate: 0.01, baseErrorRate: 0.02, latencyRegressionPct: -0.1, costSavingPct: 0.6, worseRate: 0.01 };
+  const g = { maxErrorRateIncrease: 0.02, maxLatencyRegressionPct: 0.25, minCostSavingPct: 0.10, maxWorseRate: 0.10 };
+  assert.equal(evaluateGuardrails(m, g, 20).breached, false);
+});


### PR DESCRIPTION
Phase 3 of #76. **Stacked on #80** (Phase 2) which is stacked on #79 (P0) — merge in order. Base is the Phase 2 branch, so this diff is incremental.

Turns a passed recommendation into a controlled, reversible rollout.

## Changes
- **`RoutingExperiment` model:** scope, baseline/candidate model, `rolloutPct`, guardrails, metrics window, status (`draft`/`active`/`paused`/`rolled_back`/`promoted`).
- **Gateway (`routing/canaryEngine`):** AUTO-routed requests matching an active experiment's scope are diverted to the candidate by **deterministic hash bucketing** — `hash(app+workflow+userId+experimentId) % 100 < rolloutPct`, so a given user is consistently in or out. **Explicit pinned models are never touched.** `routingDecision: "canary"` + `routingExplain.canary`. **Fully fail-open:** any error leaves normal routing intact, and allowed-model / opt-out checks still apply to the canary target.
- **Auto-rollback (`routing/canaryMonitor`):** every 5 min, recompute each active experiment's live metrics (candidate-vs-baseline error rate, p95 latency, cost saving, and shadow worse-rate) and roll back on any guardrail breach; notifies the webhook.
- **Endpoints:** `POST /recommendations/:id/create-canary` (gated on a passed eval), `GET`/`PATCH /routing-experiments`, `POST /routing-experiments/:id/{rollback,promote}`. **Promotion** creates an ENABLED, reversible `Rule` and marks the recommendation accepted.

## Honest caveat (as flagged during planning)
The rollback monitor is a 5-minute `setInterval`, same single-process fragility class as the budget cache and `errorAlertMonitor` — it is a timer, not a hard real-time guarantee, and won't coordinate across replicas. Called out in code. Hardening it (or driving it from request-time metrics) is a follow-up if this goes multi-instance.

## Tests
9 unit tests (bucket determinism + ~uniform distribution, `matchExperiment`, `evaluateGuardrails`) + integration for the create-canary gate, rollback, and promote-to-rule. Unit suite 83/83 green on Node 22; integration in CI.

## Deferred (Phase 4)
The Evals / canary dashboard.

Part of #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
