### PR TITLE
feat(recommendations): show eval-readiness (replayable count)

### DIFF
--- a/server/src/models/Recommendation.js
+++ b/server/src/models/Recommendation.js
@@ -22,6 +22,9 @@ const recommendationSchema = new mongoose.Schema(
 
     // Evidence + projection (USD over the analysed window).
     requestCount: { type: Number, default: 0 },
+    // How many of those requests an eval could actually replay (captured prompt+response,
+    // non-cache). 0 = the recommendation predates payload capture; the eval can't run on it.
+    replayableCount: { type: Number, default: null },
     currentCost: { type: Number, default: 0 },
     projectedCost: { type: Number, default: 0 },
     projectedSavings: { type: Number, default: 0 },

--- a/server/src/recommend/engine.js
+++ b/server/src/recommend/engine.js
@@ -28,6 +28,13 @@ async function recompute() {
         promptTokens: { $sum: "$promptTokens" },
         completionTokens: { $sum: "$completionTokens" },
         currentCost: { $sum: "$totalCost" },
+        // Requests an eval could actually replay: captured prompt + response, not a cache hit.
+        // (Single-shot is refined at dataset build; this is the readiness estimate.)
+        replayable: { $sum: { $cond: [{ $and: [
+          { $ne: ["$messages", null] },
+          { $gt: [{ $strLenCP: { $ifNull: ["$responseText", ""] } }, 0] },
+          { $ne: ["$cacheHit", true] },
+        ] }, 1, 0] } },
       },
     },
   ]);
@@ -65,6 +72,7 @@ async function recompute() {
       suggestedModel: target.model,
       suggestedProvider: target.provider,
       requestCount: g.requests,
+      replayableCount: g.replayable || 0,
       currentCost: g.currentCost,
       projectedCost: projected.totalCost,
       projectedSavings,

--- a/web/src/pages/Recommendations.jsx
+++ b/web/src/pages/Recommendations.jsx
@@ -65,6 +65,9 @@ function RecCard({ rec, models, onChange }) {
           <div className="mt-3 flex flex-wrap gap-2 text-xs">
             <Badge tone="charcoal">{rec.currentModel} → {rec.suggestedModel}</Badge>
             <Badge tone="gray">{fmt.num(rec.requestCount)} requests</Badge>
+            {rec.replayableCount != null && (
+              <Badge tone={rec.replayableCount === 0 ? "red" : "gray"}>{fmt.num(rec.replayableCount)} replayable</Badge>
+            )}
           </div>
           <QualitySummary s={rec.qualitySummary} />
         </div>
@@ -80,10 +83,17 @@ function RecCard({ rec, models, onChange }) {
           {/* Eval-backed flow: prove quality, then roll out under control. */}
           <div className="flex flex-wrap items-center gap-2">
             {(evalStatus === "not_started") && (
-              <button className="btn-secondary text-sm" disabled={busy}
-                onClick={() => run(() => api.createEvalDataset(rec._id), (d) => `Dataset built: ${d.itemCount} items (${d.riskTier} risk).`)}>
-                Build eval dataset
-              </button>
+              rec.replayableCount === 0 ? (
+                <span className="text-sm text-gray-500">
+                  No replayable traffic yet — this recommendation's requests have no captured prompts.
+                  Turn on payload capture (Settings → Observability); only traffic logged after it is enabled can be evaluated.
+                </span>
+              ) : (
+                <button className="btn-secondary text-sm" disabled={busy}
+                  onClick={() => run(() => api.createEvalDataset(rec._id), (d) => `Dataset built: ${d.itemCount} items (${d.riskTier} risk).`)}>
+                  Build eval dataset
+                </button>
+              )
             )}
             {(evalStatus === "dataset_ready" || evalStatus === "failed") && (
               <>


### PR DESCRIPTION
A recommendation is scored on **cost** (available for all traffic) but an eval needs **captured prompts** (only post-capture traffic). When those diverge, every recommendation built on pre-capture history dead-ends at a dataset-build 422 — which is exactly what's happening on prod (all recs are on Jun R1 traffic logged before capture was on).

Now the recommendation states its eval-readiness up front:
- **engine.recompute** aggregates a `replayable` count per group (captured prompt+response, non-cache) → `Recommendation.replayableCount`.
- **UI**: a `N replayable` badge (red at 0); when 0, the Build-eval-dataset button is replaced by an inline explanation (turn on payload capture; only post-capture traffic is evaluable) instead of letting the click fail with a 422.

Note: this does not change the savings math — cost is real regardless of capture. It only surfaces whether an eval is possible.

Lint 0 errors, unit 91/91, web build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)