### PR TITLE
feat(recommendations): self-diagnosing empty state (surface hidden savings)

### DIFF
--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -636,6 +636,12 @@ router.get("/recommendations", async (req, res, next) => {
   } catch (e) { next(e); }
 });
 
+// Explains the recommendation landscape (powers the self-diagnosing empty state): what was
+// analyzed, and the high-spend task types excluded only because they aren't marked cheap.
+router.get("/recommendations/analysis", async (_req, res, next) => {
+  try { res.json(await recommender.analyze()); } catch (e) { next(e); }
+});
+
 router.post("/recommendations/recompute", async (_req, res, next) => {
   try { res.json(await recommender.recompute()); } catch (e) { next(e); }
 });

--- a/server/src/recommend/engine.js
+++ b/server/src/recommend/engine.js
@@ -88,4 +88,65 @@ async function recompute() {
   return results.sort((a, b) => b.projectedSavings - a.projectedSavings);
 }
 
-module.exports = { recompute };
+// Explain the recommendation landscape so an empty Recompute is never a dead end. Pure.
+// groups: [{ taskType, model, provider, requests, promptTokens, completionTokens, currentCost }].
+// The key output is `unmarkedOpportunities`: (task type × premium model) groups with a real saving
+// that are EXCLUDED only because the task type isn't marked cheap — the money hiding in plain sight.
+function analyzeGroups(groups, cheapTaskTypes, { isPremium, suggestLightTarget, costFor, minRequests = MIN_REQUESTS }) {
+  const cheap = cheapTaskTypes instanceof Set
+    ? cheapTaskTypes
+    : new Set((cheapTaskTypes || []).map((x) => String(x).toLowerCase()));
+
+  let analyzedRequests = 0, analyzedCost = 0, flaggedGroups = 0;
+  const unmarked = [];
+  for (const g of groups) {
+    analyzedRequests += g.requests || 0;
+    analyzedCost += g.currentCost || 0;
+    if ((g.requests || 0) < minRequests) continue;
+    if (!isPremium(g.model)) continue;
+    const target = suggestLightTarget(g.model);
+    if (!target) continue;
+    const projected = costFor(target.model, g.promptTokens, g.completionTokens).totalCost;
+    const projectedSavings = (g.currentCost || 0) - projected;
+    if (projectedSavings <= 0) continue;
+
+    if (cheap.has(String(g.taskType || "").toLowerCase())) { flaggedGroups++; continue; } // already recommended
+    unmarked.push({
+      taskType: g.taskType, model: g.model, suggestedModel: target.model,
+      requests: g.requests, currentCost: g.currentCost || 0, projectedSavings,
+    });
+  }
+  unmarked.sort((a, b) => b.projectedSavings - a.projectedSavings);
+  return {
+    analyzedRequests, analyzedCost, flaggedGroups,
+    unmarkedOpportunities: unmarked,
+    unmarkedPotentialSavings: unmarked.reduce((s, u) => s + u.projectedSavings, 0),
+    suggestMarkCheap: [...new Set(unmarked.map((u) => String(u.taskType || "").toLowerCase()))],
+  };
+}
+
+// IO wrapper: aggregate the logged traffic + effective policy, then analyze. Returns the
+// analysis plus the current cheapTaskTypes (so the UI can offer a one-click "mark cheap").
+async function analyze() {
+  const policy = await getEffective();
+  const agg = await RequestRecord.aggregate([
+    { $match: { status: "success" } },
+    { $group: {
+        _id: { taskType: "$taskType", model: "$model", provider: "$provider" },
+        requests: { $sum: 1 },
+        promptTokens: { $sum: "$promptTokens" },
+        completionTokens: { $sum: "$completionTokens" },
+        currentCost: { $sum: "$totalCost" },
+    } },
+  ]);
+  const groups = agg.map((g) => ({
+    taskType: g._id.taskType, model: g._id.model, provider: g._id.provider,
+    requests: g.requests, promptTokens: g.promptTokens, completionTokens: g.completionTokens, currentCost: g.currentCost,
+  }));
+  const a = analyzeGroups(groups, policy.cheapTaskTypes, {
+    isPremium: pricing.isPremium, suggestLightTarget: pricing.suggestLightTarget, costFor: pricing.costFor,
+  });
+  return { ...a, cheapTaskTypes: [...policy.cheapTaskTypes] };
+}
+
+module.exports = { recompute, analyze, analyzeGroups };

--- a/server/test/unit/recommendAnalysis.test.js
+++ b/server/test/unit/recommendAnalysis.test.js
@@ -1,0 +1,37 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { analyzeGroups } = require("../../src/recommend/engine");
+
+const deps = {
+  isPremium: (m) => m === "premium",
+  suggestLightTarget: (m) => (m === "premium" ? { provider: "x", model: "light" } : null),
+  costFor: () => ({ totalCost: 1 }),
+  minRequests: 20,
+};
+
+test("analyzeGroups surfaces premium-on-unmarked-task as a hidden opportunity", () => {
+  const groups = [
+    { taskType: "entity-extraction", model: "premium", requests: 100, promptTokens: 1000, completionTokens: 100, currentCost: 9 },
+    { taskType: "classification", model: "premium", requests: 100, promptTokens: 500, completionTokens: 50, currentCost: 5 }, // cheap → already flagged
+    { taskType: "faq", model: "light", requests: 100, promptTokens: 100, completionTokens: 10, currentCost: 2 }, // not premium
+    { taskType: "entity-extraction", model: "premium", requests: 5, promptTokens: 10, completionTokens: 1, currentCost: 1 }, // below min
+  ];
+  const a = analyzeGroups(groups, new Set(["classification", "faq"]), deps);
+
+  assert.equal(a.unmarkedOpportunities.length, 1);
+  assert.equal(a.unmarkedOpportunities[0].taskType, "entity-extraction");
+  assert.equal(a.unmarkedOpportunities[0].projectedSavings, 8); // 9 - 1
+  assert.equal(a.flaggedGroups, 1); // classification (cheap + premium)
+  assert.deepEqual(a.suggestMarkCheap, ["entity-extraction"]);
+  assert.equal(a.analyzedRequests, 305);
+  assert.equal(a.analyzedCost, 17);
+  assert.equal(a.unmarkedPotentialSavings, 8);
+});
+
+test("analyzeGroups returns no opportunities when premium tasks are already marked cheap", () => {
+  const groups = [{ taskType: "extraction", model: "premium", requests: 100, promptTokens: 1, completionTokens: 1, currentCost: 9 }];
+  const a = analyzeGroups(groups, new Set(["extraction"]), deps);
+  assert.equal(a.unmarkedOpportunities.length, 0);
+  assert.equal(a.flaggedGroups, 1);
+});

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -65,6 +65,7 @@ export const api = {
   },
 
   recommendations: (status) => req(`/recommendations${qs({ status })}`),
+  recommendationsAnalysis: () => req("/recommendations/analysis"),
   recompute: () => req("/recommendations/recompute", { method: "POST" }),
   acceptRecommendation: (id, override) => req(`/recommendations/${id}/accept`, { method: "POST", body: JSON.stringify(override ? { override } : {}) }),
   dismissRecommendation: (id) => req(`/recommendations/${id}/dismiss`, { method: "POST" }),

--- a/web/src/pages/Recommendations.jsx
+++ b/web/src/pages/Recommendations.jsx
@@ -121,13 +121,86 @@ function RecCard({ rec, models, onChange }) {
   );
 }
 
+// Self-diagnosing empty state: instead of a dead end, explain what was analyzed and surface
+// high-spend task types that are excluded only because they aren't marked cheap — with a
+// one-click "mark cheap & recompute". Falls back gracefully if the analysis endpoint is absent.
+function EmptyState({ analysis, busy, onMarkCheap }) {
+  if (!analysis) {
+    return (
+      <Card>
+        <div className="py-8 text-center text-gray-400">
+          No recommendations yet. Click <span className="font-medium text-arbr-charcoal">Recompute</span> to analyse the logged data.
+        </div>
+      </Card>
+    );
+  }
+  const opps = analysis.unmarkedOpportunities || [];
+  const analyzed = `Analysed ${fmt.num(analysis.analyzedRequests)} requests (${fmt.usd(analysis.analyzedCost)}).`;
+
+  if (opps.length === 0) {
+    return (
+      <Card>
+        <div className="py-8 text-center text-gray-500">
+          <div className="text-arbr-charcoal font-medium">Nothing to optimise right now.</div>
+          <p className="mt-1 text-sm text-gray-400">{analyzed} No premium model is overused on a cheap task — cheap-task traffic is already on lighter models.</p>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <div className="space-y-4">
+        <div>
+          <h3 className="text-base font-semibold text-arbr-charcoal">
+            {fmt.usd(analysis.unmarkedPotentialSavings)} of potential savings is hidden
+          </h3>
+          <p className="mt-1 text-sm text-gray-600">
+            {analyzed} These high-spend task types run on a premium model but aren't marked <b>cheap</b>, so they're
+            excluded from recommendations. Mark them cheap to evaluate a cheaper model (nothing reroutes until an eval passes and you approve).
+          </p>
+        </div>
+        <div className="divide-y divide-gray-100 rounded-lg border border-gray-200">
+          {opps.slice(0, 8).map((o, i) => (
+            <div key={i} className="flex items-center justify-between gap-4 px-4 py-3">
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-medium text-arbr-charcoal">{o.taskType || "—"}</span>
+                  <Badge tone="charcoal">{o.model} → {o.suggestedModel}</Badge>
+                  <span className="text-xs text-gray-400">{fmt.num(o.requests)} req · {fmt.usd(o.currentCost)} spent</span>
+                </div>
+              </div>
+              <div className="flex items-center gap-3 shrink-0">
+                <span className="text-sm font-semibold text-arbr-green-600">~{fmt.usd(o.projectedSavings)}</span>
+                <button className="btn-outline text-xs" disabled={busy} onClick={() => onMarkCheap([o.taskType])}>
+                  Mark cheap
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+        <button className="btn-primary text-sm" disabled={busy}
+          onClick={() => onMarkCheap(analysis.suggestMarkCheap || opps.map((o) => o.taskType))}>
+          {busy ? "Working…" : `Mark all ${(analysis.suggestMarkCheap || []).length} cheap & recompute`}
+        </button>
+      </div>
+    </Card>
+  );
+}
+
 export default function Recommendations({ embedded = false }) {
   const [recs, setRecs] = useState(null);
   const [models, setModels] = useState([]);
+  const [analysis, setAnalysis] = useState(null);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState(null);
 
-  const load = () => api.recommendations().then(setRecs).catch((e) => setErr(e.message));
+  const load = async () => {
+    try {
+      const [r, a] = await Promise.all([api.recommendations(), api.recommendationsAnalysis().catch(() => null)]);
+      setRecs(r); setAnalysis(a);
+    } catch (e) { setErr(e.message); }
+  };
   useEffect(() => {
     load();
     api.models({ live: true }).then((m) => setModels(m || [])).catch(() => {});
@@ -137,6 +210,18 @@ export default function Recommendations({ embedded = false }) {
     setBusy(true); setErr(null);
     try { await api.recompute(); await load(); }
     catch (e) { setErr(e.message); }
+    finally { setBusy(false); }
+  };
+
+  // One-click: mark the given task types cheap (union with the current set), then recompute.
+  const markCheapAndRecompute = async (taskTypes) => {
+    setBusy(true); setErr(null);
+    try {
+      const merged = [...new Set([...(analysis?.cheapTaskTypes || []), ...taskTypes.map((t) => String(t).toLowerCase())])];
+      await api.setPolicy({ cheapTaskTypes: merged });
+      await api.recompute();
+      await load();
+    } catch (e) { setErr(e.message); }
     finally { setBusy(false); }
   };
 
@@ -154,11 +239,7 @@ export default function Recommendations({ embedded = false }) {
 
       {err && <div className="text-red-600">{err}</div>}
       {recs === null ? <Spinner /> : recs.length === 0 ? (
-        <Card>
-          <div className="py-8 text-center text-gray-400">
-            No recommendations yet. Click <span className="font-medium text-arbr-charcoal">Recompute</span> to analyse the logged data.
-          </div>
-        </Card>
+        <EmptyState analysis={analysis} busy={busy} onMarkCheap={markCheapAndRecompute} />
       ) : (
         <div className="space-y-4">
           {recs.map((r) => <RecCard key={r._id} rec={r} models={models} onChange={load} />)}


### PR DESCRIPTION
Fixes the discoverability dead end we hit on prod: Recompute returned empty and gave no hint that ~$14 of savings (a premium reasoning model serving `entity-extraction`) was excluded purely because those task types weren't marked **cheap**. The only way to find it was querying the DB by hand — that's the bug.

### What changed
- **`engine.analyze()` + pure `analyzeGroups()`** — explains the landscape: what was analyzed, and the (task type × premium model) groups with a real saving that are excluded *only* because the task type isn't in `cheapTaskTypes` ("unmarked opportunities"), ranked by saving.
- **`GET /api/recommendations/analysis`** — queryable, so this isn't only in the UI.
- **Self-diagnosing empty state** — instead of "No recommendations yet," it shows **"$X of potential savings is hidden"**, each opportunity (task type, `model → suggested`, spend, ~saving), with one-click **Mark cheap** (per item + bulk) that updates the policy and recomputes. When there genuinely is nothing, it reassures ("cheap-task traffic is already on lighter models") instead of implying failure.

### Verified live (screenshot taken)
On staged demo traffic it renders "**$4.57 of potential savings is hidden**" with classification (opus→haiku, ~$3.57) and extraction (gpt-4o→gpt-4o-mini, ~$1.01) and working Mark-cheap buttons. Lint 0 errors, unit **91/91**, web build passes.

### Note
On prod I had already marked `entity-extraction`/`concept-extraction`/`concept-canonicalization`/`relevance-check` cheap (during diagnosis), so those now show as real recommendations. This PR is what lets any user discover the *next* such opportunity without help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
