### PR TITLE
fix(eval): real validators, honest unknown-cost, accurate wording

### DIFF
--- a/server/src/analytics/aggregate.js
+++ b/server/src/analytics/aggregate.js
@@ -33,16 +33,22 @@ async function overview(filter) {
         cacheHits: { $sum: { $cond: ["$cacheHit", 1, 0] } },
         cachedReadTokens: { $sum: "$cachedReadTokens" },
         cacheSavingUsd: { $sum: "$cacheSavingUsd" },
+        // Pass-through models with no pricing entry log $0; surface them so cost isn't read as complete.
+        unknownPricingRequests: { $sum: { $cond: [{ $eq: ["$knownPricing", false] }, 1, 0] } },
       },
     },
   ]);
   const totalRequests = row?.totalRequests || 0;
   const totalCost = row?.totalCost || 0;
   const cacheHits = row?.cacheHits || 0;
+  const unknownPricingRequests = row?.unknownPricingRequests || 0;
+  const pricedRequests = totalRequests - unknownPricingRequests;
   return {
     totalRequests,
     totalCost,
-    avgCostPerRequest: totalRequests ? totalCost / totalRequests : 0,
+    // Average over priced requests only — $0 unknown-pricing records would otherwise deflate it.
+    avgCostPerRequest: pricedRequests ? totalCost / pricedRequests : 0,
+    unknownPricingRequests,
     avgLatency: row?.avgLatency || 0,
     totalTokens: row?.totalTokens || 0,
     failures: row?.failures || 0,

--- a/server/src/eval/dataset.js
+++ b/server/src/eval/dataset.js
@@ -78,6 +78,23 @@ function stratumKey(r) {
   return `${r.workflow || "-"}|${r.difficulty || "-"}`;
 }
 
+// Infer output validators for a dataset from what the BASELINE actually produced, so the
+// format pass-rate is a real check (not vacuously 100%). Pure.
+//   - baseline outputs all parse as JSON  → require the candidate to emit valid JSON.
+//   - baseline outputs are a small closed set of short strings → treat as labels; require membership.
+//   - otherwise (free-form text)          → no validator (the judge carries quality).
+function inferValidators(responses) {
+  const vals = (responses || []).map((r) => String(r || "").trim()).filter(Boolean);
+  if (vals.length < 5) return []; // too few to infer a shape confidently
+  const isJson = (s) => { try { JSON.parse(s); return true; } catch { return false; } };
+  if (vals.every(isJson)) return [{ type: "json_schema" }];
+  const distinct = [...new Set(vals)];
+  if (distinct.length <= 12 && distinct.every((v) => v.length <= 40)) {
+    return [{ type: "classification_label", labels: distinct }];
+  }
+  return [];
+}
+
 // Store the item text according to piiMode + global masking. Returns { messages, productionResponse }.
 function projectText(record, piiMode, maskEnabled, customPatterns) {
   if (piiMode === "metadata_only") return { messages: null, productionResponse: null };
@@ -135,6 +152,8 @@ async function createFromTraffic({ rec, targetCount, piiMode = "masked", windowD
       return dataset;
     }
 
+    // Attach validators inferred from the baseline outputs, so formatPassRate is a real gate.
+    const validators = inferValidators(sampled.map((r) => r.responseText));
     const items = sampled.map((r) => {
       const { messages, productionResponse } = projectText(r, effectivePiiMode, maskEnabled, customPatterns);
       return {
@@ -143,7 +162,7 @@ async function createFromTraffic({ rec, targetCount, piiMode = "masked", windowD
         messages, productionResponse,
         productionCost: r.totalCost || 0, productionLatencyMs: r.latencyMs || 0,
         promptHash: promptHashOf(r.messages), responseHash: responseHashOf(r.responseText),
-        validators: [], metadata: { classifiedBy: r.classifiedBy || null, difficulty: r.difficulty || null, confidence: r.confidence ?? null },
+        validators, metadata: { classifiedBy: r.classifiedBy || null, difficulty: r.difficulty || null, confidence: r.confidence ?? null },
       };
     });
     await EvalItem.insertMany(items);
@@ -162,5 +181,5 @@ async function createFromTraffic({ rec, targetCount, piiMode = "masked", windowD
 module.exports = {
   createFromTraffic,
   buildScopeQuery, isEligible, promptHashOf, responseHashOf,
-  dedupeByPromptHash, stratifiedSample, stratumKey, projectText,
+  dedupeByPromptHash, stratifiedSample, stratumKey, projectText, inferValidators,
 };

--- a/server/src/logging/logger.js
+++ b/server/src/logging/logger.js
@@ -49,6 +49,7 @@ async function write(record) {
 
     await RequestRecord.create({
       ...record,
+      knownPricing: record.knownPricing !== false, // normalize to a stored boolean
       messages,
       responseText,
       promptTokens,

--- a/server/src/models/RequestRecord.js
+++ b/server/src/models/RequestRecord.js
@@ -34,6 +34,9 @@ const requestRecordSchema = new mongoose.Schema(
     inputCost: { type: Number, default: 0 },
     outputCost: { type: Number, default: 0 },
     totalCost: { type: Number, default: 0, index: true },
+    // false = pass-through model with no pricing entry; cost is logged as $0 and must be
+    // EXCLUDED from spend/savings claims rather than treated as free. Surfaced in analytics.
+    knownPricing: { type: Boolean, default: true, index: true },
 
     // performance + outcome
     latencyMs: { type: Number, default: 0 },

--- a/server/test/unit/evalDataset.test.js
+++ b/server/test/unit/evalDataset.test.js
@@ -2,8 +2,24 @@
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
 const {
-  buildScopeQuery, isEligible, promptHashOf, dedupeByPromptHash, stratifiedSample, stratumKey, projectText,
+  buildScopeQuery, isEligible, promptHashOf, dedupeByPromptHash, stratifiedSample, stratumKey, projectText, inferValidators,
 } = require("../../src/eval/dataset");
+
+test("inferValidators requires JSON when baseline outputs are all JSON", () => {
+  const v = inferValidators(['{"a":1}', '{"b":2}', '{"c":3}', '{"d":4}', '{"e":5}']);
+  assert.deepEqual(v, [{ type: "json_schema" }]);
+});
+
+test("inferValidators infers a label set for a small closed set of short strings", () => {
+  const v = inferValidators(["billing", "technical", "billing", "account", "technical", "feedback"]);
+  assert.equal(v[0].type, "classification_label");
+  assert.deepEqual(new Set(v[0].labels), new Set(["billing", "technical", "account", "feedback"]));
+});
+
+test("inferValidators attaches nothing for free-form text or too-few samples", () => {
+  assert.deepEqual(inferValidators(["a long free-form sentence that is clearly prose and not a label at all", "another distinct long free-form paragraph of text here", "yet another unique long sentence", "and one more different long sentence", "plus a fifth unique long sentence"]), []);
+  assert.deepEqual(inferValidators(["billing", "technical"]), []); // < 5 samples
+});
 
 test("buildScopeQuery restricts to success + non-cache + scope", () => {
   const q = buildScopeQuery({ taskType: "classification", currentModel: "gpt-4o" }, new Date(0));

--- a/web/src/pages/ModelEvals.jsx
+++ b/web/src/pages/ModelEvals.jsx
@@ -318,7 +318,7 @@ export default function ModelEvals() {
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold text-arbr-charcoal">Model Evals</h1>
-        <p className="mt-1 text-sm text-gray-500">Prove a cheaper model holds quality — offline replay, live shadow, then a guarded canary — before it becomes a rule.</p>
+        <p className="mt-1 text-sm text-gray-500">Prove a cheaper model is no worse than the current one (safe substitution) — offline replay, live shadow, then a guarded canary — before it becomes a rule.</p>
       </div>
 
       <EvalRunsSection />

--- a/web/src/pages/Overview.jsx
+++ b/web/src/pages/Overview.jsx
@@ -35,7 +35,8 @@ function Summary() {
     <div className="space-y-6">
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <Stat label="Total requests" value={fmt.num(data.totalRequests)} />
-        <Stat label="Total cost" value={fmt.usd(data.totalCost)} />
+        <Stat label="Total cost" value={fmt.usd(data.totalCost)}
+          sub={data.unknownPricingRequests ? `excludes ${fmt.num(data.unknownPricingRequests)} unpriced req` : undefined} />
         <Stat label="Avg cost / request" value={fmt.usd(data.avgCostPerRequest)} />
         <Stat label="Realised savings" value={fmt.usd(savings?.totalSaved)} />
       </div>

--- a/web/src/pages/Recommendations.jsx
+++ b/web/src/pages/Recommendations.jsx
@@ -145,7 +145,7 @@ export default function Recommendations({ embedded = false }) {
       <div className="flex items-start justify-between">
         <div>
           {!embedded && <h1 className="text-2xl font-bold text-arbr-charcoal">Recommendations</h1>}
-          <p className="text-sm text-gray-500">Costed suggestions. Prove quality with an eval, then roll out under control — the system proposes, the human decides.</p>
+          <p className="text-sm text-gray-500">Costed suggestions. Prove a cheaper model is no worse than the current one, then roll out under control — the system proposes, the human decides.</p>
         </div>
         <button className="btn-primary" onClick={recompute} disabled={busy}>
           {busy ? "Recomputing…" : "Recompute"}


### PR DESCRIPTION
Three credibility fixes from an external code review. Base `main`.

### #4 — Validators were vacuous (biggest hole)
Dataset creation set `validators: []` on every item, and `runValidators` returns `formatPass: true` when empty, so **"format pass-rate 99%" meant "we didn't check format."** Now `inferValidators()` derives a real check from what the **baseline** actually produced:
- baseline outputs all parse as JSON → require the candidate to emit valid JSON (`json_schema`)
- a small closed set of short strings → `classification_label` membership check
- free-form text → nothing (the judge carries quality)

### #10 — Unknown-pricing cost lied
Pass-through models with no pricing entry log `$0`, which was silently summed as if free. `knownPricing` was computed but **never persisted** (dropped by Mongoose strict mode). Now it's stored, the overview returns `unknownPricingRequests`, avg cost/request is computed over **priced** requests only, and the Total-cost card shows "excludes N unpriced req".

### #2 — Wording
The judge compares candidate vs the **production** response, so it proves "no worse than the current model", not absolute correctness. Copy now says **"safe substitution / no worse than the current one"** instead of "prove quality".

### Deliberately not in this PR (coming next, per your call)
- #5 recommendation/rule scope (design: per-application recommendations)
- #3 masked-replay fidelity
- #1 eval replay as a real job model

Also: the roast's #6 (EvalCampaign "fake-scoped") is **stale** — the merged schema already stores scope/baseline/requiredEvalRunId/budgets/dates. No change needed.

Tests: 3 new unit tests for `inferValidators`; unit suite **89/89**, lint 0 errors, web build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
