### PR TITLE
perf(gateway): reduce hot-path latency via Settings cache + parallel pre-LLM fetches

### DIFF
--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -1180,6 +1180,7 @@ router.patch("/governance", async (req, res, next) => {
       update.maskPiiInResponses = !!body.maskPiiInResponses;
 
     await Settings.updateOne({ key: "global" }, { $set: update }, { upsert: true });
+    Settings.invalidateCache();
     const s = await Settings.get();
     setImmediate(() => logAction("governance.update", "settings", "global", body));
     res.json(governanceView(s));
@@ -1309,6 +1310,7 @@ router.post("/app-configs/:app/set-default-policy", async (req, res, next) => {
     const cfg = await ApplicationConfig.findOne({ applicationName: req.params.app }).lean();
     if (!cfg?.aiPolicyAssignments) return res.status(400).json({ error: "No custom policy set for this application." });
     await Settings.updateOne({ key: "global" }, { $set: { aiPolicy: cfg.aiPolicyAssignments } }, { upsert: true });
+    Settings.invalidateCache();
     aiPolicy.invalidate?.();
     setImmediate(() => logAction("appConfig.setDefaultPolicy", "settings", "global", { from: req.params.app }));
     res.json({ ok: true });

--- a/server/src/gateway/auth.js
+++ b/server/src/gateway/auth.js
@@ -63,6 +63,7 @@ async function setRequireApiKey(on) {
   const s = await Settings.get();
   s.requireApiKey = !!on;
   await s.save();
+  Settings.invalidateCache();
   return s.requireApiKey;
 }
 

--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -228,6 +228,7 @@ async function resolveRoute(body, { router, eff, application, workflow, userId =
 }
 
 async function handleChat(req, res) {
+  const _reqStart = Date.now();
   const body = req.body || {};
 
   // 1 · INGRESS — validate, capture metadata, stamp id + time.
@@ -235,27 +236,27 @@ async function handleChat(req, res) {
     return res.status(400).json({ error: "messages array is required" });
   }
 
-  // Maintenance mode (kill-switch): checked before any routing or provider access.
-  const settings = await Settings.get();
+  // Parallel: settings + appConfig + router are independent reads.
+  const earlyApp = req.apiKey?.application || body.application || "unknown";
+  const [settings, appCfg, routerResult] = await Promise.all([
+    Settings.get(),
+    getAppConfig(earlyApp),
+    getRouter(),
+  ]);
+
   if (settings.maintenanceMode?.enabled) {
     return res.status(503).json({
       error: "maintenance_mode",
       message: settings.maintenanceMode.message || "Service temporarily unavailable.",
     });
   }
-
-  // Per-application kill switch — checked before attribution is fully resolved,
-  // using the body's application claim (key binding happens later).
-  const earlyApp = req.apiKey?.application || body.application || "unknown";
-  const appCfg = await getAppConfig(earlyApp);
   if (appCfg?.killSwitchEnabled) {
     return res.status(503).json({
       error: "app_kill_switch",
       message: appCfg.killSwitchMessage || `Application "${earlyApp}" is temporarily disabled.`,
     });
   }
-
-  const { router, eff } = await getRouter();
+  const { router, eff } = routerResult;
   if (!router) {
     return res.status(503).json({
       error: "demo_mode",
@@ -412,6 +413,7 @@ async function handleChat(req, res) {
   }
 
   // 3 · INVOKE — provider call, fallback on failure.
+  const gatewayOverheadMs = Date.now() - _reqStart;
   let invocation;
   try {
     invocation = await invokeWithFallback(router, eff, {
@@ -502,7 +504,7 @@ async function handleChat(req, res) {
       totalTokens: result.usage?.totalTokens || 0,
       cachedReadTokens: result.usage?.cachedReadTokens || 0,
       cacheWriteTokens: result.usage?.cacheWriteTokens || 0,
-      latencyMs: result.latencyMs, status: "success",
+      latencyMs: result.latencyMs, gatewayOverheadMs, status: "success",
       routingDecision, cacheHit: false,
       knownPricing: served.knownPricing,
       messages: body.messages, responseText: result.text,

--- a/server/src/gateway/openaiCompat.js
+++ b/server/src/gateway/openaiCompat.js
@@ -246,6 +246,8 @@ async function proxyOpenAICompat(ctx) {
   });
   res.flushHeaders(); // send headers immediately so the client/proxy knows it's SSE
   let promptTokens = 0, completionTokens = 0, cachedReadTokens = 0, respText = "";
+  let ttftMs = null;
+  let _firstChunk = true;
   try {
     if (!upstream.ok || !upstream.body) {
       const errText = await upstream.text().catch(() => "");
@@ -257,6 +259,7 @@ async function proxyOpenAICompat(ctx) {
     for (;;) {
       const { done, value } = await reader.read();
       if (done) break;
+      if (_firstChunk && value?.length > 0) { ttftMs = Date.now() - start; _firstChunk = false; }
       res.write(Buffer.from(value)); // relay exact bytes
       buf += decoder.decode(value, { stream: true });
       let nl;
@@ -283,12 +286,12 @@ async function proxyOpenAICompat(ctx) {
       promptTokens, completionTokens, totalTokens: promptTokens + completionTokens,
       cachedReadTokens,
       responseText: respText || null,
-      latencyMs: Date.now() - start, status: "success",
+      latencyMs: Date.now() - start, ttftMs, status: "success",
     });
   } catch (err) {
     try { res.write(`data: ${JSON.stringify({ error: String(err.message || err) })}\n\n`); } catch { /* client gone */ }
     res.end();
-    logRecord({ latencyMs: Date.now() - start, status: "failure", errorMessage: String(err.message || err) });
+    logRecord({ latencyMs: Date.now() - start, ttftMs, status: "failure", errorMessage: String(err.message || err) });
   }
 }
 
@@ -301,8 +304,14 @@ async function handleOpenAICompat(req, res) {
     });
   }
 
-  // Maintenance mode (kill-switch): checked before any routing or provider access.
-  const settings = await Settings.get();
+  // Parallel: settings + router + appConfig are independent reads.
+  const appName = req.apiKey?.application || "openai-compat";
+  const [settings, routerResult, appCfg] = await Promise.all([
+    Settings.get(),
+    getRouter(),
+    getAppConfig(appName),
+  ]);
+
   if (settings.maintenanceMode?.enabled) {
     const msg = settings.maintenanceMode.message || "Service temporarily unavailable.";
     const errBody = { error: { message: msg, type: "server_error", code: "maintenance_mode" } };
@@ -315,19 +324,18 @@ async function handleOpenAICompat(req, res) {
     }
     return res.status(503).json(errBody);
   }
+  const { router, eff } = routerResult;
+  if (!router) return res.status(503).json(DEMO_503);
 
   // Max-tokens guardrail: clamp body.max_tokens to the configured ceiling.
   if (settings.maxTokensGuardrail && body.max_tokens > settings.maxTokensGuardrail) {
     body.max_tokens = settings.maxTokensGuardrail;
   }
 
-  const { router, eff } = await getRouter();
-  if (!router) return res.status(503).json(DEMO_503);
-
   const requestId = uuidv4();
   const timestamp = new Date();
   const meta = {
-    application: req.apiKey?.application || "openai-compat",
+    application: appName,
     workflow: "completion",
     userId: req.apiKey?.userId || null,
     department: "openai-compat",
@@ -337,10 +345,6 @@ async function handleOpenAICompat(req, res) {
   const normalized = { ...body, maxTokens: body.max_tokens };
   const modelRequested = (body.model || "auto").trim();
 
-  // Per-application config (kill switch, modelOptOut, generated aiPolicyAssignments). Without this
-  // the app's own policy + allowed-models opt-out are ignored and routing falls back to the global
-  // policy / default — exactly the /v1/chat path's behavior. (parity with handleChat)
-  const appCfg = await getAppConfig(meta.application);
   if (appCfg?.killSwitchEnabled) {
     return res.status(503).json({
       error: {

--- a/server/src/models/Settings.js
+++ b/server/src/models/Settings.js
@@ -87,12 +87,21 @@ const settingsSchema = new mongoose.Schema(
   { collection: "settings" }
 );
 
+let _cache = { doc: null, at: 0 };
+const CACHE_TTL_MS = 5_000;
+
 settingsSchema.statics.get = async function get() {
+  if (_cache.doc && Date.now() - _cache.at < CACHE_TTL_MS) return _cache.doc;
   let doc = await this.findOne({ key: "global" });
   if (!doc) {
     doc = await this.create({ key: "global" });
   }
+  _cache = { doc, at: Date.now() };
   return doc;
+};
+
+settingsSchema.statics.invalidateCache = function invalidateCache() {
+  _cache.at = 0;
 };
 
 module.exports = mongoose.model("Settings", settingsSchema);

--- a/server/src/routing/aiPolicy.js
+++ b/server/src/routing/aiPolicy.js
@@ -185,6 +185,7 @@ async function setAssignments(assignments) {
   s.aiPolicy = { ...(s.aiPolicy || {}), assignments: clean };
   s.markModified("aiPolicy");
   await s.save();
+  Settings.invalidateCache();
   invalidate();
   return s.aiPolicy;
 }
@@ -372,6 +373,7 @@ async function regenerate({ router, eff, goal }) {
   s.aiPolicy = { assignments, generatedAt: new Date(), generatorModel: generatorModel.id, capabilityVersion: CAPABILITY_VERSION };
   s.markModified("aiPolicy");
   await s.save();
+  Settings.invalidateCache();
   invalidate();
   return s.aiPolicy;
 }

--- a/server/src/routing/ruleEngine.js
+++ b/server/src/routing/ruleEngine.js
@@ -63,6 +63,7 @@ async function setRoutingMode(mode) {
   s.routingMode = next;
   s.autoRouting = next !== "off"; // keep legacy field consistent
   await s.save();
+  Settings.invalidateCache();
   return next;
 }
 


### PR DESCRIPTION
## Summary

- **A1 — Settings TTL cache**: `Settings.get()` was called 4+ times per request, each doing a full MongoDB `findOne` (~2–5ms each). Added a module-level 5-second TTL in-process cache. Estimated savings: **10–20ms per request**. Cache is busted via `Settings.invalidateCache()` at every mutation site: `routes.js` (`PATCH /governance`, `/app-configs/:app/set-default-policy`), `ruleEngine.setRoutingMode`, `auth.setRequireApiKey`, `aiPolicy.setAssignments` / `aiPolicy.regenerate`.
- **A2 — Parallel pre-LLM fetches**: `Settings.get()`, `getAppConfig()`, and `getRouter()` ran sequentially in both `handler.js` and `openaiCompat.js`. All three are independent reads — wrapped in `Promise.all()`. Estimated savings: **20–40ms on cold paths**.
- **Instrumentation groundwork**: records `gatewayOverheadMs` (wall-clock from `handleChat` entry to just before `invokeWithFallback`) and `ttftMs` (time-to-first-token from first SSE chunk in the streaming proxy). Schema fields and dashboard wired up in the companion PR.

## Test plan

- [ ] Start the server and send 10 back-to-back requests; confirm second+ `Settings.get()` calls are sub-millisecond (add a temporary `console.log` to the cache branch, remove after)
- [ ] Mutate a settings value (e.g. toggle kill-switch in UI); confirm the cache is invalidated and the next request reads fresh values
- [ ] Make a streaming request; confirm `ttftMs` is logged in the server output (visible once companion schema PR lands)
- [ ] Run `npm run bench:latency -- --requests 30` before and after; p50 should drop by 20–50ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)