### PR TITLE
fix(recommendations): recognise custom app task types (entity-extraction, concept-extraction, etc.)

### DIFF
--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -1009,17 +1009,21 @@ router.post("/ai-policy/simulate", async (req, res, next) => {
 router.get("/policy", async (_req, res, next) => {
   try {
     const d = await policyEngine.describe();
-    res.json({ ...d, taskTypes: TASK_TYPES });
+    // Merge built-in task types with any app-provided task types observed in traffic.
+    const observed = (await RequestRecord.distinct("taskType")).filter(Boolean).map((x) => String(x).toLowerCase());
+    const allTypes = [...new Set([...TASK_TYPES, ...observed])].sort();
+    res.json({ ...d, taskTypes: allTypes });
   } catch (e) { next(e); }
 });
 
 router.put("/policy", async (req, res, next) => {
   try {
     const body = req.body || {};
-    // Validate task types against the known catalog.
+    // Validate task types against built-in catalog + any task types observed in traffic.
     let cheapTaskTypes;
     if (Array.isArray(body.cheapTaskTypes)) {
-      const known = new Set(TASK_TYPES);
+      const observed = (await RequestRecord.distinct("taskType")).filter(Boolean).map((x) => String(x).toLowerCase());
+      const known = new Set([...TASK_TYPES, ...observed]);
       cheapTaskTypes = body.cheapTaskTypes.map((x) => String(x).toLowerCase()).filter((x) => known.has(x));
     }
     // Validate targets: each must be a known model that belongs to its provider key.

--- a/server/src/recommend/engine.js
+++ b/server/src/recommend/engine.js
@@ -8,11 +8,16 @@
 const RequestRecord = require("../models/RequestRecord");
 const Recommendation = require("../models/Recommendation");
 const pricing = require("../pricing/registry");
+const { getEffective } = require("../routing/policy");
 
 // Minimum requests in a group before we bother recommending.
 const MIN_REQUESTS = 20;
 
 async function recompute() {
+  // Use the effective routing policy so custom cheap task types (added by the user
+  // via Routing → Automated routing) are respected — not just the hardcoded defaults.
+  const policy = await getEffective();
+
   // Aggregate token totals per (taskType, model, provider).
   const groups = await RequestRecord.aggregate([
     { $match: { status: "success" } },
@@ -32,7 +37,7 @@ async function recompute() {
     const { taskType, model, provider } = g._id;
     if (g.requests < MIN_REQUESTS) continue;
     if (!pricing.isPremium(model)) continue;
-    if (!pricing.isCheapTask(taskType)) continue;
+    if (!policy.cheapTaskTypes.has(String(taskType || "").toLowerCase())) continue;
 
     const target = pricing.suggestLightTarget(model);
     if (!target) continue;


### PR DESCRIPTION
## Problem

The recommendation engine returned `[]` despite 7,305 requests and \$16.18 in spend, because it
only recognised 6 hardcoded task types as "cheap" (`classification`, `extraction`, `summarisation`,
`translation`, `faq`, `support response`). Apps using custom task types like `entity-extraction`,
`concept-extraction`, `concept-canonicalization`, and `relevance-check` — which represented **92%
of actual spend** — were silently ignored.

Two separate bugs:

1. **`engine.js`** called `pricing.isCheapTask()` (hardcoded set) instead of the user-configurable
   `policy.getEffective().cheapTaskTypes`. The Policy already had a configurable cheap task types
   list, the engine just wasn't using it.

2. **`GET /policy`** only returned built-in classifier task types in `taskTypes`, so custom
   app-provided task types never appeared as checkboxes in the Routing → Automated routing UI.
   **`PUT /policy`** silently filtered them out with `known.has(x)` on the same fixed set.

## Fix

- `engine.js`: Import `getEffective` from `routing/policy.js`; replace `pricing.isCheapTask()`
  with `policy.cheapTaskTypes.has(taskType)`.
- `routes.js` GET `/policy`: Merge `TASK_TYPES` with `RequestRecord.distinct("taskType")`
  so observed app-provided task types appear as checkboxes in the UI.
- `routes.js` PUT `/policy`: Validate against the merged set (catalog + observed) instead of
  catalog only — custom task types can now be saved to the policy.

## After merging + deploying

1. Routing → Automated routing → your custom task types now appear as checkboxes
2. Check `entity-extraction`, `concept-extraction`, `concept-canonicalization`, `relevance-check` → Save
3. Routing → Recommendations → Recompute → cards appear showing projected savings

🤖 Generated with [Claude Code](https://claude.com/claude-code)