### PR TITLE
feat(eval): land Phase 2-4 + demo seed onto main (re-land of stacked #80-#83)

### DIFF
--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -40,6 +40,8 @@ const evalReplay = require("../eval/replay");
 const evalThresholds = require("../eval/thresholds");
 const { sameFamily } = require("../eval/rubricJudge");
 const { tierForTask } = require("../classify/classifier");
+const RoutingExperiment = require("../models/RoutingExperiment");
+const canaryEngine = require("../routing/canaryEngine");
 const secrets = require("../security/secrets");
 const { config, KNOWN_PROVIDERS } = require("../config");
 const { classifyModelImport, isChatLikelyModelId } = require("../providers/importLogic");
@@ -772,6 +774,117 @@ router.get("/evals/runs/:id/results", async (req, res, next) => {
   } catch (e) { next(e); }
 });
 
+// Clamp/normalize canary guardrail inputs to sane numbers (falls back to defaults).
+function sanitizeGuardrails(g) {
+  const d = { maxErrorRateIncrease: 0.02, maxLatencyRegressionPct: 0.25, maxWorseRate: 0.10, minCostSavingPct: 0.10 };
+  if (!g || typeof g !== "object") return d;
+  const num = (v, def) => (v != null && !isNaN(Number(v)) ? Number(v) : def);
+  return {
+    maxErrorRateIncrease: num(g.maxErrorRateIncrease, d.maxErrorRateIncrease),
+    maxLatencyRegressionPct: num(g.maxLatencyRegressionPct, d.maxLatencyRegressionPct),
+    maxWorseRate: num(g.maxWorseRate, d.maxWorseRate),
+    minCostSavingPct: num(g.minCostSavingPct, d.minCostSavingPct),
+  };
+}
+
+// ── Routing experiments (canary rollout, Phase 3) ─────────────────────────────
+router.get("/routing-experiments", async (req, res, next) => {
+  try {
+    const q = req.query.status ? { status: req.query.status } : {};
+    res.json(await RoutingExperiment.find(q).sort({ createdAt: -1 }).lean());
+  } catch (e) { next(e); }
+});
+router.get("/routing-experiments/:id", async (req, res, next) => {
+  try {
+    const exp = await RoutingExperiment.findById(req.params.id).lean().catch(() => null);
+    if (!exp) return res.status(404).json({ error: "not found" });
+    res.json(exp);
+  } catch (e) { next(e); }
+});
+
+// Create a canary from a passed recommendation (only auto-routed traffic is affected).
+router.post("/recommendations/:id/create-canary", async (req, res, next) => {
+  try {
+    const rec = await Recommendation.findById(req.params.id);
+    if (!rec) return res.status(404).json({ error: "not found" });
+    const b = req.body || {};
+    const offlineRun = rec.evalRunId ? await EvalRun.findById(rec.evalRunId).lean().catch(() => null) : null;
+    const gate = evalThresholds.canActivateShadow(offlineRun, b.override); // same "passed offline or override" bar
+    if (!gate.allowed) return res.status(409).json({ error: "eval_required", message: gate.reason });
+
+    const exp = await RoutingExperiment.create({
+      evalRunId: rec.evalRunId || null, recommendationId: rec._id, shadowCampaignId: rec.shadowCampaignId || null,
+      scope: { application: b.application || rec.application || null, workflow: b.workflow || null, taskType: rec.taskType || null },
+      baselineModel: rec.currentModel, candidateModel: rec.suggestedModel,
+      candidateProvider: rec.suggestedProvider || pricing.getModel(rec.suggestedModel)?.provider || null,
+      rolloutPct: b.rolloutPct != null ? Math.min(100, Math.max(0, Number(b.rolloutPct))) : 10,
+      guardrails: sanitizeGuardrails(b.guardrails),
+      metricsWindowMinutes: b.metricsWindowMinutes != null ? Math.max(5, Number(b.metricsWindowMinutes)) : 60,
+      status: "active", createdBy: "console", approvedBy: b.approvedBy || null,
+    });
+    rec.experimentId = exp._id;
+    await rec.save();
+    canaryEngine.invalidate();
+    setImmediate(() => logAction("canary.create", "routingExperiment", String(exp._id), { recommendationId: String(rec._id), rolloutPct: exp.rolloutPct }));
+    res.status(201).json(exp);
+  } catch (e) { next(e); }
+});
+
+router.patch("/routing-experiments/:id", async (req, res, next) => {
+  try {
+    const b = req.body || {};
+    const update = {};
+    if (b.rolloutPct != null) update.rolloutPct = Math.min(100, Math.max(0, Number(b.rolloutPct)));
+    if (b.status && ["active", "paused"].includes(b.status)) update.status = b.status; // rollback/promote have their own routes
+    if (b.guardrails) update.guardrails = sanitizeGuardrails(b.guardrails);
+    if (b.metricsWindowMinutes != null) update.metricsWindowMinutes = Math.max(5, Number(b.metricsWindowMinutes));
+    const exp = await RoutingExperiment.findByIdAndUpdate(req.params.id, { $set: update }, { new: true }).lean();
+    if (!exp) return res.status(404).json({ error: "not found" });
+    canaryEngine.invalidate();
+    setImmediate(() => logAction("canary.update", "routingExperiment", req.params.id, update));
+    res.json(exp);
+  } catch (e) { next(e); }
+});
+
+// Manual rollback — stop diverting traffic; the candidate is abandoned but logs are kept.
+router.post("/routing-experiments/:id/rollback", async (req, res, next) => {
+  try {
+    const reason = (req.body && req.body.reason) || "manual rollback";
+    const exp = await RoutingExperiment.findByIdAndUpdate(
+      req.params.id, { $set: { status: "rolled_back", rollbackReason: reason } }, { new: true }
+    ).lean();
+    if (!exp) return res.status(404).json({ error: "not found" });
+    canaryEngine.invalidate();
+    setImmediate(() => logAction("canary.rollback", "routingExperiment", req.params.id, { reason }));
+    res.json(exp);
+  } catch (e) { next(e); }
+});
+
+// Promote — go to 100% by creating an ENABLED, reversible rule and marking the rec accepted.
+router.post("/routing-experiments/:id/promote", async (req, res, next) => {
+  try {
+    const exp = await RoutingExperiment.findById(req.params.id);
+    if (!exp) return res.status(404).json({ error: "not found" });
+    if (exp.status === "rolled_back") return res.status(409).json({ error: "rolled_back", message: "cannot promote a rolled-back experiment" });
+    const provider = exp.candidateProvider || pricing.getModel(exp.candidateModel)?.provider;
+    if (!provider) return res.status(422).json({ error: "no_provider", message: "cannot determine the candidate's provider; set candidateProvider on the experiment." });
+    const rule = await Rule.create({
+      condition: { taskType: exp.scope?.taskType || null, application: exp.scope?.application || null, workflow: exp.scope?.workflow || null },
+      target: { provider, model: exp.candidateModel },
+      enabled: true, createdBy: "console",
+      sourceRecommendation: exp.recommendationId || null,
+      note: `promoted canary ${exp.baselineModel} → ${exp.candidateModel}`,
+    });
+    exp.status = "promoted"; exp.rolloutPct = 100; exp.ruleId = rule._id; exp.approvedBy = (req.body && req.body.approvedBy) || exp.approvedBy;
+    await exp.save();
+    if (exp.recommendationId) await Recommendation.findByIdAndUpdate(exp.recommendationId, { status: "accepted" });
+    ruleEngine.invalidate();
+    canaryEngine.invalidate();
+    setImmediate(() => logAction("canary.promote", "routingExperiment", String(exp._id), { ruleId: String(rule._id), candidateModel: exp.candidateModel }));
+    res.json({ experiment: exp, rule });
+  } catch (e) { next(e); }
+});
+
 router.post("/recommendations/:id/dismiss", async (req, res, next) => {
   try {
     const rec = await Recommendation.findByIdAndUpdate(
@@ -1215,12 +1328,30 @@ router.get("/eval/campaigns", async (req, res, next) => {
 
 router.post("/eval/campaigns", async (req, res, next) => {
   try {
-    const { application, candidateModel, judgeModel, sampleRate, thresholds, name } = req.body || {};
+    const b = req.body || {};
+    const { application, candidateModel, judgeModel, sampleRate, thresholds, name, baselineModel, scope,
+      requiredEvalRunId, maxDailyShadowBudgetUsd, maxCandidateErrors, startDate, endDate, override } = b;
     if (!application) return res.status(400).json({ error: "application is required" });
     if (!candidateModel) return res.status(400).json({ error: "candidateModel is required" });
+
+    // Phase 2 gate: a campaign only goes ACTIVE if a linked offline eval passed (or overridden);
+    // otherwise it is created PAUSED with the reason, ready to activate once the eval passes.
+    const wantActive = b.status !== "paused";
+    const offlineRun = requiredEvalRunId ? await EvalRun.findById(requiredEvalRunId).lean().catch(() => null) : null;
+    const gate = evalThresholds.canActivateShadow(offlineRun, override);
+    const status = wantActive && gate.allowed ? "active" : "paused";
+    const statusReason = status === "paused" && wantActive ? gate.reason : null;
+
     const doc = await EvalCampaign.create({
       application, candidateModel, name: name || "",
+      baselineModel: baselineModel || null,
       judgeModel: judgeModel || null,
+      scope: { workflow: scope?.workflow || null, taskType: scope?.taskType || null },
+      requiredEvalRunId: requiredEvalRunId || null,
+      maxDailyShadowBudgetUsd: maxDailyShadowBudgetUsd != null ? Number(maxDailyShadowBudgetUsd) : null,
+      maxCandidateErrors: maxCandidateErrors != null ? Math.max(1, Number(maxCandidateErrors)) : null,
+      startDate: startDate || null, endDate: endDate || null,
+      status, statusReason,
       sampleRate: sampleRate != null ? Math.min(1, Math.max(0, Number(sampleRate))) : 0.1,
       thresholds: {
         minPairs: thresholds?.minPairs != null ? Math.max(1, Number(thresholds.minPairs)) : 50,
@@ -1228,7 +1359,7 @@ router.post("/eval/campaigns", async (req, res, next) => {
       },
     });
     invalidateCampaignCache();
-    setImmediate(() => logAction("evalCampaign.create", "evalCampaign", String(doc._id), { application, candidateModel }));
+    setImmediate(() => logAction("evalCampaign.create", "evalCampaign", String(doc._id), { application, candidateModel, status }));
     res.status(201).json(doc);
   } catch (e) { next(e); }
 });
@@ -1239,7 +1370,43 @@ router.get("/eval/campaigns/:id", async (req, res, next) => {
     if (!c) return res.status(404).json({ error: "not found" });
     const pairs = await EvalPair.find({ campaignId: c._id },
       { prodCost: 1, candidateCost: 1, prodLatencyMs: 1, candidateLatencyMs: 1, verdict: 1 }).lean();
-    res.json({ ...c, summary: summarizeEvalPairs(pairs) });
+    // Worst candidate examples for the evidence view (Phase 2).
+    const worstExamples = await EvalPair.find({ campaignId: c._id, verdict: "worse" })
+      .sort({ timestamp: -1 }).limit(20).lean();
+    res.json({ ...c, summary: summarizeEvalPairs(pairs), worstExamples });
+  } catch (e) { next(e); }
+});
+
+// Start a shadow campaign directly from a recommendation (requires its offline eval passed).
+router.post("/recommendations/:id/start-shadow", async (req, res, next) => {
+  try {
+    const rec = await Recommendation.findById(req.params.id);
+    if (!rec) return res.status(404).json({ error: "not found" });
+    const b = req.body || {};
+    const application = b.application || rec.application;
+    if (!application) return res.status(400).json({ error: "application is required (recommendations are not app-scoped)" });
+
+    const offlineRun = rec.evalRunId ? await EvalRun.findById(rec.evalRunId).lean().catch(() => null) : null;
+    const gate = evalThresholds.canActivateShadow(offlineRun, b.override);
+    if (!gate.allowed) return res.status(409).json({ error: "eval_required", message: gate.reason });
+
+    const campaign = await EvalCampaign.create({
+      name: `shadow: ${rec.currentModel} → ${rec.suggestedModel}`,
+      application, candidateModel: rec.suggestedModel, baselineModel: rec.currentModel,
+      judgeModel: b.judgeModel || null,
+      scope: { taskType: rec.taskType || null, workflow: b.workflow || null },
+      recommendationId: rec._id, requiredEvalRunId: rec.evalRunId || null,
+      sampleRate: b.sampleRate != null ? Math.min(1, Math.max(0, Number(b.sampleRate))) : 0.1,
+      maxDailyShadowBudgetUsd: b.maxDailyShadowBudgetUsd != null ? Number(b.maxDailyShadowBudgetUsd) : null,
+      maxCandidateErrors: b.maxCandidateErrors != null ? Math.max(1, Number(b.maxCandidateErrors)) : null,
+      startDate: b.startDate || null, endDate: b.endDate || null,
+      status: "active",
+    });
+    rec.shadowCampaignId = campaign._id;
+    await rec.save();
+    invalidateCampaignCache();
+    setImmediate(() => logAction("eval.shadow.start", "evalCampaign", String(campaign._id), { recommendationId: String(rec._id), via: offlineRun?.status === "passed" ? "passed" : "override" }));
+    res.status(201).json(campaign);
   } catch (e) { next(e); }
 });
 
@@ -1253,16 +1420,36 @@ router.get("/eval/campaigns/:id/pairs", async (req, res, next) => {
 router.patch("/eval/campaigns/:id", async (req, res, next) => {
   try {
     const b = req.body || {};
+    const existing = await EvalCampaign.findById(req.params.id).lean().catch(() => null);
+    if (!existing) return res.status(404).json({ error: "not found" });
+
     const update = {};
-    if (b.status && ["active", "paused", "done"].includes(b.status)) update.status = b.status;
+    // Activating is gated on a passed offline eval (Phase 2), unless overridden.
+    if (b.status && ["active", "paused", "done"].includes(b.status)) {
+      if (b.status === "active" && existing.status !== "active") {
+        const runId = b.requiredEvalRunId || existing.requiredEvalRunId;
+        const offlineRun = runId ? await EvalRun.findById(runId).lean().catch(() => null) : null;
+        const gate = evalThresholds.canActivateShadow(offlineRun, b.override);
+        if (!gate.allowed) return res.status(409).json({ error: "eval_required", message: gate.reason });
+        update.statusReason = null;
+        update.candidateErrorCount = 0; // reset the safety counter on a fresh activation
+      }
+      update.status = b.status;
+    }
     if (b.sampleRate != null) update.sampleRate = Math.min(1, Math.max(0, Number(b.sampleRate)));
     if (b.judgeModel !== undefined) update.judgeModel = b.judgeModel || null;
+    if (b.baselineModel !== undefined) update.baselineModel = b.baselineModel || null;
+    if (b.scope) update.scope = { workflow: b.scope.workflow || null, taskType: b.scope.taskType || null };
+    if (b.requiredEvalRunId !== undefined) update.requiredEvalRunId = b.requiredEvalRunId || null;
+    if (b.maxDailyShadowBudgetUsd !== undefined) update.maxDailyShadowBudgetUsd = b.maxDailyShadowBudgetUsd != null ? Number(b.maxDailyShadowBudgetUsd) : null;
+    if (b.maxCandidateErrors !== undefined) update.maxCandidateErrors = b.maxCandidateErrors != null ? Math.max(1, Number(b.maxCandidateErrors)) : null;
+    if (b.startDate !== undefined) update.startDate = b.startDate || null;
+    if (b.endDate !== undefined) update.endDate = b.endDate || null;
     if (b.thresholds) update.thresholds = {
       minPairs: b.thresholds.minPairs != null ? Math.max(1, Number(b.thresholds.minPairs)) : 50,
       maxLossRate: b.thresholds.maxLossRate != null ? Math.min(1, Math.max(0, Number(b.thresholds.maxLossRate))) : 0.1,
     };
     const c = await EvalCampaign.findByIdAndUpdate(req.params.id, { $set: update }, { new: true }).lean();
-    if (!c) return res.status(404).json({ error: "not found" });
     invalidateCampaignCache();
     res.json(c);
   } catch (e) { next(e); }

--- a/server/src/eval/logic.js
+++ b/server/src/eval/logic.js
@@ -53,4 +53,26 @@ function summarizeEvalPairs(pairs) {
   };
 }
 
-module.exports = { isSingleShot, shouldSample, parseVerdict, summarizeEvalPairs };
+// Is `now` inside a campaign's [start, end] window? null bound = open on that side. Pure.
+function withinWindow(now, startDate, endDate) {
+  const t = now instanceof Date ? now.getTime() : Number(now);
+  if (startDate && t < new Date(startDate).getTime()) return false;
+  if (endDate && t > new Date(endDate).getTime()) return false;
+  return true;
+}
+
+// Does this request fall within a campaign's scope filters? A null scope field = "any". The
+// baseline model (the model prod actually served) must match campaign.baselineModel when set.
+// Pure.
+function campaignMatches(campaign, { taskType, workflow, baselineModel }) {
+  if (!campaign) return false;
+  const scope = campaign.scope || {};
+  if (scope.taskType && String(scope.taskType).toLowerCase() !== String(taskType || "").toLowerCase()) return false;
+  if (scope.workflow && scope.workflow !== workflow) return false;
+  if (campaign.baselineModel && campaign.baselineModel !== baselineModel) return false;
+  return true;
+}
+
+module.exports = {
+  isSingleShot, shouldSample, parseVerdict, summarizeEvalPairs, withinWindow, campaignMatches,
+};

--- a/server/src/eval/replay.js
+++ b/server/src/eval/replay.js
@@ -9,7 +9,7 @@ const EvalRun = require("../models/EvalRun");
 const EvalResult = require("../models/EvalResult");
 const Recommendation = require("../models/Recommendation");
 const { clampText, maskPii } = require("../logging/piiFilter");
-const { judgeItem, runValidators, sameFamily, lastUserText } = require("./rubricJudge");
+const { judgeItem, runValidators, lastUserText } = require("./rubricJudge");
 const { evaluateRun } = require("./thresholds");
 
 function percentile(sorted, p) {

--- a/server/src/eval/shadow.js
+++ b/server/src/eval/shadow.js
@@ -8,7 +8,7 @@ const Settings = require("../models/Settings");
 const pricing = require("../pricing/registry");
 const { maskMessages, maskPii, clampText } = require("../logging/piiFilter");
 const { judge } = require("./judge");
-const { isSingleShot, shouldSample } = require("./logic");
+const { isSingleShot, shouldSample, withinWindow, campaignMatches } = require("./logic");
 
 // Short-lived active-campaign cache per application (mirrors getAppConfig in handler.js).
 const _campaignCache = new Map(); // application -> { campaign, expiresAt }
@@ -25,6 +25,28 @@ function invalidateCampaignCache() { _campaignCache.clear(); }
 function costOf(model, usage) {
   const u = usage || {};
   return pricing.costFor(model, u.inputTokens || 0, u.outputTokens || 0).totalCost;
+}
+
+// Candidate spend for this campaign since UTC midnight — enforces maxDailyShadowBudgetUsd.
+async function spentTodayUsd(campaignId) {
+  const since = new Date(); since.setUTCHours(0, 0, 0, 0);
+  const agg = await EvalPair.aggregate([
+    { $match: { campaignId, timestamp: { $gte: since } } },
+    { $group: { _id: null, total: { $sum: "$candidateCost" } } },
+  ]).catch(() => []);
+  return agg.length ? (agg[0].total || 0) : 0;
+}
+
+// Count a candidate call failure; pause the campaign once maxCandidateErrors is hit.
+async function recordCandidateError(campaign) {
+  const count = (campaign.candidateErrorCount || 0) + 1;
+  const update = { candidateErrorCount: count };
+  if (campaign.maxCandidateErrors != null && count >= campaign.maxCandidateErrors) {
+    update.status = "paused";
+    update.statusReason = `candidate error cap (${campaign.maxCandidateErrors}) reached`;
+  }
+  await EvalCampaign.updateOne({ _id: campaign._id }, { $set: update }).catch(() => {});
+  invalidateCampaignCache();
 }
 
 // Fire the "safe to switch" webhook once thresholds clear.
@@ -55,20 +77,25 @@ async function checkThresholdAndNotify(campaign) {
 }
 
 // prod = { model, provider, latencyMs, text, usage }
-async function maybeShadowEval({ application, taskType, messages, hasTools, requestId, prod, router, eff }) {
+async function maybeShadowEval({ application, workflow, taskType, messages, hasTools, requestId, prod, router, eff }) {
   try {
     const campaign = await getActiveCampaign(application);
     if (!campaign || !router || !eff) return;
+    if (!withinWindow(Date.now(), campaign.startDate, campaign.endDate)) return; // outside date window
+    if (!campaignMatches(campaign, { taskType, workflow, baselineModel: prod.model })) return; // scope filter
     if (!isSingleShot(messages, hasTools)) return;
     if (!shouldSample(Math.random(), campaign.sampleRate)) return;
     const cm = pricing.getModel(campaign.candidateModel);
     if (!cm || !eff.liveIds.includes(cm.provider)) return;   // candidate not live → skip
     if (cm.id === prod.model) return;                        // same model → nothing to compare
 
+    // Daily shadow budget: stop mirroring once today's candidate spend hits the cap.
+    if (campaign.maxDailyShadowBudgetUsd != null && await spentTodayUsd(campaign._id) >= campaign.maxDailyShadowBudgetUsd) return;
+
     const candidate = await router.complete({
       messages, providerOverride: cm.provider, modelOverride: campaign.candidateModel,
     }).catch(() => null);
-    if (!candidate) return;
+    if (!candidate) { await recordCandidateError(campaign); return; }
 
     const s = await Settings.get().catch(() => null);
     const mask = !!s?.piiMaskingEnabled;

--- a/server/src/eval/thresholds.js
+++ b/server/src/eval/thresholds.js
@@ -80,6 +80,20 @@ function gateAccept(rec, override, now = Date.now()) {
   };
 }
 
+// Phase 2 gate: a shadow campaign may only go active once its linked offline run PASSED, unless
+// an admin overrides. `offlineRun` is the EvalRun referenced by requiredEvalRunId (or null). Pure.
+// Returns { allowed, reason? }.
+function canActivateShadow(offlineRun, override) {
+  if (offlineRun && offlineRun.status === "passed") return { allowed: true };
+  if (override && override.reason && override.approver) return { allowed: true };
+  return {
+    allowed: false,
+    reason: offlineRun
+      ? `linked offline eval is "${offlineRun.status}", not "passed". Pass it first or override { reason, approver }.`
+      : "shadow requires a passed offline eval (requiredEvalRunId). Run one first, or override { reason, approver }.",
+  };
+}
+
 function pct(n) {
   if (n == null || isNaN(n)) return "n/a";
   return `${(Number(n) * 100).toFixed(1)}%`;
@@ -91,6 +105,7 @@ module.exports = {
   defaultThresholds,
   evaluateRun,
   gateAccept,
+  canActivateShadow,
   HIGH_RISK_MIN_HUMAN_REVIEW,
   _THRESHOLDS: THRESHOLDS,
 };

--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -15,6 +15,7 @@ const ruleEngine = require("../routing/ruleEngine");
 const autoRouter = require("../routing/autoRouter");
 const policyEngine = require("../routing/policy");
 const aiPolicy = require("../routing/aiPolicy");
+const canaryEngine = require("../routing/canaryEngine");
 const capEngine = require("../routing/capEngine");
 const responseCache = require("../routing/responseCache");
 const outputGuardrail = require("./outputGuardrail");
@@ -94,7 +95,7 @@ async function invokeWithFallback(router, eff, { provider, model, messages, temp
 // Shared routing resolution: classify task + decide served {provider, model}.
 // Returns { served, routingDecision, taskType, classifiedBy, cls }.
 // Callers are responsible for budget enforcement (it may short-circuit the response).
-async function resolveRoute(body, { router, eff, application, workflow, appConfig = {}, appDbConfig = null }) {
+async function resolveRoute(body, { router, eff, application, workflow, userId = null, appConfig = {}, appDbConfig = null }) {
   const routingMode = await ruleEngine.getRoutingMode();
   const explicit = resolveExplicit(body, eff);
   const autoMode = !explicit;
@@ -170,6 +171,28 @@ async function resolveRoute(body, { router, eff, application, workflow, appConfi
       }
     }
   }
+  // Eval-approved canary: divert a deterministic fraction of AUTO-routed traffic to a candidate
+  // model. Pinned (explicit) models are never touched. Fail-open — selectCanary swallows its own
+  // errors, and allowed-model / opt-out checks below still apply to the canary target.
+  if (autoMode) {
+    const canary = await canaryEngine.selectCanary({ application, workflow, taskType, servedModel: served.model, userId });
+    if (canary) {
+      // Prefer the registered model's provider; fall back to the experiment's stored provider
+      // so an unregistered candidate can still be canaried.
+      const provider = pricing.getModel(canary.toModel)?.provider || canary.experiment.candidateProvider;
+      if (provider && eff.liveIds.includes(provider)) {
+        explain.canary = {
+          experimentId: String(canary.experiment._id),
+          evalRunId: canary.experiment.evalRunId ? String(canary.experiment.evalRunId) : null,
+          fromModel: served.model, toModel: canary.toModel, rolloutPct: canary.experiment.rolloutPct,
+        };
+        explain.override = { type: "canary", from: served.model, to: canary.toModel };
+        served = { provider, model: canary.toModel };
+        routingDecision = "canary";
+      }
+    }
+  }
+
   explain.classificationUsed =
     explain.basis === "ai" || explain.basis === "auto" ||
     (explain.basis === "rule" && !!explain.rule?.condition?.taskType);
@@ -270,7 +293,7 @@ async function handleChat(req, res) {
   let served, routingDecision, taskType, classifiedBy, cls, difficulty, difficultyScore, confidence, explain;
   try {
     ({ served, routingDecision, taskType, classifiedBy, cls, difficulty, difficultyScore, confidence, explain } =
-      await resolveRoute(body, { router, eff, application: meta.application, workflow: meta.workflow, appConfig, appDbConfig: appCfg }));
+      await resolveRoute(body, { router, eff, application: meta.application, workflow: meta.workflow, userId: meta.userId, appConfig, appDbConfig: appCfg }));
   } catch (err) {
     if (err.code === "model_not_allowed") {
       return res.status(403).json({ error: err.message, code: "model_not_allowed" });
@@ -486,7 +509,7 @@ async function handleChat(req, res) {
     });
     // Shadow-eval: mirror to a candidate model if a campaign is active for this app (self-guarded, non-blocking).
     maybeShadowEval({
-      application: meta.application, taskType, messages: body.messages, hasTools: false, requestId, router, eff,
+      application: meta.application, workflow: meta.workflow, taskType, messages: body.messages, hasTools: false, requestId, router, eff,
       prod: { model: result.modelId, provider: result.providerId, latencyMs: result.latencyMs, text: result.text, usage: result.usage },
     });
   });

--- a/server/src/gateway/openaiCompat.js
+++ b/server/src/gateway/openaiCompat.js
@@ -227,7 +227,7 @@ async function proxyOpenAICompat(ctx) {
       latencyMs, status: "success",
     });
     maybeShadowEval({
-      application: meta.application, taskType, messages: body.messages, hasTools: !!(body.tools && body.tools.length),
+      application: meta.application, workflow: meta.workflow, taskType, messages: body.messages, hasTools: !!(body.tools && body.tools.length),
       requestId, router, eff,
       prod: { model: served.model, provider: served.provider, latencyMs, text: data.choices?.[0]?.message?.content || "",
               usage: { inputTokens: u.prompt_tokens || 0, outputTokens: u.completion_tokens || 0 } },
@@ -357,7 +357,7 @@ async function handleOpenAICompat(req, res) {
   let served, routingDecision, taskType, classifiedBy, difficulty, difficultyScore, confidence, explain;
   try {
     ({ served, routingDecision, taskType, classifiedBy, difficulty, difficultyScore, confidence, explain } =
-      await resolveRoute(normalized, { router, eff, application: meta.application, workflow: meta.workflow, appConfig, appDbConfig: appCfg }));
+      await resolveRoute(normalized, { router, eff, application: meta.application, workflow: meta.workflow, userId: meta.userId, appConfig, appDbConfig: appCfg }));
   } catch (err) {
     if (err.code === "model_not_allowed") {
       return res.status(403).json({ error: { message: err.message, type: "invalid_request_error", code: "model_not_allowed" } });
@@ -809,7 +809,7 @@ async function handleOpenAICompat(req, res) {
       messages: body.messages, responseText: result.text,
     });
     maybeShadowEval({
-      application: meta.application, taskType, messages: body.messages, hasTools: !!(body.tools && body.tools.length),
+      application: meta.application, workflow: meta.workflow, taskType, messages: body.messages, hasTools: !!(body.tools && body.tools.length),
       requestId, router, eff,
       prod: { model: result.modelId, provider: result.providerId, latencyMs: result.latencyMs, text: result.text, usage: result.usage },
     });

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -11,6 +11,7 @@ const { handleChat } = require("./gateway/handler");
 const { handleOpenAICompat } = require("./gateway/openaiCompat");
 const { purgeOldRecords } = require("./maintenance/purge");
 const errorAlertMonitor = require("./routing/errorAlertMonitor");
+const canaryMonitor = require("./routing/canaryMonitor");
 const { supportsTools } = require("./gateway/capabilities");
 const auth = require("./gateway/auth");
 const adminAuth = require("./api/adminAuth");
@@ -125,6 +126,10 @@ async function start() {
   // Error-rate alerting: checks rolling 1-hour error rate every 5 min and fires
   // the governance webhook when the threshold is exceeded.
   errorAlertMonitor.start();
+
+  // Canary auto-rollback: every 5 min, roll back any active routing experiment that
+  // breaches its guardrails (error rate, latency, cost saving, shadow worse-rate).
+  canaryMonitor.start();
 
   app.listen(config.port, config.host, () => {
     console.log("\n" + describe() + "\n");

--- a/server/src/models/EvalCampaign.js
+++ b/server/src/models/EvalCampaign.js
@@ -8,9 +8,25 @@ const evalCampaignSchema = new mongoose.Schema(
     name:           { type: String, default: "" },
     application:    { type: String, required: true, index: true }, // target app whose traffic is mirrored
     candidateModel: { type: String, required: true },              // model being evaluated
+    baselineModel:  { type: String, default: null },               // only mirror when prod served THIS model (null = any)
     judgeModel:     { type: String, default: null },               // LLM judge; null = capture pairs only, no verdict
     sampleRate:     { type: Number, default: 0.1, min: 0, max: 1 }, // fraction of eligible requests mirrored
     status:         { type: String, enum: ["active", "paused", "done"], default: "active", index: true },
+    statusReason:   { type: String, default: null },               // why paused (e.g. error cap hit)
+    // Narrower scope than "whole application" (Phase 2). null field = any.
+    scope: {
+      workflow: { type: String, default: null },
+      taskType: { type: String, default: null },
+    },
+    recommendationId: { type: mongoose.Schema.Types.ObjectId, ref: "Recommendation", default: null, index: true },
+    // Shadow may only run after an offline eval PASSED (Phase 2 gate) — unless overridden.
+    requiredEvalRunId: { type: mongoose.Schema.Types.ObjectId, ref: "EvalRun", default: null },
+    // Safety limits.
+    maxDailyShadowBudgetUsd: { type: Number, default: null }, // stop mirroring once today's candidate spend hits this
+    maxCandidateErrors:      { type: Number, default: null }, // pause the campaign after this many candidate call failures
+    candidateErrorCount:     { type: Number, default: 0 },
+    startDate: { type: Date, default: null },
+    endDate:   { type: Date, default: null },
     // "Safe to switch" gate: notify once pairs >= minPairs AND lossRate <= maxLossRate.
     thresholds:     {
       minPairs:    { type: Number, default: 50 },

--- a/server/src/models/Recommendation.js
+++ b/server/src/models/Recommendation.js
@@ -38,6 +38,8 @@ const recommendationSchema = new mongoose.Schema(
     },
     evalDatasetId: { type: mongoose.Schema.Types.ObjectId, ref: "EvalDataset", default: null },
     evalRunId: { type: mongoose.Schema.Types.ObjectId, ref: "EvalRun", default: null },
+    shadowCampaignId: { type: mongoose.Schema.Types.ObjectId, ref: "EvalCampaign", default: null }, // Phase 2
+    experimentId: { type: mongoose.Schema.Types.ObjectId, ref: "RoutingExperiment", default: null }, // Phase 3 canary
     qualitySummary: { type: mongoose.Schema.Types.Mixed, default: null }, // last run's summary
     override: {
       reason: { type: String, default: null },

--- a/server/src/models/RequestRecord.js
+++ b/server/src/models/RequestRecord.js
@@ -44,7 +44,7 @@ const requestRecordSchema = new mongoose.Schema(
     // routing transparency
     routingDecision: {
       type: String,
-      enum: ["passthrough", "explicit", "rule", "auto", "ai", "budget", "cache", "fallback"],
+      enum: ["passthrough", "explicit", "rule", "auto", "ai", "budget", "cache", "fallback", "canary"],
       default: "passthrough",
       index: true,
     },

--- a/server/src/models/RoutingExperiment.js
+++ b/server/src/models/RoutingExperiment.js
@@ -1,0 +1,45 @@
+// A controlled canary rollout of an eval-passed candidate model. Only created from a passed
+// EvalRun. The gateway routes a deterministic percentage of AUTO-routed traffic (pinned models
+// are never touched) to the candidate; a monitor auto-rolls-back on guardrail breach, and an
+// admin can promote it to an enabled Rule. See routing/canaryEngine + routing/canaryMonitor.
+const mongoose = require("mongoose");
+
+const routingExperimentSchema = new mongoose.Schema(
+  {
+    evalRunId: { type: mongoose.Schema.Types.ObjectId, ref: "EvalRun", default: null },
+    recommendationId: { type: mongoose.Schema.Types.ObjectId, ref: "Recommendation", default: null, index: true },
+    shadowCampaignId: { type: mongoose.Schema.Types.ObjectId, ref: "EvalCampaign", default: null }, // for a live worse-rate signal
+    ruleId: { type: mongoose.Schema.Types.ObjectId, ref: "Rule", default: null }, // set on promotion
+
+    scope: {
+      application: { type: String, default: null, index: true },
+      workflow: { type: String, default: null },
+      taskType: { type: String, default: null },
+    },
+    baselineModel: { type: String, required: true },  // the model canary traffic is diverted FROM
+    candidateModel: { type: String, required: true }, // routed TO for the canary fraction
+    candidateProvider: { type: String, default: null }, // provider for the candidate (may be unregistered in the pricing table)
+    rolloutPct: { type: Number, default: 10, min: 0, max: 100 },
+
+    status: { type: String, enum: ["draft", "active", "paused", "rolled_back", "promoted"], default: "draft", index: true },
+
+    // Auto-rollback fires if any of these is breached over the metrics window.
+    guardrails: {
+      maxErrorRateIncrease: { type: Number, default: 0.02 },   // candidate error rate minus baseline (absolute)
+      maxLatencyRegressionPct: { type: Number, default: 0.25 }, // p95 candidate vs baseline
+      maxWorseRate: { type: Number, default: 0.10 },            // from the linked shadow campaign, if any
+      minCostSavingPct: { type: Number, default: 0.10 },        // candidate must still save at least this
+    },
+    metricsWindowMinutes: { type: Number, default: 60 },
+    minSampleForRollback: { type: Number, default: 20 }, // don't judge on a handful of requests
+
+    createdBy: { type: String, default: "console" },
+    approvedBy: { type: String, default: null },
+    rollbackReason: { type: String, default: null },
+    lastMonitoredAt: { type: Date, default: null },
+    lastMetrics: { type: mongoose.Schema.Types.Mixed, default: null },
+  },
+  { collection: "routing_experiments", timestamps: true }
+);
+
+module.exports = mongoose.model("RoutingExperiment", routingExperimentSchema);

--- a/server/src/routing/canaryEngine.js
+++ b/server/src/routing/canaryEngine.js
@@ -1,0 +1,53 @@
+// Hot-path canary selection. Decides whether an AUTO-routed request should be diverted to an
+// experiment's candidate model. Cached like the rule set; pure bucketing/matching are separated
+// and unit-tested. Every caller path is fail-open: any error here leaves normal routing intact.
+const crypto = require("crypto");
+const RoutingExperiment = require("../models/RoutingExperiment");
+
+const TTL_MS = 15_000;
+let _cache = { experiments: [], at: 0 };
+
+function invalidate() { _cache.at = 0; }
+
+async function activeExperiments() {
+  if (Date.now() - _cache.at < TTL_MS) return _cache.experiments;
+  const experiments = await RoutingExperiment.find({ status: "active" }).lean().catch(() => []);
+  _cache = { experiments, at: Date.now() };
+  return experiments;
+}
+
+// Deterministic 0-99 bucket for a (user, experiment) pair, so a given user is consistently in or
+// out of the canary. Falls back to a stable per-request-context key when userId is absent. Pure.
+function bucket(application, workflow, userId, experimentId) {
+  const key = `${application || ""}|${workflow || ""}|${userId || "anon"}|${experimentId || ""}`;
+  const hex = crypto.createHash("sha256").update(key).digest("hex").slice(0, 8);
+  return parseInt(hex, 16) % 100;
+}
+
+// Does an experiment apply to this request? Scope null field = any. The request's currently
+// served model must equal the experiment's baseline (that's what we divert from). Pure.
+function matchExperiment(exp, { application, workflow, taskType, servedModel }) {
+  if (!exp || exp.status !== "active") return false;
+  if (exp.baselineModel !== servedModel) return false;
+  const s = exp.scope || {};
+  if (s.application && s.application !== application) return false;
+  if (s.workflow && s.workflow !== workflow) return false;
+  if (s.taskType && String(s.taskType).toLowerCase() !== String(taskType || "").toLowerCase()) return false;
+  return true;
+}
+
+// Returns { experiment, toModel } when this request should be served by a candidate, else null.
+async function selectCanary(ctx) {
+  try {
+    const experiments = await activeExperiments();
+    for (const exp of experiments) {
+      if (!matchExperiment(exp, ctx)) continue;
+      if (bucket(ctx.application, ctx.workflow, ctx.userId, String(exp._id)) < (exp.rolloutPct || 0)) {
+        return { experiment: exp, toModel: exp.candidateModel };
+      }
+    }
+  } catch { /* fail-open */ }
+  return null;
+}
+
+module.exports = { selectCanary, activeExperiments, invalidate, bucket, matchExperiment };

--- a/server/src/routing/canaryMonitor.js
+++ b/server/src/routing/canaryMonitor.js
@@ -1,0 +1,112 @@
+// Auto-rollback monitor for active canary experiments. Every 5 minutes it recomputes each
+// experiment's live metrics over its window and rolls back on any guardrail breach. Pure
+// guardrail evaluation is separated for unit tests. Same single-process caveat as the budget
+// cache and errorAlertMonitor: it is a timer, not a hard real-time guarantee.
+const RequestRecord = require("../models/RequestRecord");
+const RoutingExperiment = require("../models/RoutingExperiment");
+const EvalPair = require("../models/EvalPair");
+const Settings = require("../models/Settings");
+const canaryEngine = require("./canaryEngine");
+
+const INTERVAL_MS = 5 * 60 * 1000;
+let _timer = null;
+
+function pct(n) { return n == null || isNaN(n) ? "n/a" : `${(n * 100).toFixed(1)}%`; }
+
+function p95(nums) {
+  if (!nums.length) return 0;
+  const s = [...nums].sort((a, b) => a - b);
+  return s[Math.min(s.length - 1, Math.floor(0.95 * s.length))];
+}
+
+// Decide rollback from computed metrics. Pure. Returns { breached, reasons, insufficient }.
+function evaluateGuardrails(m, g, minSample) {
+  if ((m.candTotal || 0) < (minSample || 0)) return { breached: false, reasons: [], insufficient: true };
+  const reasons = [];
+  const errInc = (m.candErrorRate || 0) - (m.baseErrorRate || 0);
+  if (g.maxErrorRateIncrease != null && errInc > g.maxErrorRateIncrease) {
+    reasons.push(`error rate +${pct(errInc)} vs baseline (max +${pct(g.maxErrorRateIncrease)})`);
+  }
+  if (g.maxLatencyRegressionPct != null && m.latencyRegressionPct != null && m.latencyRegressionPct > g.maxLatencyRegressionPct) {
+    reasons.push(`p95 latency regressed ${pct(m.latencyRegressionPct)} (max ${pct(g.maxLatencyRegressionPct)})`);
+  }
+  if (g.minCostSavingPct != null && m.costSavingPct != null && m.costSavingPct < g.minCostSavingPct) {
+    reasons.push(`cost saving ${pct(m.costSavingPct)} below floor ${pct(g.minCostSavingPct)}`);
+  }
+  if (g.maxWorseRate != null && m.worseRate != null && m.worseRate > g.maxWorseRate) {
+    reasons.push(`shadow worse-rate ${pct(m.worseRate)} exceeds ${pct(g.maxWorseRate)}`);
+  }
+  return { breached: reasons.length > 0, reasons, insufficient: false };
+}
+
+// Compute candidate-vs-baseline metrics for an experiment over its window.
+async function metricsFor(exp) {
+  const since = new Date(Date.now() - (exp.metricsWindowMinutes || 60) * 60000);
+  const scope = {};
+  if (exp.scope?.application) scope.application = exp.scope.application;
+  if (exp.scope?.workflow) scope.workflow = exp.scope.workflow;
+  if (exp.scope?.taskType) scope.taskType = exp.scope.taskType;
+  const proj = { status: 1, totalCost: 1, latencyMs: 1 };
+
+  const cand = await RequestRecord.find({ ...scope, timestamp: { $gte: since }, routingDecision: "canary", model: exp.candidateModel }, proj).lean();
+  const base = await RequestRecord.find({ ...scope, timestamp: { $gte: since }, routingDecision: { $ne: "canary" }, model: exp.baselineModel }, proj).lean();
+
+  const stats = (rows) => {
+    const total = rows.length;
+    const failures = rows.filter((r) => r.status === "failure").length;
+    const ok = rows.filter((r) => r.status === "success");
+    const avgCost = ok.length ? ok.reduce((a, r) => a + (r.totalCost || 0), 0) / ok.length : 0;
+    return { total, errorRate: total ? failures / total : 0, avgCost, p95: p95(ok.map((r) => r.latencyMs || 0)) };
+  };
+  const c = stats(cand), b = stats(base);
+
+  let worseRate = null;
+  if (exp.shadowCampaignId) {
+    const judged = await EvalPair.find({ campaignId: exp.shadowCampaignId, verdict: { $ne: null } }, { verdict: 1 }).lean();
+    if (judged.length) worseRate = judged.filter((p) => p.verdict === "worse").length / judged.length;
+  }
+  return {
+    candTotal: c.total, baseTotal: b.total,
+    candErrorRate: c.errorRate, baseErrorRate: b.errorRate,
+    latencyRegressionPct: b.p95 > 0 ? (c.p95 - b.p95) / b.p95 : null,
+    costSavingPct: b.avgCost > 0 ? (b.avgCost - c.avgCost) / b.avgCost : null,
+    worseRate,
+  };
+}
+
+async function rollback(exp, reasons) {
+  await RoutingExperiment.updateOne({ _id: exp._id }, { $set: {
+    status: "rolled_back", rollbackReason: reasons.join("; "), lastMonitoredAt: new Date(),
+  } });
+  canaryEngine.invalidate();
+  const s = await Settings.get().catch(() => null);
+  if (s?.webhookUrl) {
+    fetch(s.webhookUrl, {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ event: "canary_rolled_back", experimentId: String(exp._id),
+        candidateModel: exp.candidateModel, baselineModel: exp.baselineModel, reasons }),
+      signal: AbortSignal.timeout(5000),
+    }).catch(() => {});
+  }
+}
+
+async function check() {
+  try {
+    const experiments = await RoutingExperiment.find({ status: "active" }).lean();
+    for (const exp of experiments) {
+      const m = await metricsFor(exp);
+      const verdict = evaluateGuardrails(m, exp.guardrails || {}, exp.minSampleForRollback);
+      await RoutingExperiment.updateOne({ _id: exp._id }, { $set: { lastMonitoredAt: new Date(), lastMetrics: m } });
+      if (verdict.breached) await rollback(exp, verdict.reasons);
+    }
+  } catch { /* must not crash the process */ }
+}
+
+function start() {
+  if (_timer) return;
+  _timer = setInterval(check, INTERVAL_MS);
+  if (_timer.unref) _timer.unref();
+}
+function stop() { if (_timer) { clearInterval(_timer); _timer = null; } }
+
+module.exports = { start, stop, check, evaluateGuardrails, metricsFor };

--- a/server/src/seed/promptPacks.js
+++ b/server/src/seed/promptPacks.js
@@ -1,0 +1,59 @@
+// Realistic prompt/response pairs per task type, so seeded RequestRecords carry believable
+// `messages` + `responseText`. Without these the eval flow has nothing to replay (the demo's
+// whole point). Covers the five demo task types from the growth brief — support classification,
+// FAQ, CRM summaries, legal/contract extraction, code explanation — plus a generic fallback.
+// The `extraction` pack is intentionally structured (JSON) so it drives the failure-first story
+// (a cheaper model breaking the schema).
+
+const PACKS = {
+  classification: [
+    { prompt: "Classify this support ticket as one of [billing, technical, account, feedback]:\n\"I was charged twice for my subscription this month.\"", response: "billing" },
+    { prompt: "Classify this support ticket as one of [billing, technical, account, feedback]:\n\"The app crashes every time I upload a PDF.\"", response: "technical" },
+    { prompt: "Classify this support ticket as one of [billing, technical, account, feedback]:\n\"I can't log in even after resetting my password.\"", response: "account" },
+    { prompt: "Classify this support ticket as one of [billing, technical, account, feedback]:\n\"Love the new dashboard, the charts are much clearer.\"", response: "feedback" },
+    { prompt: "Classify the sentiment of this review as [positive, neutral, negative]:\n\"Support took three days to reply and never fixed my issue.\"", response: "negative" },
+  ],
+  faq: [
+    { prompt: "How do I reset my password?", response: "Open Settings → Security → Reset password. We email a reset link that stays valid for 30 minutes; follow it to set a new password." },
+    { prompt: "What payment methods do you accept?", response: "We accept all major credit cards (Visa, Mastercard, Amex) and ACH bank transfer on annual plans. Invoicing is available for enterprise accounts." },
+    { prompt: "Can I export my data?", response: "Yes. Go to Settings → Data → Export to download a CSV or JSON archive of your workspace. Exports include records from the last 90 days by default." },
+    { prompt: "How do I invite a teammate?", response: "In Settings → Members, click Invite, enter their email, and pick a role (Admin, Editor, or Viewer). They'll get an email invitation to join the workspace." },
+    { prompt: "Is there a free trial?", response: "Yes, a 14-day trial with full features and no credit card required. You can add a payment method any time before it ends to keep your data." },
+  ],
+  summarisation: [
+    { prompt: "Summarise this sales-call note in two sentences:\n\"Spoke with the VP of Ops at Northwind. They're evaluating us against two competitors, main concern is onboarding time. Budget approved for Q3, decision expected in 4 weeks. Asked for a security questionnaire and a reference customer in logistics.\"", response: "Northwind's VP of Ops has Q3 budget approved and will decide within four weeks, weighing us against two competitors mainly on onboarding time. They requested a security questionnaire and a logistics reference customer." },
+    { prompt: "Summarise this CRM note in two sentences:\n\"Renewal call with Acme. Usage up 40% YoY, two new teams onboarded. They want volume pricing and SSO before signing a 2-year deal. Champion is supportive; procurement is the bottleneck.\"", response: "Acme's usage grew 40% year over year and they're ready for a two-year renewal, contingent on volume pricing and SSO. Their champion is supportive, but procurement is the main bottleneck." },
+    { prompt: "Summarise this support interaction in one sentence:\n\"Customer reported slow report loading; we identified a large date range as the cause and suggested narrowing filters. They confirmed it resolved the issue.\"", response: "The customer's slow report loading was caused by an overly large date range and was resolved by narrowing the filters." },
+    { prompt: "Summarise the outcome of this meeting note:\n\"Kickoff with Globex. Agreed on a 6-week pilot, success metric is 20% cost reduction. They assigned two engineers; we provide weekly check-ins.\"", response: "Globex agreed to a six-week pilot targeting a 20% cost reduction, with two of their engineers assigned and weekly check-ins from our side." },
+  ],
+  "document analysis": [
+    { prompt: "Summarise the key obligations in this indemnification clause:\n\"The Vendor shall indemnify, defend and hold harmless the Client from any third-party claims arising out of the Vendor's breach of this Agreement or negligence, up to a cap equal to fees paid in the prior 12 months.\"", response: "The Vendor must indemnify and defend the Client against third-party claims caused by the Vendor's breach or negligence. Liability is capped at the total fees paid in the preceding 12 months." },
+    { prompt: "Identify the termination rights in this clause:\n\"Either party may terminate for convenience on 60 days' written notice. The Client may terminate immediately upon a material breach that remains uncured for 15 days after notice.\"", response: "Either party may terminate for convenience with 60 days' written notice. The Client may also terminate immediately for a material breach left uncured 15 days after notice." },
+    { prompt: "What does this confidentiality clause require?\n\"Each party shall protect the other's Confidential Information with the same care it uses for its own, and not less than reasonable care, for a period of five years after disclosure.\"", response: "Each party must protect the other's confidential information with at least reasonable care (and no less than the care it gives its own), for five years after disclosure." },
+  ],
+  coding: [
+    { prompt: "Explain what this function does:\n```js\nfunction debounce(fn, ms) {\n  let t;\n  return (...args) => { clearTimeout(t); t = setTimeout(() => fn(...args), ms); };\n}\n```", response: "It returns a debounced wrapper around `fn`: each call resets a timer, so `fn` only runs once the wrapper has been idle for `ms` milliseconds. Useful for rate-limiting rapid events like keystrokes or resize handlers." },
+    { prompt: "Explain what this SQL query returns:\n```sql\nSELECT customer_id, COUNT(*) AS orders\nFROM orders WHERE created_at > NOW() - INTERVAL '30 days'\nGROUP BY customer_id HAVING COUNT(*) > 5;\n```", response: "It lists each customer who placed more than five orders in the last 30 days, along with their order count. The HAVING clause filters the grouped results to customers above the threshold." },
+    { prompt: "What does this Python snippet do?\n```python\nnums = [n for n in range(100) if n % 3 == 0 and n % 5 == 0]\n```", response: "It builds a list of numbers from 0 to 99 that are divisible by both 3 and 5 (i.e. multiples of 15): [0, 15, 30, 45, 60, 75, 90]." },
+  ],
+  // Structured-output extraction — drives the failure-first demo (JSON/schema breakage).
+  extraction: [
+    { prompt: "Extract the fields {party, effective_date, termination_notice_days, indemnity} as JSON from:\n\"This Agreement between Acme Inc. and the Client is effective January 1, 2026. Either party may terminate on 30 days notice. The Vendor shall indemnify the Client for third-party claims.\"", response: '{"party":"Acme Inc.","effective_date":"2026-01-01","termination_notice_days":30,"indemnity":true}' },
+    { prompt: "Extract {invoice_number, total_usd, due_date} as JSON from:\n\"Invoice INV-4821, amount due $12,450.00, payable by 2026-02-15.\"", response: '{"invoice_number":"INV-4821","total_usd":12450.00,"due_date":"2026-02-15"}' },
+    { prompt: "Extract {name, email, company} as JSON from this signature:\n\"Best, Dana Lee — Head of Ops, Globex — dana.lee@globex.com\"", response: '{"name":"Dana Lee","email":"dana.lee@globex.com","company":"Globex"}' },
+    { prompt: "Extract {governing_law, cap_months, auto_renew} as JSON from:\n\"This Agreement is governed by the laws of Delaware. Liability is capped at 12 months of fees. The term auto-renews annually unless cancelled.\"", response: '{"governing_law":"Delaware","cap_months":12,"auto_renew":true}' },
+  ],
+};
+
+const GENERIC = [
+  { prompt: "Draft a short, friendly reply confirming we received the customer's request and will follow up within one business day.", response: "Thanks for reaching out! We've received your request and a member of our team will follow up within one business day. We appreciate your patience." },
+  { prompt: "Rewrite this sentence to be more concise: \"We are writing to inform you that your order has now been shipped.\"", response: "Your order has shipped." },
+];
+
+// Deterministic pick within a task type's pack (index provided by the caller's PRNG).
+function getPromptPair(taskType, i) {
+  const pack = PACKS[String(taskType || "").toLowerCase()] || GENERIC;
+  return pack[i % pack.length];
+}
+
+module.exports = { getPromptPair, PACKS };

--- a/server/src/seed/seed.js
+++ b/server/src/seed/seed.js
@@ -12,7 +12,15 @@ const { v4: uuidv4 } = require("uuid");
 const { config } = require("../config");
 const RequestRecord = require("../models/RequestRecord");
 const Recommendation = require("../models/Recommendation");
+const EvalDataset = require("../models/EvalDataset");
+const EvalItem = require("../models/EvalItem");
+const EvalRun = require("../models/EvalRun");
+const EvalResult = require("../models/EvalResult");
+const RoutingExperiment = require("../models/RoutingExperiment");
 const pricing = require("../pricing/registry");
+const recommender = require("../recommend/engine");
+const { defaultThresholds } = require("../eval/thresholds");
+const { getPromptPair } = require("./promptPacks");
 
 // Deterministic PRNG so seeds are reproducible (no Math.random surprises).
 let _s = 1337;
@@ -58,6 +66,8 @@ function buildRecord({ application, workflow, department, model, provider, taskT
   const { inputCost, outputCost, totalCost } = pricing.costFor(model, promptTokens, completionTokens);
   const ts = new Date(Date.now() - daysAgo * 86400000 - between(0, 86400000));
   const failed = rnd() < 0.01;
+  // Attach a realistic prompt + response so the record is replayable by the eval flow.
+  const pair = getPromptPair(taskType, between(0, 99));
   return {
     requestId: uuidv4(),
     timestamp: ts,
@@ -70,7 +80,81 @@ function buildRecord({ application, workflow, department, model, provider, taskT
     retryCount: 0,
     routingDecision: "passthrough",
     cacheHit: false,
+    messages: [{ role: "user", content: pair.prompt }],
+    responseText: pair.response,
   };
+}
+
+// Seed a ready-made eval story so `docker compose up` (no keys) shows the wedge out of the box:
+// one PASSED downgrade (approved + a live canary) and one BLOCKED downgrade (failure-first).
+// Attaches to the recommendations recompute() produced, so it survives a later Recompute.
+async function seedEvalDemo() {
+  // ── PASSED: classification, claude-opus-4-8 → claude-haiku-4-5 ──────────────
+  const passRec = await Recommendation.findOne({ dedupeKey: "premium_overuse:classification:claude-opus-4-8" });
+  if (passRec) {
+    const ds = await EvalDataset.create({
+      name: "classification: claude-opus-4-8 → claude-haiku-4-5", recommendationId: passRec._id,
+      scope: { taskType: "classification" }, baselineModel: "claude-opus-4-8", candidateModel: "claude-haiku-4-5",
+      sampling: { method: "stratified", targetCount: 200, dedupeByPromptHash: true },
+      riskTier: "low", piiMode: "masked", itemCount: 200, status: "ready",
+    });
+    const summary = { total: 200, judged: 200, candidateBetter: 41, candidateEqual: 153, candidateWorse: 6,
+      worseRate: 0.03, criticalFailRate: 0, formatPassRate: 1, costSavingPct: 0.82, avgLatencyDeltaPct: -0.28,
+      prodCost: 4.43, candidateCost: 0.80, p95LatencyDeltaPct: -0.22 };
+    const run = await EvalRun.create({
+      recommendationId: passRec._id, datasetId: ds._id, taskType: "classification",
+      baselineModel: "claude-opus-4-8", candidateModel: "claude-haiku-4-5", judgeModel: "gpt-4o",
+      riskTier: "low", status: "passed", thresholds: defaultThresholds("low"), summary, failures: [],
+      estimatedCostUsd: 0.9, actualCostUsd: 0.86, startedAt: new Date(), completedAt: new Date(),
+    });
+    await EvalResult.insertMany([
+      { evalRunId: run._id, baselineModel: "claude-opus-4-8", candidateModel: "claude-haiku-4-5", candidateResponse: "billing", judgeVerdict: "equal", formatPass: true, dimensionScores: { correctness: 5, format: 5 }, judgeRationale: "Both correctly label the ticket 'billing'." },
+      { evalRunId: run._id, baselineModel: "claude-opus-4-8", candidateModel: "claude-haiku-4-5", candidateResponse: "technical", judgeVerdict: "equal", formatPass: true, dimensionScores: { correctness: 5, format: 5 }, judgeRationale: "Identical, correct classification." },
+      { evalRunId: run._id, baselineModel: "claude-opus-4-8", candidateModel: "claude-haiku-4-5", candidateResponse: "account", judgeVerdict: "better", formatPass: true, dimensionScores: { correctness: 5, format: 5 }, judgeRationale: "Candidate picked the more precise label." },
+      { evalRunId: run._id, baselineModel: "claude-opus-4-8", candidateModel: "claude-haiku-4-5", candidateResponse: "feedback (positive)", judgeVerdict: "worse", formatPass: true, dimensionScores: { correctness: 3, format: 4 }, judgeRationale: "Candidate added an unrequested sentiment tag; baseline was cleaner." },
+    ]);
+    passRec.evalStatus = "passed"; passRec.evalDatasetId = ds._id; passRec.evalRunId = run._id; passRec.qualitySummary = summary;
+
+    const exp = await RoutingExperiment.create({
+      evalRunId: run._id, recommendationId: passRec._id,
+      scope: { application: "support-chat", taskType: "classification" },
+      baselineModel: "claude-opus-4-8", candidateModel: "claude-haiku-4-5", candidateProvider: "anthropic",
+      rolloutPct: 10, status: "active", metricsWindowMinutes: 60,
+      lastMonitoredAt: new Date(),
+      lastMetrics: { candTotal: 63, candErrorRate: 0.008, baseErrorRate: 0.011, latencyRegressionPct: -0.26, costSavingPct: 0.8, worseRate: 0.03 },
+    });
+    passRec.experimentId = exp._id;
+    await passRec.save();
+  }
+
+  // ── BLOCKED (failure-first): extraction, gpt-4o → gpt-4o-mini ───────────────
+  const failRec = await Recommendation.findOne({ dedupeKey: "premium_overuse:extraction:gpt-4o" });
+  if (failRec) {
+    const ds = await EvalDataset.create({
+      name: "extraction: gpt-4o → gpt-4o-mini", recommendationId: failRec._id,
+      scope: { taskType: "extraction" }, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini",
+      sampling: { method: "stratified", targetCount: 300, dedupeByPromptHash: true },
+      riskTier: "medium", piiMode: "masked", itemCount: 300, status: "ready",
+    });
+    const summary = { total: 300, judged: 300, candidateBetter: 20, candidateEqual: 196, candidateWorse: 84,
+      worseRate: 0.28, criticalFailRate: 0.05, formatPassRate: 0.72, costSavingPct: 0.93, avgLatencyDeltaPct: -0.15,
+      prodCost: 1.13, candidateCost: 0.07, p95LatencyDeltaPct: -0.10 };
+    const run = await EvalRun.create({
+      recommendationId: failRec._id, datasetId: ds._id, taskType: "extraction",
+      baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", judgeModel: "claude-opus-4-8",
+      riskTier: "medium", status: "failed", thresholds: defaultThresholds("medium"), summary,
+      failures: ["worse-rate 28.0% exceeds 3.0%", "critical-failure rate 5.0% exceeds 0.2%", "format pass-rate 72.0% below 99.0%"],
+      estimatedCostUsd: 1.4, actualCostUsd: 1.31, startedAt: new Date(), completedAt: new Date(),
+    });
+    await EvalResult.insertMany([
+      { evalRunId: run._id, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", candidateResponse: '{"party":"Acme Inc.","effective_date":"Jan 1 2026","indemnity":true}', judgeVerdict: "worse", criticalFailure: true, formatPass: false, validatorResults: [{ type: "json_schema", pass: false }], dimensionScores: { correctness: 2, format: 1 }, judgeRationale: "Dropped termination_notice_days and used a non-ISO date; fails the schema." },
+      { evalRunId: run._id, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", candidateResponse: 'Here is the JSON: {"invoice_number":"INV-4821","total_usd":"12,450"}', judgeVerdict: "worse", criticalFailure: true, formatPass: false, validatorResults: [{ type: "json_schema", pass: false }], dimensionScores: { correctness: 2, format: 1 }, judgeRationale: "Wrapped JSON in prose, quoted the number with a comma, and omitted due_date." },
+      { evalRunId: run._id, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", candidateResponse: '{"governing_law":"Delaware","cap_months":12,"auto_renew":true}', judgeVerdict: "equal", formatPass: true, validatorResults: [{ type: "json_schema", pass: true }], dimensionScores: { correctness: 5, format: 5 }, judgeRationale: "Correct on the simple case." },
+      { evalRunId: run._id, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", candidateResponse: '{"name":"Dana Lee","company":"Globex"}', judgeVerdict: "worse", criticalFailure: false, formatPass: false, validatorResults: [{ type: "json_schema", pass: false }], dimensionScores: { correctness: 3, format: 2 }, judgeRationale: "Omitted the required email field." },
+    ]);
+    failRec.evalStatus = "failed"; failRec.evalDatasetId = ds._id; failRec.evalRunId = run._id; failRec.qualitySummary = summary;
+    await failRec.save();
+  }
 }
 
 async function main() {
@@ -84,6 +168,11 @@ async function main() {
 
   await RequestRecord.deleteMany({});
   await Recommendation.deleteMany({});
+  // Reset the eval demo collections too, so reseeding is idempotent.
+  await Promise.all([
+    EvalDataset.deleteMany({}), EvalItem.deleteMany({}), EvalRun.deleteMany({}),
+    EvalResult.deleteMany({}), RoutingExperiment.deleteMany({}),
+  ]);
 
   const records = [];
 
@@ -124,7 +213,16 @@ async function main() {
 
   await RequestRecord.insertMany(records);
   console.log(`Inserted ${records.length} request records.`);
-  console.log("Done. Start the server and open the dashboard; click 'Recompute' on Recommendations.");
+
+  // Generate recommendations from the traffic, then attach a ready-made eval story
+  // (one approved downgrade + a live canary, one blocked downgrade) so the eval-backed
+  // wedge is visible on first boot without any provider keys.
+  const recs = await recommender.recompute();
+  console.log(`Computed ${recs.length} recommendations.`);
+  await seedEvalDemo();
+  console.log("Seeded eval demo: 1 approved (classification, + canary) and 1 blocked (extraction).");
+
+  console.log("Done. Start the server and open the dashboard — Routing → Recommendations and Model Evals.");
   await mongoose.disconnect();
 }
 

--- a/server/test/integration/evalCanary.test.js
+++ b/server/test/integration/evalCanary.test.js
@@ -1,0 +1,84 @@
+"use strict";
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+const mongoose = require("mongoose");
+const express = require("express");
+const supertest = require("supertest");
+
+process.env.ARBR_ADMIN_KEY = "";
+
+const Recommendation = require("../../src/models/Recommendation");
+const EvalRun = require("../../src/models/EvalRun");
+const EvalDataset = require("../../src/models/EvalDataset");
+const RoutingExperiment = require("../../src/models/RoutingExperiment");
+const Rule = require("../../src/models/Rule");
+const apiRoutes = require("../../src/api/routes");
+
+let mongod, agent;
+const buildApp = () => { const a = express(); a.use(express.json()); a.use("/api", apiRoutes); return a; };
+
+const makeRec = () => Recommendation.create({
+  title: "t", reason: "r", taskType: "classification", currentModel: "gpt-4o",
+  suggestedModel: "gpt-4o-mini", suggestedProvider: "openai", dedupeKey: `k-${Math.random()}`,
+});
+async function pass(rec) {
+  const ds = await EvalDataset.create({ recommendationId: rec._id, status: "ready", riskTier: "low" });
+  const run = await EvalRun.create({ recommendationId: rec._id, datasetId: ds._id, status: "passed", candidateModel: "gpt-4o-mini", baselineModel: "gpt-4o" });
+  rec.evalRunId = run._id; rec.evalStatus = "passed"; await rec.save();
+}
+
+before(async () => { mongod = await MongoMemoryServer.create(); await mongoose.connect(mongod.getUri()); agent = supertest(buildApp()); });
+after(async () => { await mongoose.disconnect(); await mongod.stop(); });
+beforeEach(async () => { await Promise.all([Recommendation.deleteMany({}), EvalRun.deleteMany({}), EvalDataset.deleteMany({}), RoutingExperiment.deleteMany({}), Rule.deleteMany({})]); });
+
+test("create-canary is blocked without a passed eval", async () => {
+  const rec = await makeRec();
+  const res = await agent.post(`/api/recommendations/${rec._id}/create-canary`).send({ application: "support-chat" });
+  assert.equal(res.status, 409);
+});
+
+test("create-canary makes an active experiment scoped to the rec", async () => {
+  const rec = await makeRec();
+  await pass(rec);
+  const res = await agent.post(`/api/recommendations/${rec._id}/create-canary`).send({ application: "support-chat", rolloutPct: 15 });
+  assert.equal(res.status, 201);
+  assert.equal(res.body.status, "active");
+  assert.equal(res.body.rolloutPct, 15);
+  assert.equal(res.body.baselineModel, "gpt-4o");
+  assert.equal(res.body.candidateModel, "gpt-4o-mini");
+  assert.equal(res.body.scope.taskType, "classification");
+  const updated = await Recommendation.findById(rec._id);
+  assert.ok(updated.experimentId);
+});
+
+test("rollback sets status rolled_back with a reason", async () => {
+  const exp = await RoutingExperiment.create({ baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", status: "active" });
+  const res = await agent.post(`/api/routing-experiments/${exp._id}/rollback`).send({ reason: "spike" });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.status, "rolled_back");
+  assert.equal(res.body.rollbackReason, "spike");
+});
+
+test("promote creates an enabled rule and marks the rec accepted", async () => {
+  const rec = await makeRec();
+  const exp = await RoutingExperiment.create({
+    recommendationId: rec._id, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", candidateProvider: "openai",
+    scope: { taskType: "classification", application: "support-chat" }, status: "active",
+  });
+  const res = await agent.post(`/api/routing-experiments/${exp._id}/promote`).send({ approvedBy: "prasanna" });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.experiment.status, "promoted");
+  assert.equal(res.body.experiment.rolloutPct, 100);
+  assert.equal(res.body.rule.enabled, true);
+  assert.equal(res.body.rule.target.provider, "openai"); // provider comes from candidateProvider, not the registry
+  assert.equal(res.body.rule.target.model, "gpt-4o-mini");
+  const updatedRec = await Recommendation.findById(rec._id);
+  assert.equal(updatedRec.status, "accepted");
+});
+
+test("cannot promote a rolled-back experiment", async () => {
+  const exp = await RoutingExperiment.create({ baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", status: "rolled_back" });
+  const res = await agent.post(`/api/routing-experiments/${exp._id}/promote`).send({});
+  assert.equal(res.status, 409);
+});

--- a/server/test/integration/evalShadow.test.js
+++ b/server/test/integration/evalShadow.test.js
@@ -1,0 +1,79 @@
+"use strict";
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+const mongoose = require("mongoose");
+const express = require("express");
+const supertest = require("supertest");
+
+process.env.ARBR_ADMIN_KEY = "";
+
+const Recommendation = require("../../src/models/Recommendation");
+const EvalRun = require("../../src/models/EvalRun");
+const EvalDataset = require("../../src/models/EvalDataset");
+const EvalCampaign = require("../../src/models/EvalCampaign");
+const apiRoutes = require("../../src/api/routes");
+
+let mongod, agent;
+const buildApp = () => { const a = express(); a.use(express.json()); a.use("/api", apiRoutes); return a; };
+
+async function passedRunForRec(rec) {
+  const ds = await EvalDataset.create({ recommendationId: rec._id, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", status: "ready", riskTier: "low" });
+  const run = await EvalRun.create({ recommendationId: rec._id, datasetId: ds._id, status: "passed", candidateModel: "gpt-4o-mini", baselineModel: "gpt-4o" });
+  rec.evalRunId = run._id; rec.evalStatus = "passed"; await rec.save();
+  return run;
+}
+const makeRec = () => Recommendation.create({
+  title: "t", reason: "r", taskType: "classification", currentModel: "gpt-4o",
+  suggestedModel: "gpt-4o-mini", suggestedProvider: "openai", dedupeKey: `k-${Math.random()}`,
+});
+
+before(async () => { mongod = await MongoMemoryServer.create(); await mongoose.connect(mongod.getUri()); agent = supertest(buildApp()); });
+after(async () => { await mongoose.disconnect(); await mongod.stop(); });
+beforeEach(async () => { await Promise.all([Recommendation.deleteMany({}), EvalRun.deleteMany({}), EvalDataset.deleteMany({}), EvalCampaign.deleteMany({})]); });
+
+test("campaign create is forced PAUSED without a passed offline run", async () => {
+  const res = await agent.post("/api/eval/campaigns").send({ application: "support-chat", candidateModel: "gpt-4o-mini" });
+  assert.equal(res.status, 201);
+  assert.equal(res.body.status, "paused");
+  assert.ok(/passed offline eval/.test(res.body.statusReason));
+});
+
+test("campaign create goes ACTIVE with a passed requiredEvalRunId", async () => {
+  const rec = await makeRec();
+  const run = await passedRunForRec(rec);
+  const res = await agent.post("/api/eval/campaigns")
+    .send({ application: "support-chat", candidateModel: "gpt-4o-mini", requiredEvalRunId: String(run._id) });
+  assert.equal(res.status, 201);
+  assert.equal(res.body.status, "active");
+});
+
+test("start-shadow is blocked without a passed eval, allowed with one", async () => {
+  const rec = await makeRec();
+  const blocked = await agent.post(`/api/recommendations/${rec._id}/start-shadow`).send({ application: "support-chat" });
+  assert.equal(blocked.status, 409);
+  assert.equal(blocked.body.error, "eval_required");
+
+  await passedRunForRec(rec);
+  const ok = await agent.post(`/api/recommendations/${rec._id}/start-shadow`).send({ application: "support-chat" });
+  assert.equal(ok.status, 201);
+  assert.equal(ok.body.status, "active");
+  assert.equal(ok.body.baselineModel, "gpt-4o");
+  assert.equal(ok.body.scope.taskType, "classification");
+  const updated = await Recommendation.findById(rec._id);
+  assert.ok(updated.shadowCampaignId);
+});
+
+test("PATCH to active is gated on a passed run", async () => {
+  const paused = await EvalCampaign.create({ application: "support-chat", candidateModel: "gpt-4o-mini", status: "paused" });
+  const res = await agent.patch(`/api/eval/campaigns/${paused._id}`).send({ status: "active" });
+  assert.equal(res.status, 409);
+  assert.equal(res.body.error, "eval_required");
+});
+
+test("start-shadow requires an application", async () => {
+  const rec = await makeRec();
+  await passedRunForRec(rec);
+  const res = await agent.post(`/api/recommendations/${rec._id}/start-shadow`).send({});
+  assert.equal(res.status, 400);
+});

--- a/server/test/unit/evalCanary.test.js
+++ b/server/test/unit/evalCanary.test.js
@@ -1,0 +1,62 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { bucket, matchExperiment } = require("../../src/routing/canaryEngine");
+const { evaluateGuardrails } = require("../../src/routing/canaryMonitor");
+
+test("bucket is deterministic and in [0,100)", () => {
+  const a = bucket("app", "wf", "user-1", "exp-1");
+  const b = bucket("app", "wf", "user-1", "exp-1");
+  assert.equal(a, b);
+  assert.ok(a >= 0 && a < 100);
+});
+
+test("bucket varies by user and by experiment", () => {
+  const base = bucket("app", "wf", "user-1", "exp-1");
+  assert.notEqual(base, bucket("app", "wf", "user-2", "exp-1")); // different user
+  assert.notEqual(base, bucket("app", "wf", "user-1", "exp-2")); // different experiment
+});
+
+test("bucket distributes roughly uniformly (in-canary count near rolloutPct)", () => {
+  let inCanary = 0;
+  for (let i = 0; i < 1000; i++) if (bucket("app", "wf", `u${i}`, "exp") < 10) inCanary++;
+  assert.ok(inCanary > 60 && inCanary < 140, `expected ~100, got ${inCanary}`); // 10% of 1000
+});
+
+test("matchExperiment requires active status and matching baseline", () => {
+  const exp = { status: "active", baselineModel: "gpt-4o", scope: { application: "a", taskType: "classification" } };
+  assert.equal(matchExperiment(exp, { application: "a", taskType: "classification", servedModel: "gpt-4o" }), true);
+  assert.equal(matchExperiment(exp, { application: "a", taskType: "classification", servedModel: "gpt-4o-mini" }), false); // baseline mismatch
+  assert.equal(matchExperiment(exp, { application: "b", taskType: "classification", servedModel: "gpt-4o" }), false); // app mismatch
+  assert.equal(matchExperiment({ ...exp, status: "paused" }, { application: "a", taskType: "classification", servedModel: "gpt-4o" }), false);
+});
+
+test("matchExperiment treats null scope fields as any", () => {
+  const exp = { status: "active", baselineModel: "gpt-4o", scope: {} };
+  assert.equal(matchExperiment(exp, { application: "anything", workflow: "x", taskType: "y", servedModel: "gpt-4o" }), true);
+});
+
+test("evaluateGuardrails skips when sample is too small", () => {
+  const v = evaluateGuardrails({ candTotal: 3, candErrorRate: 1 }, { maxErrorRateIncrease: 0.02 }, 20);
+  assert.equal(v.breached, false);
+  assert.equal(v.insufficient, true);
+});
+
+test("evaluateGuardrails breaches on error-rate increase", () => {
+  const v = evaluateGuardrails({ candTotal: 100, candErrorRate: 0.10, baseErrorRate: 0.02 }, { maxErrorRateIncrease: 0.02 }, 20);
+  assert.equal(v.breached, true);
+  assert.ok(v.reasons[0].includes("error rate"));
+});
+
+test("evaluateGuardrails breaches on latency, cost-saving, and worse-rate", () => {
+  const g = { maxLatencyRegressionPct: 0.25, minCostSavingPct: 0.10, maxWorseRate: 0.10 };
+  assert.equal(evaluateGuardrails({ candTotal: 50, latencyRegressionPct: 0.5 }, g, 20).breached, true);
+  assert.equal(evaluateGuardrails({ candTotal: 50, costSavingPct: 0.02 }, g, 20).breached, true);
+  assert.equal(evaluateGuardrails({ candTotal: 50, worseRate: 0.3 }, g, 20).breached, true);
+});
+
+test("evaluateGuardrails passes a healthy candidate", () => {
+  const m = { candTotal: 100, candErrorRate: 0.01, baseErrorRate: 0.02, latencyRegressionPct: -0.1, costSavingPct: 0.6, worseRate: 0.01 };
+  const g = { maxErrorRateIncrease: 0.02, maxLatencyRegressionPct: 0.25, minCostSavingPct: 0.10, maxWorseRate: 0.10 };
+  assert.equal(evaluateGuardrails(m, g, 20).breached, false);
+});

--- a/server/test/unit/evalShadowHardening.test.js
+++ b/server/test/unit/evalShadowHardening.test.js
@@ -1,0 +1,42 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { withinWindow, campaignMatches } = require("../../src/eval/logic");
+const { canActivateShadow } = require("../../src/eval/thresholds");
+
+test("withinWindow respects open and closed bounds", () => {
+  const now = new Date("2026-07-05T12:00:00Z").getTime();
+  assert.equal(withinWindow(now, null, null), true);
+  assert.equal(withinWindow(now, "2026-07-01T00:00:00Z", "2026-07-10T00:00:00Z"), true);
+  assert.equal(withinWindow(now, "2026-07-06T00:00:00Z", null), false); // before start
+  assert.equal(withinWindow(now, null, "2026-07-04T00:00:00Z"), false); // after end
+});
+
+test("campaignMatches filters by taskType, workflow, and baseline model", () => {
+  const c = { scope: { taskType: "classification", workflow: "triage" }, baselineModel: "gpt-4o" };
+  assert.equal(campaignMatches(c, { taskType: "classification", workflow: "triage", baselineModel: "gpt-4o" }), true);
+  assert.equal(campaignMatches(c, { taskType: "coding", workflow: "triage", baselineModel: "gpt-4o" }), false);
+  assert.equal(campaignMatches(c, { taskType: "classification", workflow: "other", baselineModel: "gpt-4o" }), false);
+  assert.equal(campaignMatches(c, { taskType: "classification", workflow: "triage", baselineModel: "claude-haiku-4-5" }), false);
+});
+
+test("campaignMatches treats null scope fields as 'any'", () => {
+  const c = { scope: {}, baselineModel: null };
+  assert.equal(campaignMatches(c, { taskType: "anything", workflow: "x", baselineModel: "y" }), true);
+});
+
+test("campaignMatches is case-insensitive on taskType", () => {
+  const c = { scope: { taskType: "Classification" }, baselineModel: null };
+  assert.equal(campaignMatches(c, { taskType: "classification" }), true);
+});
+
+test("canActivateShadow requires a passed offline run", () => {
+  assert.equal(canActivateShadow({ status: "passed" }, null).allowed, true);
+  assert.equal(canActivateShadow({ status: "failed" }, null).allowed, false);
+  assert.equal(canActivateShadow(null, null).allowed, false);
+});
+
+test("canActivateShadow honors a valid override", () => {
+  assert.equal(canActivateShadow(null, { reason: "pilot", approver: "prasanna" }).allowed, true);
+  assert.equal(canActivateShadow({ status: "running" }, { reason: "x" }).allowed, false); // no approver
+});

--- a/server/test/unit/promptPacks.test.js
+++ b/server/test/unit/promptPacks.test.js
@@ -1,0 +1,22 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { getPromptPair } = require("../../src/seed/promptPacks");
+
+test("getPromptPair returns a prompt/response pair for a known task type", () => {
+  const p = getPromptPair("classification", 0);
+  assert.ok(p.prompt && typeof p.prompt === "string");
+  assert.ok(p.response && typeof p.response === "string");
+});
+
+test("getPromptPair cycles within a pack and falls back for unknown types", () => {
+  const p = getPromptPair("extraction", 5); // index wraps
+  assert.ok(p.prompt.includes("JSON")); // extraction pack is structured
+  const g = getPromptPair("totally-unknown-task", 0);
+  assert.ok(g.prompt && g.response); // generic fallback
+});
+
+test("extraction responses are valid JSON (drives the structured-output demo)", () => {
+  const p = getPromptPair("extraction", 0);
+  assert.doesNotThrow(() => JSON.parse(p.response));
+});

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -66,8 +66,27 @@ export const api = {
 
   recommendations: (status) => req(`/recommendations${qs({ status })}`),
   recompute: () => req("/recommendations/recompute", { method: "POST" }),
-  acceptRecommendation: (id) => req(`/recommendations/${id}/accept`, { method: "POST" }),
+  acceptRecommendation: (id, override) => req(`/recommendations/${id}/accept`, { method: "POST", body: JSON.stringify(override ? { override } : {}) }),
   dismissRecommendation: (id) => req(`/recommendations/${id}/dismiss`, { method: "POST" }),
+
+  // Eval-backed routing (P0–P3): dataset → offline run → shadow → canary.
+  createEvalDataset: (id, body = {}) => req(`/recommendations/${id}/create-eval-dataset`, { method: "POST", body: JSON.stringify(body) }),
+  runEval: (id, body = {}) => req(`/recommendations/${id}/run-eval`, { method: "POST", body: JSON.stringify(body) }),
+  startShadow: (id, body = {}) => req(`/recommendations/${id}/start-shadow`, { method: "POST", body: JSON.stringify(body) }),
+  createCanary: (id, body = {}) => req(`/recommendations/${id}/create-canary`, { method: "POST", body: JSON.stringify(body) }),
+  overrideRecommendation: (id, body) => req(`/recommendations/${id}/override`, { method: "POST", body: JSON.stringify(body) }),
+  evalDatasets: (recommendationId) => req(`/evals/datasets${qs({ recommendationId })}`),
+  evalDataset: (id) => req(`/evals/datasets/${id}`),
+  evalRuns: (recommendationId) => req(`/evals/runs${qs({ recommendationId })}`),
+  evalRun: (id) => req(`/evals/runs/${id}`),
+  evalRunResults: (id) => req(`/evals/runs/${id}/results`),
+
+  // Routing experiments (canary rollout).
+  routingExperiments: (status) => req(`/routing-experiments${qs({ status })}`),
+  routingExperiment: (id) => req(`/routing-experiments/${id}`),
+  updateRoutingExperiment: (id, body) => req(`/routing-experiments/${id}`, { method: "PATCH", body: JSON.stringify(body) }),
+  rollbackExperiment: (id, reason) => req(`/routing-experiments/${id}/rollback`, { method: "POST", body: JSON.stringify({ reason }) }),
+  promoteExperiment: (id, approvedBy) => req(`/routing-experiments/${id}/promote`, { method: "POST", body: JSON.stringify({ approvedBy }) }),
 
   models: ({ live } = {}) => req(`/models${live ? "?live=true" : ""}`),
   createModel: (body) => req("/models", { method: "POST", body: JSON.stringify(body) }),

--- a/web/src/pages/ModelEvals.jsx
+++ b/web/src/pages/ModelEvals.jsx
@@ -151,6 +151,130 @@ function CampaignDetail({ id, onClose }) {
   );
 }
 
+const RUN_TONE = { queued: "gray", running: "amber", passed: "green", failed: "red", cancelled: "gray" };
+const EXP_TONE = { draft: "gray", active: "green", paused: "amber", rolled_back: "red", promoted: "charcoal" };
+
+// Offline eval-run detail: pass/fail, aggregate summary, and the worst candidate examples.
+function RunDetail({ id, onClose }) {
+  const [run, setRun] = useState(null);
+  const [results, setResults] = useState(null);
+
+  useEffect(() => {
+    api.evalRun(id).then(setRun).catch((e) => setRun({ _error: e.message }));
+    api.evalRunResults(id).then(setResults).catch(() => setResults([]));
+  }, [id]);
+
+  const exportCsv = () => {
+    const rows = results || [];
+    const head = ["verdict", "criticalFailure", "formatPass", "candidateCost", "candidateLatencyMs", "judgeRationale"];
+    const body = rows.map((r) => head.map((k) => JSON.stringify(r[k] ?? "")).join(","));
+    const blob = new Blob([[head.join(","), ...body].join("\n")], { type: "text/csv" });
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(blob); a.download = `eval-run-${id}.csv`;
+    document.body.appendChild(a); a.click(); document.body.removeChild(a);
+  };
+
+  if (!run) return <Drawer title="Eval run" onClose={onClose}><Spinner /></Drawer>;
+  if (run._error) return <Drawer title="Eval run" onClose={onClose}><div className="text-sm text-red-600">{run._error}</div></Drawer>;
+  const s = run.summary || {};
+
+  return (
+    <Drawer title={`Eval run · ${run.candidateModel}`} onClose={onClose}>
+      <div className="space-y-5">
+        <div className={`rounded-lg p-3 text-sm font-medium ${run.status === "passed" ? "bg-green-50 text-arbr-green-700" : run.status === "failed" ? "bg-red-50 text-red-700" : "bg-gray-50 text-gray-600"}`}>
+          {run.status === "passed" ? "✓ Passed all thresholds" : run.status === "failed" ? "✗ Failed" : run.status}
+          {run.failures?.length > 0 && <ul className="mt-1 list-disc pl-5 text-xs font-normal">{run.failures.map((f, i) => <li key={i}>{f}</li>)}</ul>}
+          {run.error && <div className="mt-1 text-xs font-normal">{run.error}</div>}
+        </div>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Stat label="Judged" value={fmt.num(s.judged)} sub={`${fmt.num(s.total)} total`} />
+          <Stat label="Worse-rate" value={pct(s.worseRate)} sub={`critical ${pct(s.criticalFailRate)}`} />
+          <Stat label="Format pass" value={pct(s.formatPassRate)} />
+          <Stat label="Cost saving" value={pct(s.costSavingPct)} sub={`latency ${signedPct(s.avgLatencyDeltaPct)}`} />
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-xs text-gray-600">
+          {run.baselineModel} → {run.candidateModel} · judge {run.judgeModel || "none"} · {run.riskTier} risk · est. cost {fmt.usd(run.estimatedCostUsd)} · actual {fmt.usd(run.actualCostUsd)}
+        </div>
+        <div className="flex items-center justify-between">
+          <div className="label">Worst candidate examples</div>
+          <button className="btn-outline text-xs" onClick={exportCsv}>Export CSV</button>
+        </div>
+        {results === null ? <Spinner /> : results.length === 0 ? <div className="text-xs text-gray-400">No results.</div> : (
+          <div className="space-y-3">
+            {results.slice(0, 20).map((r) => (
+              <div key={r._id} className="rounded-lg border border-gray-200 p-3">
+                <div className="flex items-center gap-2">
+                  {r.judgeVerdict ? <Badge tone={VERDICT_TONE[r.judgeVerdict]}>{r.judgeVerdict}</Badge> : <Badge tone="gray">unjudged</Badge>}
+                  {r.criticalFailure && <Badge tone="red">critical</Badge>}
+                  {!r.formatPass && <Badge tone="amber">format fail</Badge>}
+                  {r.error && <span className="text-xs text-red-600">{r.error}</span>}
+                </div>
+                {r.judgeRationale && <p className="mt-2 text-sm text-gray-600">{r.judgeRationale}</p>}
+                {r.candidateResponse && <CodeBlock code={r.candidateResponse} />}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </Drawer>
+  );
+}
+
+// Offline eval runs across all recommendations.
+function EvalRunsSection() {
+  const [runs, setRuns] = useState(null);
+  const [openId, setOpenId] = useState(null);
+  useEffect(() => { api.evalRuns().then(setRuns).catch(() => setRuns([])); }, []);
+  const cols = [
+    { key: "candidateModel", header: "Baseline → candidate", render: (r) => <span>{r.baselineModel} → <b>{r.candidateModel}</b></span> },
+    { key: "status", header: "Status", render: (r) => <Badge tone={RUN_TONE[r.status]}>{r.status}</Badge> },
+    { key: "worse", header: "Worse-rate", render: (r) => pct(r.summary?.worseRate) },
+    { key: "saving", header: "Cost saving", render: (r) => pct(r.summary?.costSavingPct) },
+    { key: "risk", header: "Risk", render: (r) => r.riskTier },
+    { key: "actions", header: "", render: (r) => <button className="btn-outline text-xs" onClick={(e) => { e.stopPropagation(); setOpenId(r._id); }}>Evidence</button> },
+  ];
+  return (
+    <Card title="Offline eval runs">
+      {runs === null ? <Spinner /> : <Table columns={cols} rows={runs} empty="No eval runs yet — run one from a recommendation." onRowClick={(r) => setOpenId(r._id)} />}
+      {openId && <RunDetail id={openId} onClose={() => setOpenId(null)} />}
+    </Card>
+  );
+}
+
+// Live canary experiments with rollback / promote controls.
+function CanarySection() {
+  const [exps, setExps] = useState(null);
+  const [err, setErr] = useState(null);
+  const load = useCallback(() => { api.routingExperiments().then(setExps).catch(() => setExps([])); }, []);
+  useEffect(() => { load(); }, [load]);
+
+  const act = async (fn) => { setErr(null); try { await fn(); load(); } catch (e) { setErr(e.message); } };
+  const rollback = (id) => act(() => api.rollbackExperiment(id, "manual rollback from dashboard"));
+  const promote = (id) => act(() => api.promoteExperiment(id, "console"));
+
+  const cols = [
+    { key: "models", header: "Baseline → candidate", render: (e) => <span>{e.baselineModel} → <b>{e.candidateModel}</b></span> },
+    { key: "scope", header: "Scope", render: (e) => <span className="text-xs text-gray-500">{[e.scope?.application, e.scope?.taskType].filter(Boolean).join(" · ") || "any"}</span> },
+    { key: "rollout", header: "Rollout", render: (e) => `${e.rolloutPct}%` },
+    { key: "status", header: "Status", render: (e) => <Badge tone={EXP_TONE[e.status]}>{e.status}</Badge> },
+    { key: "metrics", header: "Live (err / save)", render: (e) => e.lastMetrics ? <span className="text-xs">{pct(e.lastMetrics.candErrorRate)} / {pct(e.lastMetrics.costSavingPct)}</span> : <span className="text-gray-400">—</span> },
+    { key: "actions", header: "", render: (e) => (
+      <span className="flex gap-2" onClick={(ev) => ev.stopPropagation()}>
+        {(e.status === "active" || e.status === "paused") && <button className="btn-outline text-xs" onClick={() => promote(e._id)}>Promote</button>}
+        {(e.status === "active" || e.status === "paused") && <button className="btn-outline text-xs text-red-600" onClick={() => rollback(e._id)}>Roll back</button>}
+        {e.status === "rolled_back" && e.rollbackReason && <span className="text-xs text-red-600">{e.rollbackReason}</span>}
+      </span>
+    ) },
+  ];
+  return (
+    <Card title="Canary experiments">
+      <p className="mb-3 text-sm text-gray-500">Eval-approved candidates rolled out to a deterministic slice of auto-routed traffic. Auto-rolls-back on guardrail breach; promote to make it a rule.</p>
+      {err && <div className="mb-2 text-sm text-red-600">{err}</div>}
+      {exps === null ? <Spinner /> : <Table columns={cols} rows={exps} empty="No canary experiments — start one from a passed recommendation." />}
+    </Card>
+  );
+}
+
 export default function ModelEvals() {
   const [campaigns, setCampaigns] = useState(null);
   const [models, setModels] = useState([]);
@@ -194,8 +318,11 @@ export default function ModelEvals() {
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold text-arbr-charcoal">Model Evals</h1>
-        <p className="mt-1 text-sm text-gray-500">Safely evaluate a candidate model on your own live traffic before switching.</p>
+        <p className="mt-1 text-sm text-gray-500">Prove a cheaper model holds quality — offline replay, live shadow, then a guarded canary — before it becomes a rule.</p>
       </div>
+
+      <EvalRunsSection />
+      <CanarySection />
 
       <NewCampaign models={models} apps={apps} onCreated={load} />
 

--- a/web/src/pages/Recommendations.jsx
+++ b/web/src/pages/Recommendations.jsx
@@ -2,13 +2,136 @@ import React, { useEffect, useState } from "react";
 import { api, fmt } from "../api.js";
 import { Card, Badge, Spinner } from "../components/ui.jsx";
 
+const EVAL_TONE = { not_started: "gray", dataset_ready: "gray", running: "amber", passed: "green", failed: "red", overridden: "amber" };
+const EVAL_LABEL = { not_started: "No eval", dataset_ready: "Dataset ready", running: "Evaluating…", passed: "Eval passed", failed: "Eval failed", overridden: "Overridden" };
+const pct = (n) => (n == null ? "—" : `${(n * 100).toFixed(1)}%`);
+
+// Evidence summary line from a run/quality summary.
+function QualitySummary({ s }) {
+  if (!s) return null;
+  return (
+    <div className="mt-3 flex flex-wrap gap-2 text-xs">
+      <Badge tone="gray">{fmt.num(s.judged)} judged</Badge>
+      <Badge tone={s.worseRate > 0.05 ? "red" : "green"}>worse {pct(s.worseRate)}</Badge>
+      {s.criticalFailRate != null && <Badge tone={s.criticalFailRate > 0 ? "red" : "gray"}>critical {pct(s.criticalFailRate)}</Badge>}
+      <Badge tone="gray">format {pct(s.formatPassRate)}</Badge>
+      <Badge tone="green">cost −{pct(s.costSavingPct)}</Badge>
+      {s.avgLatencyDeltaPct != null && <Badge tone="gray">latency {s.avgLatencyDeltaPct > 0 ? "+" : ""}{pct(s.avgLatencyDeltaPct)}</Badge>}
+    </div>
+  );
+}
+
+function RecCard({ rec, models, onChange }) {
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState(null);
+  const [notice, setNotice] = useState(null);
+  const [judge, setJudge] = useState("");
+  const [application, setApplication] = useState(rec.application || "");
+  const evalStatus = rec.evalStatus || "not_started";
+
+  const run = async (fn, ok) => {
+    setBusy(true); setErr(null); setNotice(null);
+    try { const r = await fn(); if (ok) setNotice(ok(r)); await onChange(); }
+    catch (e) { setErr(e.message); }
+    finally { setBusy(false); }
+  };
+
+  const accept = async () => {
+    setBusy(true); setErr(null);
+    try { await api.acceptRecommendation(rec._id); await onChange(); }
+    catch (e) {
+      if (e.status === 409) {
+        const reason = window.prompt("This recommendation has not passed an eval. Enter an override reason to accept anyway (or Cancel):");
+        if (!reason) { setBusy(false); return; }
+        const approver = window.prompt("Approver name:") || "console";
+        try { await api.acceptRecommendation(rec._id, { reason, approver }); await onChange(); }
+        catch (e2) { setErr(e2.message); }
+      } else setErr(e.message);
+    } finally { setBusy(false); }
+  };
+
+  return (
+    <Card>
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h3 className="text-base font-semibold text-arbr-charcoal">{rec.title}</h3>
+            {rec.status === "accepted" && <Badge tone="green">Accepted</Badge>}
+            {rec.status === "dismissed" && <Badge tone="gray">Dismissed</Badge>}
+            {rec.status === "pending" && <Badge tone="amber">Pending</Badge>}
+            <Badge tone={EVAL_TONE[evalStatus]}>{EVAL_LABEL[evalStatus]}</Badge>
+          </div>
+          <p className="mt-2 text-sm text-gray-600">{rec.reason}</p>
+          <div className="mt-3 flex flex-wrap gap-2 text-xs">
+            <Badge tone="charcoal">{rec.currentModel} → {rec.suggestedModel}</Badge>
+            <Badge tone="gray">{fmt.num(rec.requestCount)} requests</Badge>
+          </div>
+          <QualitySummary s={rec.qualitySummary} />
+        </div>
+        <div className="shrink-0 text-right">
+          <div className="label">Projected saving</div>
+          <div className="text-2xl font-bold text-arbr-green-600">{fmt.usd(rec.projectedSavings)}</div>
+          <div className="text-xs text-gray-500">{fmt.usd(rec.currentCost)} → {fmt.usd(rec.projectedCost)}</div>
+        </div>
+      </div>
+
+      {rec.status === "pending" && (
+        <div className="mt-4 border-t border-gray-100 pt-4">
+          {/* Eval-backed flow: prove quality, then roll out under control. */}
+          <div className="flex flex-wrap items-center gap-2">
+            {(evalStatus === "not_started") && (
+              <button className="btn-secondary text-sm" disabled={busy}
+                onClick={() => run(() => api.createEvalDataset(rec._id), (d) => `Dataset built: ${d.itemCount} items (${d.riskTier} risk).`)}>
+                1 · Build eval dataset
+              </button>
+            )}
+            {(evalStatus === "dataset_ready" || evalStatus === "failed") && (
+              <>
+                <select className="input text-sm" value={judge} onChange={(e) => setJudge(e.target.value)} title="Judge model">
+                  <option value="">Judge: none</option>
+                  {models.map((m) => <option key={m.id} value={m.id}>Judge: {m.label || m.id}</option>)}
+                </select>
+                <button className="btn-secondary text-sm" disabled={busy}
+                  onClick={() => run(() => api.runEval(rec._id, { judgeModel: judge || null }), () => "Offline eval started — refresh in a moment.")}>
+                  2 · Run offline eval
+                </button>
+              </>
+            )}
+            {evalStatus === "running" && <span className="text-sm text-amber-600">Evaluating… refresh to see the result.</span>}
+            {evalStatus === "passed" && (
+              <>
+                <input className="input text-sm" placeholder="application for rollout" value={application} onChange={(e) => setApplication(e.target.value)} />
+                <button className="btn-secondary text-sm" disabled={busy || !application.trim()}
+                  onClick={() => run(() => api.createCanary(rec._id, { application: application.trim() }), (x) => `Canary started at ${x.rolloutPct}%.`)}>
+                  3 · Start canary
+                </button>
+              </>
+            )}
+            <button className="btn-outline text-sm" disabled={busy} onClick={accept}>Accept as rule</button>
+            <button className="btn-outline text-sm" disabled={busy} onClick={() => run(() => api.dismissRecommendation(rec._id))}>Dismiss</button>
+          </div>
+          <p className="mt-2 text-xs text-gray-400">
+            Accepting creates a routing rule (off until you switch it on). It is gated on a passed eval; without one you'll be asked for an override reason.
+          </p>
+          {notice && <div className="mt-2 text-sm text-arbr-green-700">{notice}</div>}
+          {err && <div className="mt-2 text-sm text-red-600">{err}</div>}
+        </div>
+      )}
+    </Card>
+  );
+}
+
 export default function Recommendations({ embedded = false }) {
   const [recs, setRecs] = useState(null);
+  const [models, setModels] = useState([]);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState(null);
 
   const load = () => api.recommendations().then(setRecs).catch((e) => setErr(e.message));
-  useEffect(() => { load(); }, []);
+  useEffect(() => {
+    load();
+    api.models({ live: true }).then((m) => setModels(m || [])).catch(() => {});
+  }, []);
 
   const recompute = async () => {
     setBusy(true); setErr(null);
@@ -17,15 +140,12 @@ export default function Recommendations({ embedded = false }) {
     finally { setBusy(false); }
   };
 
-  const accept = async (id) => { await api.acceptRecommendation(id); await load(); };
-  const dismiss = async (id) => { await api.dismissRecommendation(id); await load(); };
-
   return (
     <div className="space-y-6">
       <div className="flex items-start justify-between">
         <div>
           {!embedded && <h1 className="text-2xl font-bold text-arbr-charcoal">Recommendations</h1>}
-          <p className="text-sm text-gray-500">Costed optimisation suggestions. The system proposes; the human decides.</p>
+          <p className="text-sm text-gray-500">Costed suggestions. Prove quality with an eval, then roll out under control — the system proposes, the human decides.</p>
         </div>
         <button className="btn-primary" onClick={recompute} disabled={busy}>
           {busy ? "Recomputing…" : "Recompute"}
@@ -41,37 +161,7 @@ export default function Recommendations({ embedded = false }) {
         </Card>
       ) : (
         <div className="space-y-4">
-          {recs.map((r) => (
-            <Card key={r._id}>
-              <div className="flex items-start justify-between gap-4">
-                <div className="min-w-0">
-                  <div className="flex items-center gap-2">
-                    <h3 className="text-base font-semibold text-arbr-charcoal">{r.title}</h3>
-                    {r.status === "accepted" && <Badge tone="green">Accepted</Badge>}
-                    {r.status === "dismissed" && <Badge tone="gray">Dismissed</Badge>}
-                    {r.status === "pending" && <Badge tone="amber">Pending</Badge>}
-                  </div>
-                  <p className="mt-2 text-sm text-gray-600">{r.reason}</p>
-                  <div className="mt-3 flex flex-wrap gap-2 text-xs">
-                    <Badge tone="charcoal">{r.currentModel} → {r.suggestedModel}</Badge>
-                    <Badge tone="gray">{fmt.num(r.requestCount)} requests</Badge>
-                  </div>
-                </div>
-                <div className="shrink-0 text-right">
-                  <div className="label">Projected saving</div>
-                  <div className="text-2xl font-bold text-arbr-green-600">{fmt.usd(r.projectedSavings)}</div>
-                  <div className="text-xs text-gray-500">{fmt.usd(r.currentCost)} → {fmt.usd(r.projectedCost)}</div>
-                </div>
-              </div>
-              {r.status === "pending" && (
-                <div className="mt-4 flex gap-2 border-t border-gray-100 pt-4">
-                  <button className="btn-secondary" onClick={() => accept(r._id)}>Accept as rule</button>
-                  <button className="btn-outline" onClick={() => dismiss(r._id)}>Dismiss</button>
-                  <span className="self-center text-xs text-gray-400">Accepting creates a routing rule — off until you switch it on.</span>
-                </div>
-              )}
-            </Card>
-          ))}
+          {recs.map((r) => <RecCard key={r._id} rec={r} models={models} onChange={load} />)}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Why this exists
The eval feature was authored as **stacked PRs** (#79 → #80 → #81 → #82 → #83). Each child PR's base was its parent branch, not `main`. When merged, only **#79 (P0)** had `main` as its base and actually landed there — **#80, #81, #82, #83 each merged into their parent branch**, so Phase 2/3/4 and the demo seed never reached `main`.

This PR lands exactly those deltas on current `main`. P0 files are untouched (they're already on `main` via #79); only the Phase 2/3/4/seed changes are included.

## What lands (previously reviewed as #80–#83)
- **Phase 2 (#80)** — shadow-eval hardening: `EvalCampaign` scope/baseline/`requiredEvalRunId`, daily budget + error caps, date window, activation gate on a passed offline run, `start-shadow`.
- **Phase 3 (#81)** — `RoutingExperiment` + `canaryEngine` (deterministic bucketing, fail-open, `routingDecision:"canary"`) + `canaryMonitor` (5-min auto-rollback) + create-canary / rollback / promote. Includes the `candidateProvider` fix so promote/canary don't depend on the pricing registry.
- **Phase 4 (#82)** — Recommendations eval stepper + gate-aware accept; Model Evals offline-runs + canary sections with evidence and rollback/promote.
- **Seed (#83)** — `promptPacks` (replayable prompts/responses across 5 task types) + a baked-in eval story (approved classification + live canary; blocked failure-first extraction) so the demo runs on `docker compose up` with no keys.

## Verification
- `npm run lint`: 0 errors (14 pre-existing warnings).
- Unit suite: **86 pass / 0 fail** on Node 22.
- `npm run web:build`: passes.
- Integration tests run in CI (local `mongod` SIGABRTs). Demo verified earlier via `docker compose up`.

Merging this makes `main` contain the complete eval-backed routing feature (P0 + Phases 2–4 + demo seed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
