### PR TITLE
feat(observability): latency benchmarking, TTFT/overhead tracking, and dashboard stats

### DIFF
--- a/bench/aggregate.js
+++ b/bench/aggregate.js
@@ -9,12 +9,13 @@ if (!file) { console.error("usage: node bench/aggregate.js <results.jsonl>"); pr
 const rows = fs.readFileSync(file, "utf8").trim().split("\n").filter(Boolean).map((l) => JSON.parse(l));
 const s = summarize(rows);
 
-const pct = (n) => (n == null ? "  —  " : `${n.toFixed(1)}%`);
-const usd = (n) => `$${(Number(n) || 0).toFixed(4)}`;
+const pct  = (n) => (n == null ? "  —  " : `${n.toFixed(1)}%`);
+const usd  = (n) => `$${(Number(n) || 0).toFixed(4)}`;
+const ms   = (n) => (n == null ? "  —" : `${Math.round(n)}ms`);
 
 const benchName = (rows[0] && rows[0].benchmark) || "benchmark";
 console.log(`\n${benchName} router comparison  (${rows.length} rows)\n`);
-console.log("baseline          quality   qRetained   $/query    cost%prem   scored  err  unpriced");
+console.log("baseline          quality   qRetained   $/query    cost%prem   p50      p95      max      scored  err  unpriced");
 for (const k of Object.keys(s)) {
   const b = s[k];
   console.log(
@@ -22,6 +23,9 @@ for (const k of Object.keys(s)) {
     `${pct(b.qualityRetainedPct)}`.padEnd(12) +
     `${usd(b.costPerQuery)}`.padEnd(11) +
     `${pct(b.costVsPremiumPct)}`.padEnd(11) +
+    `${ms(b.latencyP50)}`.padEnd(9) +
+    `${ms(b.latencyP95)}`.padEnd(9) +
+    `${ms(b.latencyMax)}`.padEnd(9) +
     `${b.scoredN}`.padEnd(8) + `${b.errors}`.padEnd(5) + `${b.unpriced}`
   );
 }

--- a/bench/lib/summarize.js
+++ b/bench/lib/summarize.js
@@ -1,14 +1,21 @@
 // Pure aggregation of raw result rows → the cost-vs-quality summary (unit-tested).
 // quality = mean score over SCORED rows (unscored categories excluded, not counted as 0).
 // Derives, vs always-premium: quality retained % and cost %.
+
+function latencyPct(sorted, p) {
+  if (!sorted.length) return null;
+  return sorted[Math.max(0, Math.ceil(p * sorted.length) - 1)];
+}
+
 function summarize(rows) {
   const acc = {};
   for (const r of rows) {
-    const b = acc[r.baseline] || (acc[r.baseline] = { n: 0, errors: 0, scoredN: 0, scoreSum: 0, costSum: 0, unpriced: 0, cat: {} });
+    const b = acc[r.baseline] || (acc[r.baseline] = { n: 0, errors: 0, scoredN: 0, scoreSum: 0, costSum: 0, unpriced: 0, cat: {}, latencies: [] });
     b.n++;
     if (r.error) { b.errors++; continue; }
     if (r.priced === false) b.unpriced++;
     b.costSum += Number(r.costUsd) || 0;
+    if (r.latencyMs != null) b.latencies.push(Number(r.latencyMs));
     if (r.scored) {
       b.scoredN++; b.scoreSum += Number(r.score) || 0;
       const c = b.cat[r.category] || (b.cat[r.category] = { n: 0, sum: 0 });
@@ -18,11 +25,15 @@ function summarize(rows) {
   const out = {};
   for (const k of Object.keys(acc)) {
     const b = acc[k];
+    const sorted = [...b.latencies].sort((a, x) => a - x);
     out[k] = {
       baseline: k, n: b.n, errors: b.errors, scoredN: b.scoredN, unpriced: b.unpriced,
       quality: b.scoredN ? b.scoreSum / b.scoredN : null,
       totalCost: b.costSum,
       costPerQuery: b.n ? b.costSum / b.n : 0,
+      latencyP50: latencyPct(sorted, 0.5),
+      latencyP95: latencyPct(sorted, 0.95),
+      latencyMax: sorted.length ? sorted[sorted.length - 1] : null,
       byCategory: Object.fromEntries(Object.keys(b.cat).map((cat) => [cat, b.cat[cat].n ? b.cat[cat].sum / b.cat[cat].n : null])),
     };
   }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "docs:preview": "vitepress preview docs",
     "test:server:unit": "node --test server/test/unit/*.test.js",
     "test:server:integration": "node --test server/test/integration/*.test.js",
-    "test:server": "node --test server/test/unit/*.test.js server/test/integration/*.test.js"
+    "test:server": "node --test server/test/unit/*.test.js server/test/integration/*.test.js",
+    "bench:latency": "node server/scripts/latency-bench.js",
+    "bench:latency:stream": "node server/scripts/latency-bench.js --stream"
   },
   "dependencies": {
     "@langchain/anthropic": "^1.5.1",

--- a/server/scripts/latency-bench.js
+++ b/server/scripts/latency-bench.js
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+// Standalone latency benchmark for the Arbr gateway.
+// Usage:
+//   ARBR_GATEWAY_URL=http://localhost:4100 ARBR_API_KEY=ab_... \
+//     node server/scripts/latency-bench.js [--requests 50] [--concurrency 5] [--stream] [--model gpt-4o-mini]
+//   node server/scripts/latency-bench.js --compare bench/results/latency-A.json bench/results/latency-B.json
+
+const fs   = require("fs");
+const path = require("path");
+const http  = require("http");
+const https = require("https");
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+const argv = process.argv.slice(2);
+function flag(name, def) {
+  const i = argv.indexOf(`--${name}`);
+  if (i === -1) return def;
+  return argv[i + 1] !== undefined && !argv[i + 1].startsWith("--") ? argv[i + 1] : true;
+}
+
+const COMPARE_IDX = argv.indexOf("--compare");
+if (COMPARE_IDX !== -1) {
+  const a = argv[COMPARE_IDX + 1];
+  const b = argv[COMPARE_IDX + 2];
+  if (!a || !b) { console.error("--compare requires two file paths"); process.exit(1); }
+  compareResults(a, b);
+  process.exit(0);
+}
+
+const REQUESTS    = parseInt(flag("requests",    "50"),  10);
+const CONCURRENCY = parseInt(flag("concurrency", "5"),   10);
+const STREAM      = flag("stream", false) === true || flag("stream", false) === "true";
+const MODEL       = flag("model", "gpt-4o-mini");
+const WARMUP      = 5;
+const PROMPT      = "Reply with exactly three words.";
+
+const BASE_URL = process.env.ARBR_GATEWAY_URL || "http://localhost:4100";
+const API_KEY  = process.env.ARBR_API_KEY     || "";
+
+if (!API_KEY) {
+  console.error("Set ARBR_API_KEY env var before running.");
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+function post(url, body, { streaming } = {}) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const lib = parsed.protocol === "https:" ? https : http;
+    const data = JSON.stringify(body);
+    const req = lib.request(
+      {
+        hostname: parsed.hostname,
+        port:     parsed.port || (parsed.protocol === "https:" ? 443 : 80),
+        path:     parsed.pathname + parsed.search,
+        method:   "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(data),
+          "Authorization": `Bearer ${API_KEY}`,
+        },
+      },
+      (res) => {
+        if (streaming) {
+          resolve(res); // caller reads the stream
+        } else {
+          const chunks = [];
+          res.on("data", (c) => chunks.push(c));
+          res.on("end", () => {
+            try { resolve({ status: res.statusCode, body: JSON.parse(Buffer.concat(chunks).toString()) }); }
+            catch (e) { reject(e); }
+          });
+        }
+      }
+    );
+    req.on("error", reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Single request — non-streaming
+// ---------------------------------------------------------------------------
+async function requestOnce() {
+  const start = Date.now();
+  const { status, body } = await post(`${BASE_URL}/v1/chat/completions`, {
+    model: MODEL,
+    messages: [{ role: "user", content: PROMPT }],
+    max_tokens: 32,
+    temperature: 0,
+  });
+  const latencyMs = Date.now() - start;
+  if (status !== 200) throw new Error(`HTTP ${status}: ${JSON.stringify(body)}`);
+  return { latencyMs, ttftMs: null };
+}
+
+// ---------------------------------------------------------------------------
+// Single request — streaming (SSE), records TTFT
+// ---------------------------------------------------------------------------
+async function requestStream() {
+  const start = Date.now();
+  const res = await post(
+    `${BASE_URL}/v1/chat/completions`,
+    { model: MODEL, messages: [{ role: "user", content: PROMPT }], max_tokens: 32, temperature: 0, stream: true },
+    { streaming: true }
+  );
+  if (res.statusCode !== 200) {
+    const chunks = [];
+    for await (const c of res) chunks.push(c);
+    throw new Error(`HTTP ${res.statusCode}: ${Buffer.concat(chunks).toString()}`);
+  }
+  return new Promise((resolve, reject) => {
+    let ttftMs = null;
+    res.on("data", (chunk) => {
+      if (ttftMs === null) {
+        const text = chunk.toString();
+        // First non-empty SSE data line marks TTFT
+        if (text.includes("data:") && !text.includes("data: [DONE]")) {
+          ttftMs = Date.now() - start;
+        }
+      }
+    });
+    res.on("end", () => resolve({ latencyMs: Date.now() - start, ttftMs }));
+    res.on("error", reject);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Stats helpers
+// ---------------------------------------------------------------------------
+function percentile(sorted, p) {
+  if (!sorted.length) return null;
+  const idx = Math.ceil(p * sorted.length) - 1;
+  return sorted[Math.max(0, Math.min(idx, sorted.length - 1))];
+}
+
+function stats(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const sum = sorted.reduce((a, b) => a + b, 0);
+  return {
+    count: sorted.length,
+    min:   sorted[0],
+    max:   sorted[sorted.length - 1],
+    mean:  Math.round(sum / sorted.length),
+    p50:   percentile(sorted, 0.5),
+    p95:   percentile(sorted, 0.95),
+    p99:   percentile(sorted, 0.99),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency pool
+// ---------------------------------------------------------------------------
+async function runPool(n, concurrency, fn) {
+  const results = [];
+  let running = 0;
+  let sent    = 0;
+
+  return new Promise((resolve, reject) => {
+    function next() {
+      while (running < concurrency && sent < n) {
+        const idx = sent++;
+        running++;
+        fn(idx)
+          .then((r) => { results.push(r); })
+          .catch((e) => { results.push({ error: e.message }); })
+          .finally(() => { running--; if (results.length === n) resolve(results); else next(); });
+      }
+    }
+    next();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Main bench
+// ---------------------------------------------------------------------------
+async function main() {
+  const reqFn = STREAM ? requestStream : requestOnce;
+
+  process.stdout.write(`Warming up (${WARMUP} requests)…`);
+  for (let i = 0; i < WARMUP; i++) {
+    await reqFn().catch(() => {});
+    process.stdout.write(".");
+  }
+  console.log(" done.\n");
+
+  console.log(`Running ${REQUESTS} requests (concurrency=${CONCURRENCY}, stream=${STREAM}, model=${MODEL})…`);
+  const results = await runPool(REQUESTS, CONCURRENCY, () => reqFn());
+
+  const errors = results.filter((r) => r.error);
+  const ok     = results.filter((r) => !r.error);
+
+  if (errors.length) {
+    console.warn(`\n${errors.length} errors:`);
+    errors.slice(0, 3).forEach((e) => console.warn("  ", e.error));
+    if (errors.length > 3) console.warn(`  … and ${errors.length - 3} more`);
+  }
+
+  const latencies = ok.map((r) => r.latencyMs);
+  const ttfts     = ok.map((r) => r.ttftMs).filter((v) => v !== null);
+
+  const latencyStats = stats(latencies);
+  const ttftStats    = ttfts.length ? stats(ttfts) : null;
+
+  console.log("\nLatency (wall-clock, ms):");
+  console.log(`  min=${latencyStats.min}  p50=${latencyStats.p50}  p95=${latencyStats.p95}  p99=${latencyStats.p99}  max=${latencyStats.max}  mean=${latencyStats.mean}  n=${latencyStats.count}`);
+
+  if (ttftStats) {
+    console.log("\nTTFT (ms):");
+    console.log(`  min=${ttftStats.min}  p50=${ttftStats.p50}  p95=${ttftStats.p95}  p99=${ttftStats.p99}  max=${ttftStats.max}  mean=${ttftStats.mean}  n=${ttftStats.count}`);
+  }
+
+  // Save results
+  const dateStr = new Date().toISOString().slice(0, 10);
+  const outDir  = path.join(__dirname, "../../bench/results");
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, `latency-${dateStr}.json`);
+  const record = {
+    date: new Date().toISOString(),
+    config: { requests: REQUESTS, concurrency: CONCURRENCY, stream: STREAM, model: MODEL },
+    errors: errors.length,
+    latency: latencyStats,
+    ttft: ttftStats,
+  };
+  fs.writeFileSync(outPath, JSON.stringify(record, null, 2));
+  console.log(`\nResults saved → ${outPath}`);
+}
+
+// ---------------------------------------------------------------------------
+// --compare
+// ---------------------------------------------------------------------------
+function compareResults(pathA, pathB) {
+  const a = JSON.parse(fs.readFileSync(pathA, "utf8"));
+  const b = JSON.parse(fs.readFileSync(pathB, "utf8"));
+
+  console.log(`\nComparing latency results:`);
+  console.log(`  A: ${pathA}  (${a.date})`);
+  console.log(`  B: ${pathB}  (${b.date})\n`);
+
+  const METRICS = ["p50", "p95", "p99", "min", "max", "mean"];
+  const pad = (s, n) => String(s).padStart(n);
+  const pct = (va, vb) => {
+    if (va == null || vb == null) return "n/a";
+    const d = ((vb - va) / va) * 100;
+    return `${d >= 0 ? "+" : ""}${d.toFixed(1)}%`;
+  };
+
+  console.log("Latency (ms):");
+  console.log(`  ${"metric".padEnd(8)} ${pad("A", 8)} ${pad("B", 8)} ${"delta".padStart(10)} ${"change".padStart(8)}`);
+  for (const m of METRICS) {
+    const va = a.latency?.[m];
+    const vb = b.latency?.[m];
+    const delta = (va != null && vb != null) ? (vb - va) : null;
+    console.log(`  ${m.padEnd(8)} ${pad(va ?? "—", 8)} ${pad(vb ?? "—", 8)} ${pad(delta != null ? (delta >= 0 ? "+" + delta : delta) : "—", 10)}ms ${pad(pct(va, vb), 8)}`);
+  }
+
+  if (a.ttft || b.ttft) {
+    console.log("\nTTFT (ms):");
+    console.log(`  ${"metric".padEnd(8)} ${pad("A", 8)} ${pad("B", 8)} ${"delta".padStart(10)} ${"change".padStart(8)}`);
+    for (const m of METRICS) {
+      const va = a.ttft?.[m];
+      const vb = b.ttft?.[m];
+      const delta = (va != null && vb != null) ? (vb - va) : null;
+      console.log(`  ${m.padEnd(8)} ${pad(va ?? "—", 8)} ${pad(vb ?? "—", 8)} ${pad(delta != null ? (delta >= 0 ? "+" + delta : delta) : "—", 10)}ms ${pad(pct(va, vb), 8)}`);
+    }
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/server/src/analytics/aggregate.js
+++ b/server/src/analytics/aggregate.js
@@ -196,7 +196,8 @@ async function timeseries(filter, bucket = "day") {
   return rows;
 }
 
-// Global latency percentiles (p50 + p95) for the selected window, success requests only.
+// Global latency percentiles (p50 / p95 / p99) + TTFT percentiles for the selected window.
+// Only success requests; TTFT only from records where ttftMs was captured (streaming proxy path).
 async function latencyPercentiles(filter) {
   const match = buildMatch(filter);
   const [row] = await RequestRecord.aggregate([
@@ -204,19 +205,25 @@ async function latencyPercentiles(filter) {
     {
       $group: {
         _id: null,
-        p50: { $percentile: { input: "$latencyMs", p: [0.5],  method: "approximate" } },
-        p95: { $percentile: { input: "$latencyMs", p: [0.95], method: "approximate" } },
+        p50:     { $percentile: { input: "$latencyMs", p: [0.5],  method: "approximate" } },
+        p95:     { $percentile: { input: "$latencyMs", p: [0.95], method: "approximate" } },
+        p99:     { $percentile: { input: "$latencyMs", p: [0.99], method: "approximate" } },
+        ttftP50: { $percentile: { input: "$ttftMs",    p: [0.5],  method: "approximate" } },
+        ttftP95: { $percentile: { input: "$ttftMs",    p: [0.95], method: "approximate" } },
       },
     },
     {
       $project: {
         _id: 0,
-        p50: { $round: [{ $first: "$p50" }, 0] },
-        p95: { $round: [{ $first: "$p95" }, 0] },
+        p50:     { $round: [{ $first: "$p50" },     0] },
+        p95:     { $round: [{ $first: "$p95" },     0] },
+        p99:     { $round: [{ $first: "$p99" },     0] },
+        ttftP50: { $round: [{ $first: "$ttftP50" }, 0] },
+        ttftP95: { $round: [{ $first: "$ttftP95" }, 0] },
       },
     },
   ]);
-  return row || { p50: null, p95: null };
+  return row || { p50: null, p95: null, p99: null, ttftP50: null, ttftP95: null };
 }
 
 module.exports = {

--- a/server/src/models/RequestRecord.js
+++ b/server/src/models/RequestRecord.js
@@ -37,6 +37,10 @@ const requestRecordSchema = new mongoose.Schema(
 
     // performance + outcome
     latencyMs: { type: Number, default: 0 },
+    // Time-to-first-token in ms (streaming proxy path only; null for non-streaming or LangChain path).
+    ttftMs: { type: Number, default: null },
+    // Gateway processing overhead in ms before the LLM call was dispatched (excludes provider time).
+    gatewayOverheadMs: { type: Number, default: null },
     status: { type: String, enum: ["success", "failure", "blocked"], default: "success", index: true },
     errorMessage: { type: String, default: null },   // provider error text on status:"failure"
     retryCount: { type: Number, default: 0 },

--- a/web/src/pages/Overview.jsx
+++ b/web/src/pages/Overview.jsx
@@ -28,8 +28,12 @@ function Summary() {
   if (err) return <div className="text-red-600">{err}</div>;
   if (!data) return <Spinner />;
 
-  const p50 = latency?.p50 != null ? fmt.ms(latency.p50) : "—";
-  const p95 = latency?.p95 != null ? fmt.ms(latency.p95) : "—";
+  const p50     = latency?.p50     != null ? fmt.ms(latency.p50)     : "—";
+  const p95     = latency?.p95     != null ? fmt.ms(latency.p95)     : "—";
+  const p99     = latency?.p99     != null ? fmt.ms(latency.p99)     : "—";
+  const ttftP50 = latency?.ttftP50 != null ? fmt.ms(latency.ttftP50) : "—";
+  const ttftP95 = latency?.ttftP95 != null ? fmt.ms(latency.ttftP95) : "—";
+  const hasttft = latency?.ttftP50 != null;
 
   return (
     <div className="space-y-6">
@@ -40,9 +44,15 @@ function Summary() {
         <Stat label="Realised savings" value={fmt.usd(savings?.totalSaved)} />
       </div>
 
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
+      <div className={`grid grid-cols-1 gap-4 sm:grid-cols-2 ${hasttft ? "lg:grid-cols-5" : "lg:grid-cols-3"}`}>
         <Stat label="Latency p50" value={p50} sub="median (success)" />
         <Stat label="Latency p95" value={p95} sub="95th percentile" />
+        <Stat label="Latency p99" value={p99} sub="99th percentile" />
+        {hasttft && <Stat label="TTFT p50" value={ttftP50} sub="streaming median" />}
+        {hasttft && <Stat label="TTFT p95" value={ttftP95} sub="streaming 95th pct" />}
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         <Stat label="Cache hit rate" value={`${((data.cacheHitRate || 0) * 100).toFixed(1)}%`} />
         <Stat label="Cached tokens" value={fmt.num(data.cachedReadTokens)} />
         <Stat label="Cache savings" value={fmt.usd(data.cacheSavingUsd)} />


### PR DESCRIPTION
## Summary

Companion to #85. Adds the full measurement and benchmarking layer on top of the latency improvements.

- **B1+B2 — New `RequestRecord` fields** (both `null`-defaulted, no migration needed):
  - `ttftMs`: time-to-first-token, captured when the first non-empty SSE chunk arrives in the streaming proxy path (`openaiCompat.js`). `null` for non-streaming/LangChain requests.
  - `gatewayOverheadMs`: wall-clock from `handleChat` entry to just before `invokeWithFallback` — isolates gateway overhead from pure provider time.
- **B3 — Extended analytics + dashboard**:
  - `latencyPercentiles()` in `aggregate.js` now returns `p99`, `ttftP50`, `ttftP95` via MongoDB `$percentile`.
  - `Overview.jsx` shows a dedicated latency row (p50/p95/p99 always visible; TTFT p50/p95 only when at least one streaming request has been recorded). Cache stats moved to their own row.
- **B4 — `server/scripts/latency-bench.js`**: standalone benchmark script.
  - 5-request warmup to prime the Settings cache and MongoDB connections
  - Configurable `--requests` (default 50) and `--concurrency` (default 5)
  - `--stream` flag enables streaming mode + TTFT capture
  - Computes p50/p95/p99/min/max/mean from sorted samples (no extra deps)
  - Saves to `bench/results/latency-YYYY-MM-DD.json`
  - `--compare A B` diffs two result files as ms + percentage change
  - Run via `npm run bench:latency` / `npm run bench:latency:stream`
- **B5 — `bench/lib/summarize.js` + `bench/aggregate.js`**: per-baseline `latencyP50`, `latencyP95`, `latencyMax` added to the summary object; new columns printed in the aggregate table.

## Test plan

- [ ] Make a streaming request; check the saved `RequestRecord` in MongoDB has a non-null `ttftMs`
- [ ] Make a non-streaming request; confirm `ttftMs: null` and `gatewayOverheadMs` is populated
- [ ] Open the Overview dashboard; confirm the latency row shows p50/p95/p99; after a streaming request, confirm TTFT p50/p95 appear
- [ ] Run `ARBR_GATEWAY_URL=http://localhost:4100 ARBR_API_KEY=<key> npm run bench:latency -- --requests 20` and confirm JSON is written to `bench/results/`
- [ ] Run with `--compare` on two result files and confirm the diff table is readable
- [ ] Run `node bench/runner.js --limit 5 --dataset <file>` then `node bench/aggregate.js <file>` and confirm latency columns appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)