### PR TITLE
fix(eval): explain dataset-build failures instead of a bare 422

### DIFF
--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -699,7 +699,12 @@ router.post("/recommendations/:id/create-eval-dataset", async (req, res, next) =
       await rec.save();
     }
     setImmediate(() => logAction("eval.dataset.create", "evalDataset", String(dataset._id), { recommendationId: String(rec._id), itemCount: dataset.itemCount, status: dataset.status }));
-    res.status(dataset.status === "failed" ? 422 : 200).json(dataset);
+    if (dataset.status === "failed") {
+      // Surface the reason as `message` so the UI shows *why*, not a bare "422".
+      const body = dataset.toObject ? dataset.toObject() : dataset;
+      return res.status(422).json({ ...body, error: "no_replayable_traffic", message: dataset.error });
+    }
+    res.json(dataset);
   } catch (e) { next(e); }
 });
 

--- a/server/src/eval/dataset.js
+++ b/server/src/eval/dataset.js
@@ -150,9 +150,11 @@ async function createFromTraffic({ rec, targetCount, piiMode = "masked", windowD
       const withMsgs = raw.filter((r) => r.messages).length;
       const singleShot = raw.filter((r) => r.messages && isSingleShot(r.messages, false)).length;
       dataset.status = "failed";
-      dataset.error = raw.length
-        ? `no eligible records: ${raw.length} found, ${withResp} with responseText, ${withMsgs} with messages, ${singleShot} single-shot`
-        : "no eligible historical requests matched this scope";
+      dataset.error = !raw.length
+        ? "No requests match this recommendation's scope (task type + model) in the window."
+        : withMsgs === 0
+          ? `${raw.length} requests match, but none have a captured prompt to replay. Turn on payload capture (Settings → Observability); only traffic logged after it is enabled can be evaluated.`
+          : `No replayable requests: of ${raw.length} matched, ${withResp} have a response and ${withMsgs} a prompt, ${singleShot} single-shot (multi-turn / tool calls are skipped).`;
       await dataset.save();
       return dataset;
     }

--- a/web/src/pages/Recommendations.jsx
+++ b/web/src/pages/Recommendations.jsx
@@ -82,7 +82,7 @@ function RecCard({ rec, models, onChange }) {
             {(evalStatus === "not_started") && (
               <button className="btn-secondary text-sm" disabled={busy}
                 onClick={() => run(() => api.createEvalDataset(rec._id), (d) => `Dataset built: ${d.itemCount} items (${d.riskTier} risk).`)}>
-                1 · Build eval dataset
+                Build eval dataset
               </button>
             )}
             {(evalStatus === "dataset_ready" || evalStatus === "failed") && (
@@ -93,7 +93,7 @@ function RecCard({ rec, models, onChange }) {
                 </select>
                 <button className="btn-secondary text-sm" disabled={busy}
                   onClick={() => run(() => api.runEval(rec._id, { judgeModel: judge || null }), () => "Offline eval started — refresh in a moment.")}>
-                  2 · Run offline eval
+                  Run offline eval
                 </button>
               </>
             )}
@@ -103,7 +103,7 @@ function RecCard({ rec, models, onChange }) {
                 <input className="input text-sm" placeholder="application for rollout" value={application} onChange={(e) => setApplication(e.target.value)} />
                 <button className="btn-secondary text-sm" disabled={busy || !application.trim()}
                   onClick={() => run(() => api.createCanary(rec._id, { application: application.trim() }), (x) => `Canary started at ${x.rolloutPct}%.`)}>
-                  3 · Start canary
+                  Start canary
                 </button>
               </>
             )}


### PR DESCRIPTION
Clicking **Build eval dataset** on a recommendation whose traffic has no captured prompts returned a bare red **"422"** with no reason.

**Root cause (found on prod):** all current recommendations point at historical DeepSeek-R1 traffic that was logged *before* payload capture was enabled, so there is nothing to replay. Not a bug — but the UI gave zero indication why.

### Changes
- **`dataset.js`** — actionable failure message, three cases: no requests match the scope / N match but none have a captured prompt (*turn on payload capture; only traffic logged after it is enabled can be evaluated*) / matched but multi-turn or tool-only.
- **`routes.js`** create-eval-dataset — on failure return the reason as `message` (+ `error: no_replayable_traffic`) so the dashboard shows *why*, not just the status code.
- **`Recommendations.jsx`** — drop the `1 · / 2 · / 3 ·` step numbering from the buttons.

### Follow-up (noted, not in this PR)
Surface an eval-readiness count on the card up front — e.g. "1,900 requests · 0 replayable" — so users know an eval is possible before clicking.

Lint 0 errors, unit 89/89, web build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)