### PR TITLE
feat(seed): demo-ready traffic + baked-in eval story (failure-first)

### DIFF
--- a/server/src/seed/promptPacks.js
+++ b/server/src/seed/promptPacks.js
@@ -1,0 +1,59 @@
+// Realistic prompt/response pairs per task type, so seeded RequestRecords carry believable
+// `messages` + `responseText`. Without these the eval flow has nothing to replay (the demo's
+// whole point). Covers the five demo task types from the growth brief — support classification,
+// FAQ, CRM summaries, legal/contract extraction, code explanation — plus a generic fallback.
+// The `extraction` pack is intentionally structured (JSON) so it drives the failure-first story
+// (a cheaper model breaking the schema).
+
+const PACKS = {
+  classification: [
+    { prompt: "Classify this support ticket as one of [billing, technical, account, feedback]:\n\"I was charged twice for my subscription this month.\"", response: "billing" },
+    { prompt: "Classify this support ticket as one of [billing, technical, account, feedback]:\n\"The app crashes every time I upload a PDF.\"", response: "technical" },
+    { prompt: "Classify this support ticket as one of [billing, technical, account, feedback]:\n\"I can't log in even after resetting my password.\"", response: "account" },
+    { prompt: "Classify this support ticket as one of [billing, technical, account, feedback]:\n\"Love the new dashboard, the charts are much clearer.\"", response: "feedback" },
+    { prompt: "Classify the sentiment of this review as [positive, neutral, negative]:\n\"Support took three days to reply and never fixed my issue.\"", response: "negative" },
+  ],
+  faq: [
+    { prompt: "How do I reset my password?", response: "Open Settings → Security → Reset password. We email a reset link that stays valid for 30 minutes; follow it to set a new password." },
+    { prompt: "What payment methods do you accept?", response: "We accept all major credit cards (Visa, Mastercard, Amex) and ACH bank transfer on annual plans. Invoicing is available for enterprise accounts." },
+    { prompt: "Can I export my data?", response: "Yes. Go to Settings → Data → Export to download a CSV or JSON archive of your workspace. Exports include records from the last 90 days by default." },
+    { prompt: "How do I invite a teammate?", response: "In Settings → Members, click Invite, enter their email, and pick a role (Admin, Editor, or Viewer). They'll get an email invitation to join the workspace." },
+    { prompt: "Is there a free trial?", response: "Yes, a 14-day trial with full features and no credit card required. You can add a payment method any time before it ends to keep your data." },
+  ],
+  summarisation: [
+    { prompt: "Summarise this sales-call note in two sentences:\n\"Spoke with the VP of Ops at Northwind. They're evaluating us against two competitors, main concern is onboarding time. Budget approved for Q3, decision expected in 4 weeks. Asked for a security questionnaire and a reference customer in logistics.\"", response: "Northwind's VP of Ops has Q3 budget approved and will decide within four weeks, weighing us against two competitors mainly on onboarding time. They requested a security questionnaire and a logistics reference customer." },
+    { prompt: "Summarise this CRM note in two sentences:\n\"Renewal call with Acme. Usage up 40% YoY, two new teams onboarded. They want volume pricing and SSO before signing a 2-year deal. Champion is supportive; procurement is the bottleneck.\"", response: "Acme's usage grew 40% year over year and they're ready for a two-year renewal, contingent on volume pricing and SSO. Their champion is supportive, but procurement is the main bottleneck." },
+    { prompt: "Summarise this support interaction in one sentence:\n\"Customer reported slow report loading; we identified a large date range as the cause and suggested narrowing filters. They confirmed it resolved the issue.\"", response: "The customer's slow report loading was caused by an overly large date range and was resolved by narrowing the filters." },
+    { prompt: "Summarise the outcome of this meeting note:\n\"Kickoff with Globex. Agreed on a 6-week pilot, success metric is 20% cost reduction. They assigned two engineers; we provide weekly check-ins.\"", response: "Globex agreed to a six-week pilot targeting a 20% cost reduction, with two of their engineers assigned and weekly check-ins from our side." },
+  ],
+  "document analysis": [
+    { prompt: "Summarise the key obligations in this indemnification clause:\n\"The Vendor shall indemnify, defend and hold harmless the Client from any third-party claims arising out of the Vendor's breach of this Agreement or negligence, up to a cap equal to fees paid in the prior 12 months.\"", response: "The Vendor must indemnify and defend the Client against third-party claims caused by the Vendor's breach or negligence. Liability is capped at the total fees paid in the preceding 12 months." },
+    { prompt: "Identify the termination rights in this clause:\n\"Either party may terminate for convenience on 60 days' written notice. The Client may terminate immediately upon a material breach that remains uncured for 15 days after notice.\"", response: "Either party may terminate for convenience with 60 days' written notice. The Client may also terminate immediately for a material breach left uncured 15 days after notice." },
+    { prompt: "What does this confidentiality clause require?\n\"Each party shall protect the other's Confidential Information with the same care it uses for its own, and not less than reasonable care, for a period of five years after disclosure.\"", response: "Each party must protect the other's confidential information with at least reasonable care (and no less than the care it gives its own), for five years after disclosure." },
+  ],
+  coding: [
+    { prompt: "Explain what this function does:\n```js\nfunction debounce(fn, ms) {\n  let t;\n  return (...args) => { clearTimeout(t); t = setTimeout(() => fn(...args), ms); };\n}\n```", response: "It returns a debounced wrapper around `fn`: each call resets a timer, so `fn` only runs once the wrapper has been idle for `ms` milliseconds. Useful for rate-limiting rapid events like keystrokes or resize handlers." },
+    { prompt: "Explain what this SQL query returns:\n```sql\nSELECT customer_id, COUNT(*) AS orders\nFROM orders WHERE created_at > NOW() - INTERVAL '30 days'\nGROUP BY customer_id HAVING COUNT(*) > 5;\n```", response: "It lists each customer who placed more than five orders in the last 30 days, along with their order count. The HAVING clause filters the grouped results to customers above the threshold." },
+    { prompt: "What does this Python snippet do?\n```python\nnums = [n for n in range(100) if n % 3 == 0 and n % 5 == 0]\n```", response: "It builds a list of numbers from 0 to 99 that are divisible by both 3 and 5 (i.e. multiples of 15): [0, 15, 30, 45, 60, 75, 90]." },
+  ],
+  // Structured-output extraction — drives the failure-first demo (JSON/schema breakage).
+  extraction: [
+    { prompt: "Extract the fields {party, effective_date, termination_notice_days, indemnity} as JSON from:\n\"This Agreement between Acme Inc. and the Client is effective January 1, 2026. Either party may terminate on 30 days notice. The Vendor shall indemnify the Client for third-party claims.\"", response: '{"party":"Acme Inc.","effective_date":"2026-01-01","termination_notice_days":30,"indemnity":true}' },
+    { prompt: "Extract {invoice_number, total_usd, due_date} as JSON from:\n\"Invoice INV-4821, amount due $12,450.00, payable by 2026-02-15.\"", response: '{"invoice_number":"INV-4821","total_usd":12450.00,"due_date":"2026-02-15"}' },
+    { prompt: "Extract {name, email, company} as JSON from this signature:\n\"Best, Dana Lee — Head of Ops, Globex — dana.lee@globex.com\"", response: '{"name":"Dana Lee","email":"dana.lee@globex.com","company":"Globex"}' },
+    { prompt: "Extract {governing_law, cap_months, auto_renew} as JSON from:\n\"This Agreement is governed by the laws of Delaware. Liability is capped at 12 months of fees. The term auto-renews annually unless cancelled.\"", response: '{"governing_law":"Delaware","cap_months":12,"auto_renew":true}' },
+  ],
+};
+
+const GENERIC = [
+  { prompt: "Draft a short, friendly reply confirming we received the customer's request and will follow up within one business day.", response: "Thanks for reaching out! We've received your request and a member of our team will follow up within one business day. We appreciate your patience." },
+  { prompt: "Rewrite this sentence to be more concise: \"We are writing to inform you that your order has now been shipped.\"", response: "Your order has shipped." },
+];
+
+// Deterministic pick within a task type's pack (index provided by the caller's PRNG).
+function getPromptPair(taskType, i) {
+  const pack = PACKS[String(taskType || "").toLowerCase()] || GENERIC;
+  return pack[i % pack.length];
+}
+
+module.exports = { getPromptPair, PACKS };

--- a/server/src/seed/seed.js
+++ b/server/src/seed/seed.js
@@ -12,7 +12,15 @@ const { v4: uuidv4 } = require("uuid");
 const { config } = require("../config");
 const RequestRecord = require("../models/RequestRecord");
 const Recommendation = require("../models/Recommendation");
+const EvalDataset = require("../models/EvalDataset");
+const EvalItem = require("../models/EvalItem");
+const EvalRun = require("../models/EvalRun");
+const EvalResult = require("../models/EvalResult");
+const RoutingExperiment = require("../models/RoutingExperiment");
 const pricing = require("../pricing/registry");
+const recommender = require("../recommend/engine");
+const { defaultThresholds } = require("../eval/thresholds");
+const { getPromptPair } = require("./promptPacks");
 
 // Deterministic PRNG so seeds are reproducible (no Math.random surprises).
 let _s = 1337;
@@ -58,6 +66,8 @@ function buildRecord({ application, workflow, department, model, provider, taskT
   const { inputCost, outputCost, totalCost } = pricing.costFor(model, promptTokens, completionTokens);
   const ts = new Date(Date.now() - daysAgo * 86400000 - between(0, 86400000));
   const failed = rnd() < 0.01;
+  // Attach a realistic prompt + response so the record is replayable by the eval flow.
+  const pair = getPromptPair(taskType, between(0, 99));
   return {
     requestId: uuidv4(),
     timestamp: ts,
@@ -70,7 +80,81 @@ function buildRecord({ application, workflow, department, model, provider, taskT
     retryCount: 0,
     routingDecision: "passthrough",
     cacheHit: false,
+    messages: [{ role: "user", content: pair.prompt }],
+    responseText: pair.response,
   };
+}
+
+// Seed a ready-made eval story so `docker compose up` (no keys) shows the wedge out of the box:
+// one PASSED downgrade (approved + a live canary) and one BLOCKED downgrade (failure-first).
+// Attaches to the recommendations recompute() produced, so it survives a later Recompute.
+async function seedEvalDemo() {
+  // ── PASSED: classification, claude-opus-4-8 → claude-haiku-4-5 ──────────────
+  const passRec = await Recommendation.findOne({ dedupeKey: "premium_overuse:classification:claude-opus-4-8" });
+  if (passRec) {
+    const ds = await EvalDataset.create({
+      name: "classification: claude-opus-4-8 → claude-haiku-4-5", recommendationId: passRec._id,
+      scope: { taskType: "classification" }, baselineModel: "claude-opus-4-8", candidateModel: "claude-haiku-4-5",
+      sampling: { method: "stratified", targetCount: 200, dedupeByPromptHash: true },
+      riskTier: "low", piiMode: "masked", itemCount: 200, status: "ready",
+    });
+    const summary = { total: 200, judged: 200, candidateBetter: 41, candidateEqual: 153, candidateWorse: 6,
+      worseRate: 0.03, criticalFailRate: 0, formatPassRate: 1, costSavingPct: 0.82, avgLatencyDeltaPct: -0.28,
+      prodCost: 4.43, candidateCost: 0.80, p95LatencyDeltaPct: -0.22 };
+    const run = await EvalRun.create({
+      recommendationId: passRec._id, datasetId: ds._id, taskType: "classification",
+      baselineModel: "claude-opus-4-8", candidateModel: "claude-haiku-4-5", judgeModel: "gpt-4o",
+      riskTier: "low", status: "passed", thresholds: defaultThresholds("low"), summary, failures: [],
+      estimatedCostUsd: 0.9, actualCostUsd: 0.86, startedAt: new Date(), completedAt: new Date(),
+    });
+    await EvalResult.insertMany([
+      { evalRunId: run._id, baselineModel: "claude-opus-4-8", candidateModel: "claude-haiku-4-5", candidateResponse: "billing", judgeVerdict: "equal", formatPass: true, dimensionScores: { correctness: 5, format: 5 }, judgeRationale: "Both correctly label the ticket 'billing'." },
+      { evalRunId: run._id, baselineModel: "claude-opus-4-8", candidateModel: "claude-haiku-4-5", candidateResponse: "technical", judgeVerdict: "equal", formatPass: true, dimensionScores: { correctness: 5, format: 5 }, judgeRationale: "Identical, correct classification." },
+      { evalRunId: run._id, baselineModel: "claude-opus-4-8", candidateModel: "claude-haiku-4-5", candidateResponse: "account", judgeVerdict: "better", formatPass: true, dimensionScores: { correctness: 5, format: 5 }, judgeRationale: "Candidate picked the more precise label." },
+      { evalRunId: run._id, baselineModel: "claude-opus-4-8", candidateModel: "claude-haiku-4-5", candidateResponse: "feedback (positive)", judgeVerdict: "worse", formatPass: true, dimensionScores: { correctness: 3, format: 4 }, judgeRationale: "Candidate added an unrequested sentiment tag; baseline was cleaner." },
+    ]);
+    passRec.evalStatus = "passed"; passRec.evalDatasetId = ds._id; passRec.evalRunId = run._id; passRec.qualitySummary = summary;
+
+    const exp = await RoutingExperiment.create({
+      evalRunId: run._id, recommendationId: passRec._id,
+      scope: { application: "support-chat", taskType: "classification" },
+      baselineModel: "claude-opus-4-8", candidateModel: "claude-haiku-4-5", candidateProvider: "anthropic",
+      rolloutPct: 10, status: "active", metricsWindowMinutes: 60,
+      lastMonitoredAt: new Date(),
+      lastMetrics: { candTotal: 63, candErrorRate: 0.008, baseErrorRate: 0.011, latencyRegressionPct: -0.26, costSavingPct: 0.8, worseRate: 0.03 },
+    });
+    passRec.experimentId = exp._id;
+    await passRec.save();
+  }
+
+  // ── BLOCKED (failure-first): extraction, gpt-4o → gpt-4o-mini ───────────────
+  const failRec = await Recommendation.findOne({ dedupeKey: "premium_overuse:extraction:gpt-4o" });
+  if (failRec) {
+    const ds = await EvalDataset.create({
+      name: "extraction: gpt-4o → gpt-4o-mini", recommendationId: failRec._id,
+      scope: { taskType: "extraction" }, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini",
+      sampling: { method: "stratified", targetCount: 300, dedupeByPromptHash: true },
+      riskTier: "medium", piiMode: "masked", itemCount: 300, status: "ready",
+    });
+    const summary = { total: 300, judged: 300, candidateBetter: 20, candidateEqual: 196, candidateWorse: 84,
+      worseRate: 0.28, criticalFailRate: 0.05, formatPassRate: 0.72, costSavingPct: 0.93, avgLatencyDeltaPct: -0.15,
+      prodCost: 1.13, candidateCost: 0.07, p95LatencyDeltaPct: -0.10 };
+    const run = await EvalRun.create({
+      recommendationId: failRec._id, datasetId: ds._id, taskType: "extraction",
+      baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", judgeModel: "claude-opus-4-8",
+      riskTier: "medium", status: "failed", thresholds: defaultThresholds("medium"), summary,
+      failures: ["worse-rate 28.0% exceeds 3.0%", "critical-failure rate 5.0% exceeds 0.2%", "format pass-rate 72.0% below 99.0%"],
+      estimatedCostUsd: 1.4, actualCostUsd: 1.31, startedAt: new Date(), completedAt: new Date(),
+    });
+    await EvalResult.insertMany([
+      { evalRunId: run._id, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", candidateResponse: '{"party":"Acme Inc.","effective_date":"Jan 1 2026","indemnity":true}', judgeVerdict: "worse", criticalFailure: true, formatPass: false, validatorResults: [{ type: "json_schema", pass: false }], dimensionScores: { correctness: 2, format: 1 }, judgeRationale: "Dropped termination_notice_days and used a non-ISO date; fails the schema." },
+      { evalRunId: run._id, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", candidateResponse: 'Here is the JSON: {"invoice_number":"INV-4821","total_usd":"12,450"}', judgeVerdict: "worse", criticalFailure: true, formatPass: false, validatorResults: [{ type: "json_schema", pass: false }], dimensionScores: { correctness: 2, format: 1 }, judgeRationale: "Wrapped JSON in prose, quoted the number with a comma, and omitted due_date." },
+      { evalRunId: run._id, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", candidateResponse: '{"governing_law":"Delaware","cap_months":12,"auto_renew":true}', judgeVerdict: "equal", formatPass: true, validatorResults: [{ type: "json_schema", pass: true }], dimensionScores: { correctness: 5, format: 5 }, judgeRationale: "Correct on the simple case." },
+      { evalRunId: run._id, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", candidateResponse: '{"name":"Dana Lee","company":"Globex"}', judgeVerdict: "worse", criticalFailure: false, formatPass: false, validatorResults: [{ type: "json_schema", pass: false }], dimensionScores: { correctness: 3, format: 2 }, judgeRationale: "Omitted the required email field." },
+    ]);
+    failRec.evalStatus = "failed"; failRec.evalDatasetId = ds._id; failRec.evalRunId = run._id; failRec.qualitySummary = summary;
+    await failRec.save();
+  }
 }
 
 async function main() {
@@ -84,6 +168,11 @@ async function main() {
 
   await RequestRecord.deleteMany({});
   await Recommendation.deleteMany({});
+  // Reset the eval demo collections too, so reseeding is idempotent.
+  await Promise.all([
+    EvalDataset.deleteMany({}), EvalItem.deleteMany({}), EvalRun.deleteMany({}),
+    EvalResult.deleteMany({}), RoutingExperiment.deleteMany({}),
+  ]);
 
   const records = [];
 
@@ -124,7 +213,16 @@ async function main() {
 
   await RequestRecord.insertMany(records);
   console.log(`Inserted ${records.length} request records.`);
-  console.log("Done. Start the server and open the dashboard; click 'Recompute' on Recommendations.");
+
+  // Generate recommendations from the traffic, then attach a ready-made eval story
+  // (one approved downgrade + a live canary, one blocked downgrade) so the eval-backed
+  // wedge is visible on first boot without any provider keys.
+  const recs = await recommender.recompute();
+  console.log(`Computed ${recs.length} recommendations.`);
+  await seedEvalDemo();
+  console.log("Seeded eval demo: 1 approved (classification, + canary) and 1 blocked (extraction).");
+
+  console.log("Done. Start the server and open the dashboard — Routing → Recommendations and Model Evals.");
   await mongoose.disconnect();
 }
 

--- a/server/test/unit/promptPacks.test.js
+++ b/server/test/unit/promptPacks.test.js
@@ -1,0 +1,22 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { getPromptPair } = require("../../src/seed/promptPacks");
+
+test("getPromptPair returns a prompt/response pair for a known task type", () => {
+  const p = getPromptPair("classification", 0);
+  assert.ok(p.prompt && typeof p.prompt === "string");
+  assert.ok(p.response && typeof p.response === "string");
+});
+
+test("getPromptPair cycles within a pack and falls back for unknown types", () => {
+  const p = getPromptPair("extraction", 5); // index wraps
+  assert.ok(p.prompt.includes("JSON")); // extraction pack is structured
+  const g = getPromptPair("totally-unknown-task", 0);
+  assert.ok(g.prompt && g.response); // generic fallback
+});
+
+test("extraction responses are valid JSON (drives the structured-output demo)", () => {
+  const p = getPromptPair("extraction", 0);
+  assert.doesNotThrow(() => JSON.parse(p.response));
+});


### PR DESCRIPTION
Makes the eval-backed wedge **runnable and memorable on a fresh `docker compose up` with no provider keys** — the precondition the growth brief sets before any launch. **Stacked on #82** (the eval chain); merge after #79→#82.

## Why
Synthetic seed records had no `messages`/`responseText`, so the eval flow had nothing to replay (`create-eval-dataset` returned 422 on demo data). The flagship demo couldn't actually run.

## What
- **`promptPacks.js`** — realistic prompt/response pairs across the five demo task types (support classification, FAQ, CRM summaries, legal/contract extraction, code explanation). Every seeded record now carries a replayable prompt + response, so a user who adds a key can run real evals too.
- **`seed.js`** — after generating recommendations from traffic, seeds a ready-made eval story (attached by `dedupeKey`, so it survives a later Recompute):
  - **APPROVED** — classification `claude-opus-4-8 → claude-haiku-4-5`: passed offline eval (worse 3%, cost −82%) **plus a live 10% canary**.
  - **BLOCKED (failure-first)** — extraction `gpt-4o → gpt-4o-mini`: saves 93% but **fails** (worse 28%, 5% critical, 72% format pass) because the cheaper model breaks the JSON schema, so the downgrade can't be approved. This is the "savings blocked by quality" story the brief calls the memorable one.
- Idempotent: reseeding clears the eval collections too.

## Verified (screenshots taken)
`docker compose up` with no keys →
- Recommendations page: classification shows **Eval passed** (+ Start canary), extraction shows **Eval failed** with red worse/critical/format badges.
- Model Evals page: both offline runs with Evidence buttons + the active 10% canary with Promote / Roll back.

Also added a small unit test for the prompt packs (valid JSON for extraction, fallback behavior).

Part of #76. Together with #79–#82 this satisfies the brief's P0 (one-command demo, synthetic traffic pack, eval-backed recommendation, failure-first example).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
