### PR TITLE
feat(eval): durable worker, masked-fidelity labeling, explicit rule scope

### DIFF
--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -655,8 +655,17 @@ router.post("/recommendations/:id/accept", async (req, res, next) => {
       rec.override = { reason: override.reason, approver: override.approver, at: new Date(), expiresAt: override.expiresAt || null };
     }
 
+    // Rule scope is explicit, not silently global: use the caller-provided scope, else the
+    // recommendation's own scope. Both default to null (any) only when nothing is set, and the
+    // resolved condition is returned + audited so a broad rule is never a surprise.
+    const scope = (req.body && req.body.scope) || {};
+    const condition = {
+      taskType: rec.taskType,
+      application: scope.application ?? rec.application ?? null,
+      workflow: scope.workflow ?? rec.workflow ?? null,
+    };
     const rule = await Rule.create({
-      condition: { taskType: rec.taskType, application: null, workflow: null },
+      condition,
       target: { provider: rec.suggestedProvider, model: rec.suggestedModel },
       enabled: false, // human must explicitly switch it on
       createdBy: "console",
@@ -759,6 +768,18 @@ router.get("/evals/runs/:id", async (req, res, next) => {
   try {
     const run = await EvalRun.findById(req.params.id).lean().catch(() => null);
     if (!run) return res.status(404).json({ error: "not found" });
+    res.json(run);
+  } catch (e) { next(e); }
+});
+// Cancel a queued/running run; the worker stops it at the next checkpoint (queued stops immediately).
+router.post("/evals/runs/:id/cancel", async (req, res, next) => {
+  try {
+    const run = await EvalRun.findOneAndUpdate(
+      { _id: req.params.id, status: { $in: ["queued", "running"] } },
+      { $set: { status: "cancelled" } }, { new: true }
+    ).lean().catch(() => null);
+    if (!run) return res.status(409).json({ error: "not_cancellable", message: "run is not queued or running" });
+    setImmediate(() => logAction("eval.run.cancel", "evalRun", req.params.id, null));
     res.json(run);
   } catch (e) { next(e); }
 });

--- a/server/src/eval/replay.js
+++ b/server/src/eval/replay.js
@@ -86,6 +86,7 @@ async function startRun({ rec, dataset, judgeModel, thresholds, maxRunCostUsd = 
     candidateModel: dataset.candidateModel,
     judgeModel: judgeModel || null,
     riskTier: dataset.riskTier,
+    fidelity: dataset.piiMode === "raw_allowed" ? "high" : (dataset.piiMode === "metadata_only" ? "metadata_only" : "masked"),
     thresholds,
     estimatedCostUsd,
     maxRunCostUsd,
@@ -102,21 +103,23 @@ async function startRun({ rec, dataset, judgeModel, thresholds, maxRunCostUsd = 
   }
   if (rec) { rec.evalStatus = "running"; rec.evalRunId = run._id; await rec.save().catch(() => {}); }
 
-  // Fire-and-forget; the run updates its own status.
-  setImmediate(() => executeRun(run._id).catch((e) => console.error("[eval-replay] run failed:", e.message)));
+  // The run stays "queued"; the eval worker (eval/worker.js) claims and executes it. This
+  // survives a process restart (a queued run is picked up on next boot) instead of being lost
+  // with an in-process setImmediate.
   return run;
 }
 
 async function executeRun(runId) {
-  const run = await EvalRun.findById(runId);
-  if (!run || run.status !== "queued") return;
+  // Atomically claim the run (queued → running) so concurrent workers can't double-execute it.
+  const run = await EvalRun.findOneAndUpdate(
+    { _id: runId, status: "queued" },
+    { $set: { status: "running", startedAt: new Date() } },
+    { new: true }
+  );
+  if (!run) return; // already claimed, cancelled, or gone
   const dataset = await EvalDataset.findById(run.datasetId);
   const items = await EvalItem.find({ datasetId: run.datasetId }).lean();
   const { router, eff } = await getRouter().catch(() => ({}));
-
-  run.status = "running";
-  run.startedAt = new Date();
-  await run.save();
 
   if (!router || !eff) return finish(run, [], "no live provider/router (demo mode); cannot replay");
 
@@ -130,6 +133,7 @@ async function executeRun(runId) {
 
   const entries = [];
   let actualCost = 0;
+  let cancelled = false;
   for (const item of items) {
     if (!item.messages) { // metadata_only dataset — nothing to replay
       entries.push({ errored: true });
@@ -138,6 +142,11 @@ async function executeRun(runId) {
     if (run.maxRunCostUsd != null && actualCost > run.maxRunCostUsd) {
       run.error = `cost cap $${run.maxRunCostUsd} reached after ${entries.length} items; stopped early`;
       break;
+    }
+    // Honor cancellation mid-run (checked periodically to bound DB reads).
+    if (entries.length % 10 === 0) {
+      const fresh = await EvalRun.findById(run._id, { status: 1 }).lean().catch(() => null);
+      if (fresh && fresh.status === "cancelled") { cancelled = true; break; }
     }
     try {
       const candidate = await router.complete({
@@ -179,7 +188,7 @@ async function executeRun(runId) {
       entries.push({ errored: true });
     }
   }
-  return finish(run, entries, null, actualCost);
+  return finish(run, entries, cancelled ? "__cancelled__" : null, actualCost);
 }
 
 async function finish(run, entries, hardError, actualCost = 0) {
@@ -187,7 +196,11 @@ async function finish(run, entries, hardError, actualCost = 0) {
   run.summary = summary;
   run.actualCostUsd = actualCost;
   run.completedAt = new Date();
-  if (hardError) {
+  if (hardError === "__cancelled__") {
+    run.status = "cancelled";
+    run.error = "cancelled mid-run";
+    run.failures = [];
+  } else if (hardError) {
     run.status = "failed";
     run.error = hardError;
     run.failures = [hardError];
@@ -201,9 +214,14 @@ async function finish(run, entries, hardError, actualCost = 0) {
   if (run.recommendationId) {
     const rec = await Recommendation.findById(run.recommendationId).catch(() => null);
     if (rec) {
-      rec.evalStatus = run.status === "passed" ? "passed" : "failed";
+      // A cancelled run leaves the recommendation re-runnable, not "failed".
+      if (run.status === "cancelled") {
+        rec.evalStatus = "dataset_ready";
+      } else {
+        rec.evalStatus = run.status === "passed" ? "passed" : "failed";
+        rec.qualitySummary = summary;
+      }
       rec.evalRunId = run._id;
-      rec.qualitySummary = summary;
       await rec.save().catch(() => {});
     }
   }

--- a/server/src/eval/worker.js
+++ b/server/src/eval/worker.js
@@ -1,0 +1,35 @@
+// Eval replay worker. Polls for queued EvalRuns and executes them via replay.executeRun, which
+// atomically claims each run (queued → running) so this is safe to run in more than one process.
+// Replaces the old in-process setImmediate: a queued run now survives a restart and is picked up
+// on the next tick instead of being lost. Bounded concurrency keeps provider load in check.
+const EvalRun = require("../models/EvalRun");
+const { executeRun } = require("./replay");
+
+const INTERVAL_MS = 5_000;
+const MAX_CONCURRENT = 2;
+
+let _timer = null;
+let _active = 0;
+
+async function tick() {
+  try {
+    while (_active < MAX_CONCURRENT) {
+      // Peek at the oldest queued run; executeRun does the atomic claim, so a race just no-ops.
+      const next = await EvalRun.findOne({ status: "queued" }).sort({ createdAt: 1 }).select({ _id: 1 }).lean();
+      if (!next) break;
+      _active++;
+      executeRun(next._id)
+        .catch((e) => console.error("[eval-worker] run failed:", e.message))
+        .finally(() => { _active--; });
+    }
+  } catch { /* must not crash the process */ }
+}
+
+function start() {
+  if (_timer) return;
+  _timer = setInterval(tick, INTERVAL_MS);
+  if (_timer.unref) _timer.unref();
+}
+function stop() { if (_timer) { clearInterval(_timer); _timer = null; } }
+
+module.exports = { start, stop, tick };

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -12,6 +12,7 @@ const { handleOpenAICompat } = require("./gateway/openaiCompat");
 const { purgeOldRecords } = require("./maintenance/purge");
 const errorAlertMonitor = require("./routing/errorAlertMonitor");
 const canaryMonitor = require("./routing/canaryMonitor");
+const evalWorker = require("./eval/worker");
 const { supportsTools } = require("./gateway/capabilities");
 const auth = require("./gateway/auth");
 const adminAuth = require("./api/adminAuth");
@@ -130,6 +131,9 @@ async function start() {
   // Canary auto-rollback: every 5 min, roll back any active routing experiment that
   // breaches its guardrails (error rate, latency, cost saving, shadow worse-rate).
   canaryMonitor.start();
+
+  // Eval replay worker: picks up queued eval runs (survives restarts; setImmediate did not).
+  evalWorker.start();
 
   app.listen(config.port, config.host, () => {
     console.log("\n" + describe() + "\n");

--- a/server/src/models/EvalRun.js
+++ b/server/src/models/EvalRun.js
@@ -14,6 +14,10 @@ const evalRunSchema = new mongoose.Schema(
     candidateModel: { type: String, default: null },
     judgeModel: { type: String, default: null },
     riskTier: { type: String, enum: ["low", "medium", "high"], default: "medium" },
+    // Eval fidelity, derived from the dataset's piiMode. A "masked" run compares the candidate on
+    // redacted prompts against a baseline answer produced from the ORIGINAL prompt, so it is not
+    // strictly apples-to-apples — treat a masked pass as lower-confidence than a "high" (raw) one.
+    fidelity: { type: String, enum: ["high", "masked", "metadata_only"], default: "high" },
 
     status: { type: String, enum: ["queued", "running", "passed", "failed", "cancelled"], default: "queued", index: true },
     thresholds: { type: mongoose.Schema.Types.Mixed, default: null },

--- a/server/src/models/Recommendation.js
+++ b/server/src/models/Recommendation.js
@@ -8,7 +8,12 @@ const recommendationSchema = new mongoose.Schema(
     title: { type: String, required: true },
     reason: { type: String, required: true },
 
-    // What the recommendation is about.
+    // What the recommendation is about. Scope narrows where an accepted rule applies; null = any.
+    // (Today's engine produces task-type-global recs; these let accept constrain the rule and
+    // leave room for per-application recommendations without another schema change.)
+    application: { type: String, default: null },
+    workflow: { type: String, default: null },
+    department: { type: String, default: null },
     taskType: { type: String, default: null },
     currentModel: { type: String, default: null },
     currentProvider: { type: String, default: null },

--- a/server/test/integration/evalHardening.test.js
+++ b/server/test/integration/evalHardening.test.js
@@ -1,0 +1,66 @@
+"use strict";
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+const mongoose = require("mongoose");
+const express = require("express");
+const supertest = require("supertest");
+
+process.env.ARBR_ADMIN_KEY = "";
+
+const Recommendation = require("../../src/models/Recommendation");
+const Rule = require("../../src/models/Rule");
+const EvalDataset = require("../../src/models/EvalDataset");
+const EvalItem = require("../../src/models/EvalItem");
+const EvalRun = require("../../src/models/EvalRun");
+const replay = require("../../src/eval/replay");
+const apiRoutes = require("../../src/api/routes");
+
+let mongod, agent;
+const buildApp = () => { const a = express(); a.use(express.json()); a.use("/api", apiRoutes); return a; };
+const passedRec = () => Recommendation.create({
+  title: "t", reason: "r", taskType: "classification", currentModel: "gpt-4o",
+  suggestedModel: "gpt-4o-mini", suggestedProvider: "openai", evalStatus: "passed", dedupeKey: `k-${Math.random()}`,
+});
+
+before(async () => { mongod = await MongoMemoryServer.create(); await mongoose.connect(mongod.getUri()); agent = supertest(buildApp()); });
+after(async () => { await mongoose.disconnect(); await mongod.stop(); });
+beforeEach(async () => { await Promise.all([Recommendation.deleteMany({}), Rule.deleteMany({}), EvalDataset.deleteMany({}), EvalItem.deleteMany({}), EvalRun.deleteMany({})]); });
+
+test("#5 accept scopes the rule to the given application (not silently global)", async () => {
+  const rec = await passedRec();
+  const res = await agent.post(`/api/recommendations/${rec._id}/accept`).send({ scope: { application: "support-chat" } });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.rule.condition.application, "support-chat");
+  assert.equal(res.body.rule.condition.taskType, "classification");
+});
+
+test("#5 accept defaults to task-wide when no scope is given", async () => {
+  const rec = await passedRec();
+  const res = await agent.post(`/api/recommendations/${rec._id}/accept`).send({});
+  assert.equal(res.status, 200);
+  assert.equal(res.body.rule.condition.application, null);
+});
+
+test("#1 a queued run can be cancelled via the API", async () => {
+  const run = await EvalRun.create({ datasetId: new mongoose.Types.ObjectId(), status: "queued" });
+  const res = await agent.post(`/api/evals/runs/${run._id}/cancel`).send({});
+  assert.equal(res.status, 200);
+  assert.equal(res.body.status, "cancelled");
+  // cancelling again is a no-op conflict
+  const again = await agent.post(`/api/evals/runs/${run._id}/cancel`).send({});
+  assert.equal(again.status, 409);
+});
+
+test("#1 executeRun atomically claims a queued run and finishes gracefully with no provider", async () => {
+  const rec = await passedRec();
+  const ds = await EvalDataset.create({ recommendationId: rec._id, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", status: "ready", riskTier: "low", piiMode: "masked" });
+  await EvalItem.create({ datasetId: ds._id, messages: [{ role: "user", content: "hi" }], productionResponse: "ok" });
+  const run = await EvalRun.create({ recommendationId: rec._id, datasetId: ds._id, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", riskTier: "low", status: "queued", fidelity: "masked" });
+
+  await replay.executeRun(run._id); // no provider configured in test → graceful fail, not a throw
+  const after = await EvalRun.findById(run._id).lean();
+  assert.equal(after.status, "failed");
+  assert.match(after.error, /no live provider/);
+  assert.equal(after.fidelity, "masked"); // #3 fidelity persisted
+});

--- a/web/src/pages/ModelEvals.jsx
+++ b/web/src/pages/ModelEvals.jsx
@@ -194,6 +194,7 @@ function RunDetail({ id, onClose }) {
         </div>
         <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-xs text-gray-600">
           {run.baselineModel} → {run.candidateModel} · judge {run.judgeModel || "none"} · {run.riskTier} risk · est. cost {fmt.usd(run.estimatedCostUsd)} · actual {fmt.usd(run.actualCostUsd)}
+          {run.fidelity === "masked" && <span className="ml-1 text-amber-600">· masked dataset (lower-fidelity: candidate saw redacted prompts vs the original baseline)</span>}
         </div>
         <div className="flex items-center justify-between">
           <div className="label">Worst candidate examples</div>


### PR DESCRIPTION
Round 2 of the eval-trust fixes. **Base `main`** (independent of #87 — deliberately not stacked, so no merge-collapse). Only shared file with #87 is `ModelEvals.jsx`, in a different region.

### #1 — Eval replay is no longer fire-and-forget
`startRun` now leaves the run **queued**; a Mongo-polled worker (`eval/worker.js`, started in `index.js` alongside the other monitors) claims it **atomically** (`queued → running` via `findOneAndUpdate`, safe across processes) and executes it. A queued run now **survives a restart** instead of vanishing with `setImmediate`. Runs honor cancellation at a checkpoint (every 10 items), and `POST /evals/runs/:id/cancel` is added. Lease-expiry/retry are noted as a follow-up.

### #3 — Masked replay is labeled, not silently trusted
A masked dataset has the candidate answer **redacted** prompts while the baseline answer came from the **original** prompt, so it's not apples-to-apples. `EvalRun.fidelity` (`high`/`masked`/`metadata_only`) is derived from the dataset's `piiMode`, and the run detail flags a masked run as lower-confidence. Not blocked, just honest.

### #5 — Rule scope is explicit, not silently global
`Recommendation` gains `application`/`workflow`/`department`. `accept` no longer hardcodes a global rule: the created rule's condition comes from an explicit `scope` (or the rec's own scope), defaults to task-wide only when nothing is set, and the resolved condition is returned + audited. (Full per-application recommendation *generation* is a larger follow-up.)

### Note on the roast's #6
Stale — the merged `EvalCampaign` schema already stores scope/baseline/requiredEvalRunId/budgets/dates. No change needed.

### Verification
Lint 0 errors; unit suite **86/86** on Node 22; web build passes. New integration tests (CI) for accept-scope, run-cancel, and the worker claim path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
