### PR TITLE
fix(api): correct /about package.json path (500 + broke deploy seed check)

### DIFF
--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -90,7 +90,11 @@ router.get("/status", async (_req, res, next) => {
 
 router.get("/about", async (_req, res, next) => {
   try {
-    const pkg = require("../../package.json");
+    // package.json is at the repo root (server/src/api → ../../../). Guarded so a missing file
+    // degrades to "unknown version" instead of 500-ing /about (which ops/deploy.sh reads for the
+    // model-seed version).
+    let pkg = {};
+    try { pkg = require("../../../package.json"); } catch { /* version unknown */ }
     const s = await Settings.get().catch(() => null);
     res.json({
       version: pkg.version,

--- a/server/test/integration/about.test.js
+++ b/server/test/integration/about.test.js
@@ -1,0 +1,26 @@
+"use strict";
+const { test, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+const mongoose = require("mongoose");
+const express = require("express");
+const supertest = require("supertest");
+
+process.env.ARBR_ADMIN_KEY = "";
+const apiRoutes = require("../../src/api/routes");
+
+let mongod, agent;
+before(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  const app = express(); app.use(express.json()); app.use("/api", apiRoutes);
+  agent = supertest(app);
+});
+after(async () => { await mongoose.disconnect(); await mongod.stop(); });
+
+test("GET /api/about returns 200 with a version (package.json resolves)", async () => {
+  const res = await agent.get("/api/about");
+  assert.equal(res.status, 200);
+  assert.ok(res.body.version, "version should be present");
+  assert.ok(res.body.name, "name should be present");
+});


### PR DESCRIPTION
`/api/about` did `require("../../package.json")` from `server/src/api/routes.js`, resolving to `server/package.json` which doesn't exist (package.json is at the repo root). Every call 500'd with MODULE_NOT_FOUND.

**Surfaced** in prod logs after the latest deploy, but **pre-existing** (introduced in the Settings refactor `687beb3`, not #85-#88).

**Side effect:** `ops/deploy.sh` reads `/api/about` for `modelSeedVersion` to decide whether to re-run the LiteLLM sync, so that step has been silently no-op'ing.

**Fix:** require the root `package.json` (`../../../`), guarded so a missing file degrades to "unknown version" instead of 500-ing. Adds an integration test asserting `/api/about` → 200 with a version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)