### PR TITLE
feat(web): Phase 4 — eval-backed routing dashboard

### DIFF
--- a/server/src/seed/promptPacks.js
+++ b/server/src/seed/promptPacks.js
@@ -1,0 +1,59 @@
+// Realistic prompt/response pairs per task type, so seeded RequestRecords carry believable
+// `messages` + `responseText`. Without these the eval flow has nothing to replay (the demo's
+// whole point). Covers the five demo task types from the growth brief — support classification,
+// FAQ, CRM summaries, legal/contract extraction, code explanation — plus a generic fallback.
+// The `extraction` pack is intentionally structured (JSON) so it drives the failure-first story
+// (a cheaper model breaking the schema).
+
+const PACKS = {
+  classification: [
+    { prompt: "Classify this support ticket as one of [billing, technical, account, feedback]:\n\"I was charged twice for my subscription this month.\"", response: "billing" },
+    { prompt: "Classify this support ticket as one of [billing, technical, account, feedback]:\n\"The app crashes every time I upload a PDF.\"", response: "technical" },
+    { prompt: "Classify this support ticket as one of [billing, technical, account, feedback]:\n\"I can't log in even after resetting my password.\"", response: "account" },
+    { prompt: "Classify this support ticket as one of [billing, technical, account, feedback]:\n\"Love the new dashboard, the charts are much clearer.\"", response: "feedback" },
+    { prompt: "Classify the sentiment of this review as [positive, neutral, negative]:\n\"Support took three days to reply and never fixed my issue.\"", response: "negative" },
+  ],
+  faq: [
+    { prompt: "How do I reset my password?", response: "Open Settings → Security → Reset password. We email a reset link that stays valid for 30 minutes; follow it to set a new password." },
+    { prompt: "What payment methods do you accept?", response: "We accept all major credit cards (Visa, Mastercard, Amex) and ACH bank transfer on annual plans. Invoicing is available for enterprise accounts." },
+    { prompt: "Can I export my data?", response: "Yes. Go to Settings → Data → Export to download a CSV or JSON archive of your workspace. Exports include records from the last 90 days by default." },
+    { prompt: "How do I invite a teammate?", response: "In Settings → Members, click Invite, enter their email, and pick a role (Admin, Editor, or Viewer). They'll get an email invitation to join the workspace." },
+    { prompt: "Is there a free trial?", response: "Yes, a 14-day trial with full features and no credit card required. You can add a payment method any time before it ends to keep your data." },
+  ],
+  summarisation: [
+    { prompt: "Summarise this sales-call note in two sentences:\n\"Spoke with the VP of Ops at Northwind. They're evaluating us against two competitors, main concern is onboarding time. Budget approved for Q3, decision expected in 4 weeks. Asked for a security questionnaire and a reference customer in logistics.\"", response: "Northwind's VP of Ops has Q3 budget approved and will decide within four weeks, weighing us against two competitors mainly on onboarding time. They requested a security questionnaire and a logistics reference customer." },
+    { prompt: "Summarise this CRM note in two sentences:\n\"Renewal call with Acme. Usage up 40% YoY, two new teams onboarded. They want volume pricing and SSO before signing a 2-year deal. Champion is supportive; procurement is the bottleneck.\"", response: "Acme's usage grew 40% year over year and they're ready for a two-year renewal, contingent on volume pricing and SSO. Their champion is supportive, but procurement is the main bottleneck." },
+    { prompt: "Summarise this support interaction in one sentence:\n\"Customer reported slow report loading; we identified a large date range as the cause and suggested narrowing filters. They confirmed it resolved the issue.\"", response: "The customer's slow report loading was caused by an overly large date range and was resolved by narrowing the filters." },
+    { prompt: "Summarise the outcome of this meeting note:\n\"Kickoff with Globex. Agreed on a 6-week pilot, success metric is 20% cost reduction. They assigned two engineers; we provide weekly check-ins.\"", response: "Globex agreed to a six-week pilot targeting a 20% cost reduction, with two of their engineers assigned and weekly check-ins from our side." },
+  ],
+  "document analysis": [
+    { prompt: "Summarise the key obligations in this indemnification clause:\n\"The Vendor shall indemnify, defend and hold harmless the Client from any third-party claims arising out of the Vendor's breach of this Agreement or negligence, up to a cap equal to fees paid in the prior 12 months.\"", response: "The Vendor must indemnify and defend the Client against third-party claims caused by the Vendor's breach or negligence. Liability is capped at the total fees paid in the preceding 12 months." },
+    { prompt: "Identify the termination rights in this clause:\n\"Either party may terminate for convenience on 60 days' written notice. The Client may terminate immediately upon a material breach that remains uncured for 15 days after notice.\"", response: "Either party may terminate for convenience with 60 days' written notice. The Client may also terminate immediately for a material breach left uncured 15 days after notice." },
+    { prompt: "What does this confidentiality clause require?\n\"Each party shall protect the other's Confidential Information with the same care it uses for its own, and not less than reasonable care, for a period of five years after disclosure.\"", response: "Each party must protect the other's confidential information with at least reasonable care (and no less than the care it gives its own), for five years after disclosure." },
+  ],
+  coding: [
+    { prompt: "Explain what this function does:\n```js\nfunction debounce(fn, ms) {\n  let t;\n  return (...args) => { clearTimeout(t); t = setTimeout(() => fn(...args), ms); };\n}\n```", response: "It returns a debounced wrapper around `fn`: each call resets a timer, so `fn` only runs once the wrapper has been idle for `ms` milliseconds. Useful for rate-limiting rapid events like keystrokes or resize handlers." },
+    { prompt: "Explain what this SQL query returns:\n```sql\nSELECT customer_id, COUNT(*) AS orders\nFROM orders WHERE created_at > NOW() - INTERVAL '30 days'\nGROUP BY customer_id HAVING COUNT(*) > 5;\n```", response: "It lists each customer who placed more than five orders in the last 30 days, along with their order count. The HAVING clause filters the grouped results to customers above the threshold." },
+    { prompt: "What does this Python snippet do?\n```python\nnums = [n for n in range(100) if n % 3 == 0 and n % 5 == 0]\n```", response: "It builds a list of numbers from 0 to 99 that are divisible by both 3 and 5 (i.e. multiples of 15): [0, 15, 30, 45, 60, 75, 90]." },
+  ],
+  // Structured-output extraction — drives the failure-first demo (JSON/schema breakage).
+  extraction: [
+    { prompt: "Extract the fields {party, effective_date, termination_notice_days, indemnity} as JSON from:\n\"This Agreement between Acme Inc. and the Client is effective January 1, 2026. Either party may terminate on 30 days notice. The Vendor shall indemnify the Client for third-party claims.\"", response: '{"party":"Acme Inc.","effective_date":"2026-01-01","termination_notice_days":30,"indemnity":true}' },
+    { prompt: "Extract {invoice_number, total_usd, due_date} as JSON from:\n\"Invoice INV-4821, amount due $12,450.00, payable by 2026-02-15.\"", response: '{"invoice_number":"INV-4821","total_usd":12450.00,"due_date":"2026-02-15"}' },
+    { prompt: "Extract {name, email, company} as JSON from this signature:\n\"Best, Dana Lee — Head of Ops, Globex — dana.lee@globex.com\"", response: '{"name":"Dana Lee","email":"dana.lee@globex.com","company":"Globex"}' },
+    { prompt: "Extract {governing_law, cap_months, auto_renew} as JSON from:\n\"This Agreement is governed by the laws of Delaware. Liability is capped at 12 months of fees. The term auto-renews annually unless cancelled.\"", response: '{"governing_law":"Delaware","cap_months":12,"auto_renew":true}' },
+  ],
+};
+
+const GENERIC = [
+  { prompt: "Draft a short, friendly reply confirming we received the customer's request and will follow up within one business day.", response: "Thanks for reaching out! We've received your request and a member of our team will follow up within one business day. We appreciate your patience." },
+  { prompt: "Rewrite this sentence to be more concise: \"We are writing to inform you that your order has now been shipped.\"", response: "Your order has shipped." },
+];
+
+// Deterministic pick within a task type's pack (index provided by the caller's PRNG).
+function getPromptPair(taskType, i) {
+  const pack = PACKS[String(taskType || "").toLowerCase()] || GENERIC;
+  return pack[i % pack.length];
+}
+
+module.exports = { getPromptPair, PACKS };

--- a/server/src/seed/seed.js
+++ b/server/src/seed/seed.js
@@ -12,7 +12,15 @@ const { v4: uuidv4 } = require("uuid");
 const { config } = require("../config");
 const RequestRecord = require("../models/RequestRecord");
 const Recommendation = require("../models/Recommendation");
+const EvalDataset = require("../models/EvalDataset");
+const EvalItem = require("../models/EvalItem");
+const EvalRun = require("../models/EvalRun");
+const EvalResult = require("../models/EvalResult");
+const RoutingExperiment = require("../models/RoutingExperiment");
 const pricing = require("../pricing/registry");
+const recommender = require("../recommend/engine");
+const { defaultThresholds } = require("../eval/thresholds");
+const { getPromptPair } = require("./promptPacks");
 
 // Deterministic PRNG so seeds are reproducible (no Math.random surprises).
 let _s = 1337;
@@ -58,6 +66,8 @@ function buildRecord({ application, workflow, department, model, provider, taskT
   const { inputCost, outputCost, totalCost } = pricing.costFor(model, promptTokens, completionTokens);
   const ts = new Date(Date.now() - daysAgo * 86400000 - between(0, 86400000));
   const failed = rnd() < 0.01;
+  // Attach a realistic prompt + response so the record is replayable by the eval flow.
+  const pair = getPromptPair(taskType, between(0, 99));
   return {
     requestId: uuidv4(),
     timestamp: ts,
@@ -70,7 +80,81 @@ function buildRecord({ application, workflow, department, model, provider, taskT
     retryCount: 0,
     routingDecision: "passthrough",
     cacheHit: false,
+    messages: [{ role: "user", content: pair.prompt }],
+    responseText: pair.response,
   };
+}
+
+// Seed a ready-made eval story so `docker compose up` (no keys) shows the wedge out of the box:
+// one PASSED downgrade (approved + a live canary) and one BLOCKED downgrade (failure-first).
+// Attaches to the recommendations recompute() produced, so it survives a later Recompute.
+async function seedEvalDemo() {
+  // ── PASSED: classification, claude-opus-4-8 → claude-haiku-4-5 ──────────────
+  const passRec = await Recommendation.findOne({ dedupeKey: "premium_overuse:classification:claude-opus-4-8" });
+  if (passRec) {
+    const ds = await EvalDataset.create({
+      name: "classification: claude-opus-4-8 → claude-haiku-4-5", recommendationId: passRec._id,
+      scope: { taskType: "classification" }, baselineModel: "claude-opus-4-8", candidateModel: "claude-haiku-4-5",
+      sampling: { method: "stratified", targetCount: 200, dedupeByPromptHash: true },
+      riskTier: "low", piiMode: "masked", itemCount: 200, status: "ready",
+    });
+    const summary = { total: 200, judged: 200, candidateBetter: 41, candidateEqual: 153, candidateWorse: 6,
+      worseRate: 0.03, criticalFailRate: 0, formatPassRate: 1, costSavingPct: 0.82, avgLatencyDeltaPct: -0.28,
+      prodCost: 4.43, candidateCost: 0.80, p95LatencyDeltaPct: -0.22 };
+    const run = await EvalRun.create({
+      recommendationId: passRec._id, datasetId: ds._id, taskType: "classification",
+      baselineModel: "claude-opus-4-8", candidateModel: "claude-haiku-4-5", judgeModel: "gpt-4o",
+      riskTier: "low", status: "passed", thresholds: defaultThresholds("low"), summary, failures: [],
+      estimatedCostUsd: 0.9, actualCostUsd: 0.86, startedAt: new Date(), completedAt: new Date(),
+    });
+    await EvalResult.insertMany([
+      { evalRunId: run._id, baselineModel: "claude-opus-4-8", candidateModel: "claude-haiku-4-5", candidateResponse: "billing", judgeVerdict: "equal", formatPass: true, dimensionScores: { correctness: 5, format: 5 }, judgeRationale: "Both correctly label the ticket 'billing'." },
+      { evalRunId: run._id, baselineModel: "claude-opus-4-8", candidateModel: "claude-haiku-4-5", candidateResponse: "technical", judgeVerdict: "equal", formatPass: true, dimensionScores: { correctness: 5, format: 5 }, judgeRationale: "Identical, correct classification." },
+      { evalRunId: run._id, baselineModel: "claude-opus-4-8", candidateModel: "claude-haiku-4-5", candidateResponse: "account", judgeVerdict: "better", formatPass: true, dimensionScores: { correctness: 5, format: 5 }, judgeRationale: "Candidate picked the more precise label." },
+      { evalRunId: run._id, baselineModel: "claude-opus-4-8", candidateModel: "claude-haiku-4-5", candidateResponse: "feedback (positive)", judgeVerdict: "worse", formatPass: true, dimensionScores: { correctness: 3, format: 4 }, judgeRationale: "Candidate added an unrequested sentiment tag; baseline was cleaner." },
+    ]);
+    passRec.evalStatus = "passed"; passRec.evalDatasetId = ds._id; passRec.evalRunId = run._id; passRec.qualitySummary = summary;
+
+    const exp = await RoutingExperiment.create({
+      evalRunId: run._id, recommendationId: passRec._id,
+      scope: { application: "support-chat", taskType: "classification" },
+      baselineModel: "claude-opus-4-8", candidateModel: "claude-haiku-4-5", candidateProvider: "anthropic",
+      rolloutPct: 10, status: "active", metricsWindowMinutes: 60,
+      lastMonitoredAt: new Date(),
+      lastMetrics: { candTotal: 63, candErrorRate: 0.008, baseErrorRate: 0.011, latencyRegressionPct: -0.26, costSavingPct: 0.8, worseRate: 0.03 },
+    });
+    passRec.experimentId = exp._id;
+    await passRec.save();
+  }
+
+  // ── BLOCKED (failure-first): extraction, gpt-4o → gpt-4o-mini ───────────────
+  const failRec = await Recommendation.findOne({ dedupeKey: "premium_overuse:extraction:gpt-4o" });
+  if (failRec) {
+    const ds = await EvalDataset.create({
+      name: "extraction: gpt-4o → gpt-4o-mini", recommendationId: failRec._id,
+      scope: { taskType: "extraction" }, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini",
+      sampling: { method: "stratified", targetCount: 300, dedupeByPromptHash: true },
+      riskTier: "medium", piiMode: "masked", itemCount: 300, status: "ready",
+    });
+    const summary = { total: 300, judged: 300, candidateBetter: 20, candidateEqual: 196, candidateWorse: 84,
+      worseRate: 0.28, criticalFailRate: 0.05, formatPassRate: 0.72, costSavingPct: 0.93, avgLatencyDeltaPct: -0.15,
+      prodCost: 1.13, candidateCost: 0.07, p95LatencyDeltaPct: -0.10 };
+    const run = await EvalRun.create({
+      recommendationId: failRec._id, datasetId: ds._id, taskType: "extraction",
+      baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", judgeModel: "claude-opus-4-8",
+      riskTier: "medium", status: "failed", thresholds: defaultThresholds("medium"), summary,
+      failures: ["worse-rate 28.0% exceeds 3.0%", "critical-failure rate 5.0% exceeds 0.2%", "format pass-rate 72.0% below 99.0%"],
+      estimatedCostUsd: 1.4, actualCostUsd: 1.31, startedAt: new Date(), completedAt: new Date(),
+    });
+    await EvalResult.insertMany([
+      { evalRunId: run._id, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", candidateResponse: '{"party":"Acme Inc.","effective_date":"Jan 1 2026","indemnity":true}', judgeVerdict: "worse", criticalFailure: true, formatPass: false, validatorResults: [{ type: "json_schema", pass: false }], dimensionScores: { correctness: 2, format: 1 }, judgeRationale: "Dropped termination_notice_days and used a non-ISO date; fails the schema." },
+      { evalRunId: run._id, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", candidateResponse: 'Here is the JSON: {"invoice_number":"INV-4821","total_usd":"12,450"}', judgeVerdict: "worse", criticalFailure: true, formatPass: false, validatorResults: [{ type: "json_schema", pass: false }], dimensionScores: { correctness: 2, format: 1 }, judgeRationale: "Wrapped JSON in prose, quoted the number with a comma, and omitted due_date." },
+      { evalRunId: run._id, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", candidateResponse: '{"governing_law":"Delaware","cap_months":12,"auto_renew":true}', judgeVerdict: "equal", formatPass: true, validatorResults: [{ type: "json_schema", pass: true }], dimensionScores: { correctness: 5, format: 5 }, judgeRationale: "Correct on the simple case." },
+      { evalRunId: run._id, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", candidateResponse: '{"name":"Dana Lee","company":"Globex"}', judgeVerdict: "worse", criticalFailure: false, formatPass: false, validatorResults: [{ type: "json_schema", pass: false }], dimensionScores: { correctness: 3, format: 2 }, judgeRationale: "Omitted the required email field." },
+    ]);
+    failRec.evalStatus = "failed"; failRec.evalDatasetId = ds._id; failRec.evalRunId = run._id; failRec.qualitySummary = summary;
+    await failRec.save();
+  }
 }
 
 async function main() {
@@ -84,6 +168,11 @@ async function main() {
 
   await RequestRecord.deleteMany({});
   await Recommendation.deleteMany({});
+  // Reset the eval demo collections too, so reseeding is idempotent.
+  await Promise.all([
+    EvalDataset.deleteMany({}), EvalItem.deleteMany({}), EvalRun.deleteMany({}),
+    EvalResult.deleteMany({}), RoutingExperiment.deleteMany({}),
+  ]);
 
   const records = [];
 
@@ -124,7 +213,16 @@ async function main() {
 
   await RequestRecord.insertMany(records);
   console.log(`Inserted ${records.length} request records.`);
-  console.log("Done. Start the server and open the dashboard; click 'Recompute' on Recommendations.");
+
+  // Generate recommendations from the traffic, then attach a ready-made eval story
+  // (one approved downgrade + a live canary, one blocked downgrade) so the eval-backed
+  // wedge is visible on first boot without any provider keys.
+  const recs = await recommender.recompute();
+  console.log(`Computed ${recs.length} recommendations.`);
+  await seedEvalDemo();
+  console.log("Seeded eval demo: 1 approved (classification, + canary) and 1 blocked (extraction).");
+
+  console.log("Done. Start the server and open the dashboard — Routing → Recommendations and Model Evals.");
   await mongoose.disconnect();
 }
 

--- a/server/test/unit/promptPacks.test.js
+++ b/server/test/unit/promptPacks.test.js
@@ -1,0 +1,22 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { getPromptPair } = require("../../src/seed/promptPacks");
+
+test("getPromptPair returns a prompt/response pair for a known task type", () => {
+  const p = getPromptPair("classification", 0);
+  assert.ok(p.prompt && typeof p.prompt === "string");
+  assert.ok(p.response && typeof p.response === "string");
+});
+
+test("getPromptPair cycles within a pack and falls back for unknown types", () => {
+  const p = getPromptPair("extraction", 5); // index wraps
+  assert.ok(p.prompt.includes("JSON")); // extraction pack is structured
+  const g = getPromptPair("totally-unknown-task", 0);
+  assert.ok(g.prompt && g.response); // generic fallback
+});
+
+test("extraction responses are valid JSON (drives the structured-output demo)", () => {
+  const p = getPromptPair("extraction", 0);
+  assert.doesNotThrow(() => JSON.parse(p.response));
+});

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -66,8 +66,27 @@ export const api = {
 
   recommendations: (status) => req(`/recommendations${qs({ status })}`),
   recompute: () => req("/recommendations/recompute", { method: "POST" }),
-  acceptRecommendation: (id) => req(`/recommendations/${id}/accept`, { method: "POST" }),
+  acceptRecommendation: (id, override) => req(`/recommendations/${id}/accept`, { method: "POST", body: JSON.stringify(override ? { override } : {}) }),
   dismissRecommendation: (id) => req(`/recommendations/${id}/dismiss`, { method: "POST" }),
+
+  // Eval-backed routing (P0–P3): dataset → offline run → shadow → canary.
+  createEvalDataset: (id, body = {}) => req(`/recommendations/${id}/create-eval-dataset`, { method: "POST", body: JSON.stringify(body) }),
+  runEval: (id, body = {}) => req(`/recommendations/${id}/run-eval`, { method: "POST", body: JSON.stringify(body) }),
+  startShadow: (id, body = {}) => req(`/recommendations/${id}/start-shadow`, { method: "POST", body: JSON.stringify(body) }),
+  createCanary: (id, body = {}) => req(`/recommendations/${id}/create-canary`, { method: "POST", body: JSON.stringify(body) }),
+  overrideRecommendation: (id, body) => req(`/recommendations/${id}/override`, { method: "POST", body: JSON.stringify(body) }),
+  evalDatasets: (recommendationId) => req(`/evals/datasets${qs({ recommendationId })}`),
+  evalDataset: (id) => req(`/evals/datasets/${id}`),
+  evalRuns: (recommendationId) => req(`/evals/runs${qs({ recommendationId })}`),
+  evalRun: (id) => req(`/evals/runs/${id}`),
+  evalRunResults: (id) => req(`/evals/runs/${id}/results`),
+
+  // Routing experiments (canary rollout).
+  routingExperiments: (status) => req(`/routing-experiments${qs({ status })}`),
+  routingExperiment: (id) => req(`/routing-experiments/${id}`),
+  updateRoutingExperiment: (id, body) => req(`/routing-experiments/${id}`, { method: "PATCH", body: JSON.stringify(body) }),
+  rollbackExperiment: (id, reason) => req(`/routing-experiments/${id}/rollback`, { method: "POST", body: JSON.stringify({ reason }) }),
+  promoteExperiment: (id, approvedBy) => req(`/routing-experiments/${id}/promote`, { method: "POST", body: JSON.stringify({ approvedBy }) }),
 
   models: ({ live } = {}) => req(`/models${live ? "?live=true" : ""}`),
   createModel: (body) => req("/models", { method: "POST", body: JSON.stringify(body) }),

--- a/web/src/pages/ModelEvals.jsx
+++ b/web/src/pages/ModelEvals.jsx
@@ -151,6 +151,130 @@ function CampaignDetail({ id, onClose }) {
   );
 }
 
+const RUN_TONE = { queued: "gray", running: "amber", passed: "green", failed: "red", cancelled: "gray" };
+const EXP_TONE = { draft: "gray", active: "green", paused: "amber", rolled_back: "red", promoted: "charcoal" };
+
+// Offline eval-run detail: pass/fail, aggregate summary, and the worst candidate examples.
+function RunDetail({ id, onClose }) {
+  const [run, setRun] = useState(null);
+  const [results, setResults] = useState(null);
+
+  useEffect(() => {
+    api.evalRun(id).then(setRun).catch((e) => setRun({ _error: e.message }));
+    api.evalRunResults(id).then(setResults).catch(() => setResults([]));
+  }, [id]);
+
+  const exportCsv = () => {
+    const rows = results || [];
+    const head = ["verdict", "criticalFailure", "formatPass", "candidateCost", "candidateLatencyMs", "judgeRationale"];
+    const body = rows.map((r) => head.map((k) => JSON.stringify(r[k] ?? "")).join(","));
+    const blob = new Blob([[head.join(","), ...body].join("\n")], { type: "text/csv" });
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(blob); a.download = `eval-run-${id}.csv`;
+    document.body.appendChild(a); a.click(); document.body.removeChild(a);
+  };
+
+  if (!run) return <Drawer title="Eval run" onClose={onClose}><Spinner /></Drawer>;
+  if (run._error) return <Drawer title="Eval run" onClose={onClose}><div className="text-sm text-red-600">{run._error}</div></Drawer>;
+  const s = run.summary || {};
+
+  return (
+    <Drawer title={`Eval run · ${run.candidateModel}`} onClose={onClose}>
+      <div className="space-y-5">
+        <div className={`rounded-lg p-3 text-sm font-medium ${run.status === "passed" ? "bg-green-50 text-arbr-green-700" : run.status === "failed" ? "bg-red-50 text-red-700" : "bg-gray-50 text-gray-600"}`}>
+          {run.status === "passed" ? "✓ Passed all thresholds" : run.status === "failed" ? "✗ Failed" : run.status}
+          {run.failures?.length > 0 && <ul className="mt-1 list-disc pl-5 text-xs font-normal">{run.failures.map((f, i) => <li key={i}>{f}</li>)}</ul>}
+          {run.error && <div className="mt-1 text-xs font-normal">{run.error}</div>}
+        </div>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Stat label="Judged" value={fmt.num(s.judged)} sub={`${fmt.num(s.total)} total`} />
+          <Stat label="Worse-rate" value={pct(s.worseRate)} sub={`critical ${pct(s.criticalFailRate)}`} />
+          <Stat label="Format pass" value={pct(s.formatPassRate)} />
+          <Stat label="Cost saving" value={pct(s.costSavingPct)} sub={`latency ${signedPct(s.avgLatencyDeltaPct)}`} />
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-xs text-gray-600">
+          {run.baselineModel} → {run.candidateModel} · judge {run.judgeModel || "none"} · {run.riskTier} risk · est. cost {fmt.usd(run.estimatedCostUsd)} · actual {fmt.usd(run.actualCostUsd)}
+        </div>
+        <div className="flex items-center justify-between">
+          <div className="label">Worst candidate examples</div>
+          <button className="btn-outline text-xs" onClick={exportCsv}>Export CSV</button>
+        </div>
+        {results === null ? <Spinner /> : results.length === 0 ? <div className="text-xs text-gray-400">No results.</div> : (
+          <div className="space-y-3">
+            {results.slice(0, 20).map((r) => (
+              <div key={r._id} className="rounded-lg border border-gray-200 p-3">
+                <div className="flex items-center gap-2">
+                  {r.judgeVerdict ? <Badge tone={VERDICT_TONE[r.judgeVerdict]}>{r.judgeVerdict}</Badge> : <Badge tone="gray">unjudged</Badge>}
+                  {r.criticalFailure && <Badge tone="red">critical</Badge>}
+                  {!r.formatPass && <Badge tone="amber">format fail</Badge>}
+                  {r.error && <span className="text-xs text-red-600">{r.error}</span>}
+                </div>
+                {r.judgeRationale && <p className="mt-2 text-sm text-gray-600">{r.judgeRationale}</p>}
+                {r.candidateResponse && <CodeBlock code={r.candidateResponse} />}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </Drawer>
+  );
+}
+
+// Offline eval runs across all recommendations.
+function EvalRunsSection() {
+  const [runs, setRuns] = useState(null);
+  const [openId, setOpenId] = useState(null);
+  useEffect(() => { api.evalRuns().then(setRuns).catch(() => setRuns([])); }, []);
+  const cols = [
+    { key: "candidateModel", header: "Baseline → candidate", render: (r) => <span>{r.baselineModel} → <b>{r.candidateModel}</b></span> },
+    { key: "status", header: "Status", render: (r) => <Badge tone={RUN_TONE[r.status]}>{r.status}</Badge> },
+    { key: "worse", header: "Worse-rate", render: (r) => pct(r.summary?.worseRate) },
+    { key: "saving", header: "Cost saving", render: (r) => pct(r.summary?.costSavingPct) },
+    { key: "risk", header: "Risk", render: (r) => r.riskTier },
+    { key: "actions", header: "", render: (r) => <button className="btn-outline text-xs" onClick={(e) => { e.stopPropagation(); setOpenId(r._id); }}>Evidence</button> },
+  ];
+  return (
+    <Card title="Offline eval runs">
+      {runs === null ? <Spinner /> : <Table columns={cols} rows={runs} empty="No eval runs yet — run one from a recommendation." onRowClick={(r) => setOpenId(r._id)} />}
+      {openId && <RunDetail id={openId} onClose={() => setOpenId(null)} />}
+    </Card>
+  );
+}
+
+// Live canary experiments with rollback / promote controls.
+function CanarySection() {
+  const [exps, setExps] = useState(null);
+  const [err, setErr] = useState(null);
+  const load = useCallback(() => { api.routingExperiments().then(setExps).catch(() => setExps([])); }, []);
+  useEffect(() => { load(); }, [load]);
+
+  const act = async (fn) => { setErr(null); try { await fn(); load(); } catch (e) { setErr(e.message); } };
+  const rollback = (id) => act(() => api.rollbackExperiment(id, "manual rollback from dashboard"));
+  const promote = (id) => act(() => api.promoteExperiment(id, "console"));
+
+  const cols = [
+    { key: "models", header: "Baseline → candidate", render: (e) => <span>{e.baselineModel} → <b>{e.candidateModel}</b></span> },
+    { key: "scope", header: "Scope", render: (e) => <span className="text-xs text-gray-500">{[e.scope?.application, e.scope?.taskType].filter(Boolean).join(" · ") || "any"}</span> },
+    { key: "rollout", header: "Rollout", render: (e) => `${e.rolloutPct}%` },
+    { key: "status", header: "Status", render: (e) => <Badge tone={EXP_TONE[e.status]}>{e.status}</Badge> },
+    { key: "metrics", header: "Live (err / save)", render: (e) => e.lastMetrics ? <span className="text-xs">{pct(e.lastMetrics.candErrorRate)} / {pct(e.lastMetrics.costSavingPct)}</span> : <span className="text-gray-400">—</span> },
+    { key: "actions", header: "", render: (e) => (
+      <span className="flex gap-2" onClick={(ev) => ev.stopPropagation()}>
+        {(e.status === "active" || e.status === "paused") && <button className="btn-outline text-xs" onClick={() => promote(e._id)}>Promote</button>}
+        {(e.status === "active" || e.status === "paused") && <button className="btn-outline text-xs text-red-600" onClick={() => rollback(e._id)}>Roll back</button>}
+        {e.status === "rolled_back" && e.rollbackReason && <span className="text-xs text-red-600">{e.rollbackReason}</span>}
+      </span>
+    ) },
+  ];
+  return (
+    <Card title="Canary experiments">
+      <p className="mb-3 text-sm text-gray-500">Eval-approved candidates rolled out to a deterministic slice of auto-routed traffic. Auto-rolls-back on guardrail breach; promote to make it a rule.</p>
+      {err && <div className="mb-2 text-sm text-red-600">{err}</div>}
+      {exps === null ? <Spinner /> : <Table columns={cols} rows={exps} empty="No canary experiments — start one from a passed recommendation." />}
+    </Card>
+  );
+}
+
 export default function ModelEvals() {
   const [campaigns, setCampaigns] = useState(null);
   const [models, setModels] = useState([]);
@@ -194,8 +318,11 @@ export default function ModelEvals() {
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold text-arbr-charcoal">Model Evals</h1>
-        <p className="mt-1 text-sm text-gray-500">Safely evaluate a candidate model on your own live traffic before switching.</p>
+        <p className="mt-1 text-sm text-gray-500">Prove a cheaper model holds quality — offline replay, live shadow, then a guarded canary — before it becomes a rule.</p>
       </div>
+
+      <EvalRunsSection />
+      <CanarySection />
 
       <NewCampaign models={models} apps={apps} onCreated={load} />
 

--- a/web/src/pages/Recommendations.jsx
+++ b/web/src/pages/Recommendations.jsx
@@ -2,13 +2,136 @@ import React, { useEffect, useState } from "react";
 import { api, fmt } from "../api.js";
 import { Card, Badge, Spinner } from "../components/ui.jsx";
 
+const EVAL_TONE = { not_started: "gray", dataset_ready: "gray", running: "amber", passed: "green", failed: "red", overridden: "amber" };
+const EVAL_LABEL = { not_started: "No eval", dataset_ready: "Dataset ready", running: "Evaluating…", passed: "Eval passed", failed: "Eval failed", overridden: "Overridden" };
+const pct = (n) => (n == null ? "—" : `${(n * 100).toFixed(1)}%`);
+
+// Evidence summary line from a run/quality summary.
+function QualitySummary({ s }) {
+  if (!s) return null;
+  return (
+    <div className="mt-3 flex flex-wrap gap-2 text-xs">
+      <Badge tone="gray">{fmt.num(s.judged)} judged</Badge>
+      <Badge tone={s.worseRate > 0.05 ? "red" : "green"}>worse {pct(s.worseRate)}</Badge>
+      {s.criticalFailRate != null && <Badge tone={s.criticalFailRate > 0 ? "red" : "gray"}>critical {pct(s.criticalFailRate)}</Badge>}
+      <Badge tone="gray">format {pct(s.formatPassRate)}</Badge>
+      <Badge tone="green">cost −{pct(s.costSavingPct)}</Badge>
+      {s.avgLatencyDeltaPct != null && <Badge tone="gray">latency {s.avgLatencyDeltaPct > 0 ? "+" : ""}{pct(s.avgLatencyDeltaPct)}</Badge>}
+    </div>
+  );
+}
+
+function RecCard({ rec, models, onChange }) {
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState(null);
+  const [notice, setNotice] = useState(null);
+  const [judge, setJudge] = useState("");
+  const [application, setApplication] = useState(rec.application || "");
+  const evalStatus = rec.evalStatus || "not_started";
+
+  const run = async (fn, ok) => {
+    setBusy(true); setErr(null); setNotice(null);
+    try { const r = await fn(); if (ok) setNotice(ok(r)); await onChange(); }
+    catch (e) { setErr(e.message); }
+    finally { setBusy(false); }
+  };
+
+  const accept = async () => {
+    setBusy(true); setErr(null);
+    try { await api.acceptRecommendation(rec._id); await onChange(); }
+    catch (e) {
+      if (e.status === 409) {
+        const reason = window.prompt("This recommendation has not passed an eval. Enter an override reason to accept anyway (or Cancel):");
+        if (!reason) { setBusy(false); return; }
+        const approver = window.prompt("Approver name:") || "console";
+        try { await api.acceptRecommendation(rec._id, { reason, approver }); await onChange(); }
+        catch (e2) { setErr(e2.message); }
+      } else setErr(e.message);
+    } finally { setBusy(false); }
+  };
+
+  return (
+    <Card>
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h3 className="text-base font-semibold text-arbr-charcoal">{rec.title}</h3>
+            {rec.status === "accepted" && <Badge tone="green">Accepted</Badge>}
+            {rec.status === "dismissed" && <Badge tone="gray">Dismissed</Badge>}
+            {rec.status === "pending" && <Badge tone="amber">Pending</Badge>}
+            <Badge tone={EVAL_TONE[evalStatus]}>{EVAL_LABEL[evalStatus]}</Badge>
+          </div>
+          <p className="mt-2 text-sm text-gray-600">{rec.reason}</p>
+          <div className="mt-3 flex flex-wrap gap-2 text-xs">
+            <Badge tone="charcoal">{rec.currentModel} → {rec.suggestedModel}</Badge>
+            <Badge tone="gray">{fmt.num(rec.requestCount)} requests</Badge>
+          </div>
+          <QualitySummary s={rec.qualitySummary} />
+        </div>
+        <div className="shrink-0 text-right">
+          <div className="label">Projected saving</div>
+          <div className="text-2xl font-bold text-arbr-green-600">{fmt.usd(rec.projectedSavings)}</div>
+          <div className="text-xs text-gray-500">{fmt.usd(rec.currentCost)} → {fmt.usd(rec.projectedCost)}</div>
+        </div>
+      </div>
+
+      {rec.status === "pending" && (
+        <div className="mt-4 border-t border-gray-100 pt-4">
+          {/* Eval-backed flow: prove quality, then roll out under control. */}
+          <div className="flex flex-wrap items-center gap-2">
+            {(evalStatus === "not_started") && (
+              <button className="btn-secondary text-sm" disabled={busy}
+                onClick={() => run(() => api.createEvalDataset(rec._id), (d) => `Dataset built: ${d.itemCount} items (${d.riskTier} risk).`)}>
+                1 · Build eval dataset
+              </button>
+            )}
+            {(evalStatus === "dataset_ready" || evalStatus === "failed") && (
+              <>
+                <select className="input text-sm" value={judge} onChange={(e) => setJudge(e.target.value)} title="Judge model">
+                  <option value="">Judge: none</option>
+                  {models.map((m) => <option key={m.id} value={m.id}>Judge: {m.label || m.id}</option>)}
+                </select>
+                <button className="btn-secondary text-sm" disabled={busy}
+                  onClick={() => run(() => api.runEval(rec._id, { judgeModel: judge || null }), () => "Offline eval started — refresh in a moment.")}>
+                  2 · Run offline eval
+                </button>
+              </>
+            )}
+            {evalStatus === "running" && <span className="text-sm text-amber-600">Evaluating… refresh to see the result.</span>}
+            {evalStatus === "passed" && (
+              <>
+                <input className="input text-sm" placeholder="application for rollout" value={application} onChange={(e) => setApplication(e.target.value)} />
+                <button className="btn-secondary text-sm" disabled={busy || !application.trim()}
+                  onClick={() => run(() => api.createCanary(rec._id, { application: application.trim() }), (x) => `Canary started at ${x.rolloutPct}%.`)}>
+                  3 · Start canary
+                </button>
+              </>
+            )}
+            <button className="btn-outline text-sm" disabled={busy} onClick={accept}>Accept as rule</button>
+            <button className="btn-outline text-sm" disabled={busy} onClick={() => run(() => api.dismissRecommendation(rec._id))}>Dismiss</button>
+          </div>
+          <p className="mt-2 text-xs text-gray-400">
+            Accepting creates a routing rule (off until you switch it on). It is gated on a passed eval; without one you'll be asked for an override reason.
+          </p>
+          {notice && <div className="mt-2 text-sm text-arbr-green-700">{notice}</div>}
+          {err && <div className="mt-2 text-sm text-red-600">{err}</div>}
+        </div>
+      )}
+    </Card>
+  );
+}
+
 export default function Recommendations({ embedded = false }) {
   const [recs, setRecs] = useState(null);
+  const [models, setModels] = useState([]);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState(null);
 
   const load = () => api.recommendations().then(setRecs).catch((e) => setErr(e.message));
-  useEffect(() => { load(); }, []);
+  useEffect(() => {
+    load();
+    api.models({ live: true }).then((m) => setModels(m || [])).catch(() => {});
+  }, []);
 
   const recompute = async () => {
     setBusy(true); setErr(null);
@@ -17,15 +140,12 @@ export default function Recommendations({ embedded = false }) {
     finally { setBusy(false); }
   };
 
-  const accept = async (id) => { await api.acceptRecommendation(id); await load(); };
-  const dismiss = async (id) => { await api.dismissRecommendation(id); await load(); };
-
   return (
     <div className="space-y-6">
       <div className="flex items-start justify-between">
         <div>
           {!embedded && <h1 className="text-2xl font-bold text-arbr-charcoal">Recommendations</h1>}
-          <p className="text-sm text-gray-500">Costed optimisation suggestions. The system proposes; the human decides.</p>
+          <p className="text-sm text-gray-500">Costed suggestions. Prove quality with an eval, then roll out under control — the system proposes, the human decides.</p>
         </div>
         <button className="btn-primary" onClick={recompute} disabled={busy}>
           {busy ? "Recomputing…" : "Recompute"}
@@ -41,37 +161,7 @@ export default function Recommendations({ embedded = false }) {
         </Card>
       ) : (
         <div className="space-y-4">
-          {recs.map((r) => (
-            <Card key={r._id}>
-              <div className="flex items-start justify-between gap-4">
-                <div className="min-w-0">
-                  <div className="flex items-center gap-2">
-                    <h3 className="text-base font-semibold text-arbr-charcoal">{r.title}</h3>
-                    {r.status === "accepted" && <Badge tone="green">Accepted</Badge>}
-                    {r.status === "dismissed" && <Badge tone="gray">Dismissed</Badge>}
-                    {r.status === "pending" && <Badge tone="amber">Pending</Badge>}
-                  </div>
-                  <p className="mt-2 text-sm text-gray-600">{r.reason}</p>
-                  <div className="mt-3 flex flex-wrap gap-2 text-xs">
-                    <Badge tone="charcoal">{r.currentModel} → {r.suggestedModel}</Badge>
-                    <Badge tone="gray">{fmt.num(r.requestCount)} requests</Badge>
-                  </div>
-                </div>
-                <div className="shrink-0 text-right">
-                  <div className="label">Projected saving</div>
-                  <div className="text-2xl font-bold text-arbr-green-600">{fmt.usd(r.projectedSavings)}</div>
-                  <div className="text-xs text-gray-500">{fmt.usd(r.currentCost)} → {fmt.usd(r.projectedCost)}</div>
-                </div>
-              </div>
-              {r.status === "pending" && (
-                <div className="mt-4 flex gap-2 border-t border-gray-100 pt-4">
-                  <button className="btn-secondary" onClick={() => accept(r._id)}>Accept as rule</button>
-                  <button className="btn-outline" onClick={() => dismiss(r._id)}>Dismiss</button>
-                  <span className="self-center text-xs text-gray-400">Accepting creates a routing rule — off until you switch it on.</span>
-                </div>
-              )}
-            </Card>
-          ))}
+          {recs.map((r) => <RecCard key={r._id} rec={r} models={models} onChange={load} />)}
         </div>
       )}
     </div>


### PR DESCRIPTION
Phase 4 of #76 — the dashboard. **Stacked on #81** (Phase 3) → #80 → #79. Merge in order; base is the Phase 3 branch so the diff is incremental.

Surfaces the P0–P3 flow in the UI.

## Changes
- **Recommendations** becomes the evidence-driven control surface: per-recommendation eval-status badge + quality summary (worse-rate, cost saving, latency), and a stepper — **build dataset → run offline eval** (with a judge-model picker) **→ start canary** — plus a gate-aware **Accept as rule** that prompts for an override reason on a `409`.
- **Model Evals** gains two sections above the existing shadow campaigns:
  - **Offline eval runs** — pass/fail, worse-rate, cost saving; an evidence drawer with the worst candidate examples, rubric rationale, and CSV export.
  - **Canary experiments** — rollout %, live error/saving metrics, and roll-back / promote controls.
- `api.js`: methods for datasets, runs, results, recommendation eval actions, and routing experiments.

## Verified
- `npm run web:build` passes.
- Both pages render in the demo (screenshotted): Recommendations shows the eval stepper; Model Evals shows the two new sections with correct empty states.
- Runtime: `create-eval-dataset` returns **200** with items on eligible traffic; the accept gate returns **409** without a passed eval.

Completes the phased plan on #76 (P0 → P2 → P3 → P4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
