### PR TITLE
feat(recommendations): make recommendations application-aware

### DIFF
--- a/server/src/recommend/engine.js
+++ b/server/src/recommend/engine.js
@@ -13,17 +13,86 @@ const { getEffective } = require("../routing/policy");
 // Minimum requests in a group before we bother recommending.
 const MIN_REQUESTS = 20;
 
+// Build one recommendation doc. Pure. `grp` carries requests/tokens/cost/replayable for the scope.
+function buildDoc({ application, taskType, model, provider, grp, target, projected, saving }) {
+  const cost = grp.currentCost || 0;
+  const pct = cost > 0 ? Math.round((saving / cost) * 100) : 0;
+  const scope = application ? ` in '${application}'` : "";
+  return {
+    type: "premium_model_overuse",
+    title: `${pct}% of '${taskType}' spend${scope} is on a premium model (${model})`,
+    reason:
+      `${grp.requests} '${taskType}' requests${scope} ran on ${model} (premium tier). ` +
+      `'${taskType}' is a low-complexity task type; re-pricing the same ` +
+      `${((grp.promptTokens || 0) + (grp.completionTokens || 0)).toLocaleString()} tokens on ${target.model} ` +
+      `would cost $${projected.toFixed(2)} instead of $${cost.toFixed(2)} — ` +
+      `an estimated saving of $${saving.toFixed(2)}. ` +
+      `Flagged by comparing task type and model tier against the price table, not answer quality.`,
+    application: application || null,
+    taskType, currentModel: model, currentProvider: provider,
+    suggestedModel: target.model, suggestedProvider: target.provider,
+    requestCount: grp.requests, replayableCount: grp.replayable || 0,
+    currentCost: cost, projectedCost: projected, projectedSavings: saving,
+    dedupeKey: application ? `premium_overuse:${application}:${taskType}:${model}` : `premium_overuse:${taskType}:${model}`,
+  };
+}
+
+// Plan recommendations from per-(application, taskType, model, provider) groups. Pure.
+// For each (taskType, model): emit an APP-SCOPED rec for every app that individually clears
+// MIN_REQUESTS (so a downgrade proven for one app doesn't silently apply to others). Only when
+// NO single app qualifies but the combined volume does, fall back to ONE global rec — so the two
+// never overlap (a global rule would otherwise also match the app-scoped ones).
+function planRecommendations(groups, cheapTaskTypes, { isPremium, suggestLightTarget, costFor, minRequests = MIN_REQUESTS }) {
+  const cheap = cheapTaskTypes instanceof Set
+    ? cheapTaskTypes : new Set((cheapTaskTypes || []).map((x) => String(x).toLowerCase()));
+
+  const byTM = new Map(); // taskType|model|provider -> { taskType, model, provider, apps:[], total }
+  for (const g of groups) {
+    const key = `${g.taskType}|${g.model}|${g.provider}`;
+    if (!byTM.has(key)) byTM.set(key, { taskType: g.taskType, model: g.model, provider: g.provider, apps: [],
+      total: { requests: 0, promptTokens: 0, completionTokens: 0, currentCost: 0, replayable: 0 } });
+    const e = byTM.get(key);
+    e.apps.push(g);
+    for (const f of ["requests", "promptTokens", "completionTokens", "currentCost", "replayable"]) e.total[f] += g[f] || 0;
+  }
+
+  const out = [];
+  for (const e of byTM.values()) {
+    if (!isPremium(e.model)) continue;
+    if (!cheap.has(String(e.taskType || "").toLowerCase())) continue;
+    const target = suggestLightTarget(e.model);
+    if (!target) continue;
+    const mk = (application, grp) => {
+      const projected = costFor(target.model, grp.promptTokens, grp.completionTokens).totalCost;
+      const saving = (grp.currentCost || 0) - projected;
+      return saving > 0 ? buildDoc({ application, taskType: e.taskType, model: e.model, provider: e.provider, grp, target, projected, saving }) : null;
+    };
+    let emittedAppScoped = false;
+    for (const g of e.apps) {
+      if (!g.application || g.application === "unknown" || (g.requests || 0) < minRequests) continue;
+      const d = mk(g.application, g);
+      if (d) { out.push(d); emittedAppScoped = true; }
+    }
+    if (!emittedAppScoped && e.total.requests >= minRequests) {
+      const d = mk(null, e.total);
+      if (d) out.push(d);
+    }
+  }
+  return out.sort((a, b) => b.projectedSavings - a.projectedSavings);
+}
+
 async function recompute() {
   // Use the effective routing policy so custom cheap task types (added by the user
   // via Routing → Automated routing) are respected — not just the hardcoded defaults.
   const policy = await getEffective();
 
-  // Aggregate token totals per (taskType, model, provider).
-  const groups = await RequestRecord.aggregate([
+  // Aggregate token totals per (application, taskType, model, provider) so recommendations can
+  // be scoped to the app whose traffic justifies them (routing is already app-aware).
+  const agg = await RequestRecord.aggregate([
     { $match: { status: "success" } },
     {
       $group: {
-        _id: { taskType: "$taskType", model: "$model", provider: "$provider" },
+        _id: { application: "$application", taskType: "$taskType", model: "$model", provider: "$provider" },
         requests: { $sum: 1 },
         promptTokens: { $sum: "$promptTokens" },
         completionTokens: { $sum: "$completionTokens" },
@@ -39,59 +108,32 @@ async function recompute() {
     },
   ]);
 
+  const groups = agg.map((g) => ({
+    application: g._id.application, taskType: g._id.taskType, model: g._id.model, provider: g._id.provider,
+    requests: g.requests, promptTokens: g.promptTokens, completionTokens: g.completionTokens,
+    currentCost: g.currentCost, replayable: g.replayable,
+  }));
+  const planned = planRecommendations(groups, policy.cheapTaskTypes, {
+    isPremium: pricing.isPremium, suggestLightTarget: pricing.suggestLightTarget, costFor: pricing.costFor,
+  });
+
   const results = [];
-  for (const g of groups) {
-    const { taskType, model, provider } = g._id;
-    if (g.requests < MIN_REQUESTS) continue;
-    if (!pricing.isPremium(model)) continue;
-    if (!policy.cheapTaskTypes.has(String(taskType || "").toLowerCase())) continue;
-
-    const target = pricing.suggestLightTarget(model);
-    if (!target) continue;
-
-    // Re-price the same tokens at the target model.
-    const projected = pricing.costFor(target.model, g.promptTokens, g.completionTokens);
-    const projectedSavings = g.currentCost - projected.totalCost;
-    if (projectedSavings <= 0) continue;
-
-    const dedupeKey = `premium_overuse:${taskType}:${model}`;
-    const pct = Math.round((projectedSavings / g.currentCost) * 100);
-    const doc = {
-      type: "premium_model_overuse",
-      title: `${pct}% of '${taskType}' spend is on a premium model (${model})`,
-      reason:
-        `${g.requests} '${taskType}' requests ran on ${model} (premium tier). ` +
-        `'${taskType}' is a low-complexity task type; re-pricing the same ` +
-        `${(g.promptTokens + g.completionTokens).toLocaleString()} tokens on ${target.model} ` +
-        `would cost $${projected.totalCost.toFixed(2)} instead of $${g.currentCost.toFixed(2)} — ` +
-        `an estimated saving of $${projectedSavings.toFixed(2)}. ` +
-        `Flagged by comparing task type and model tier against the price table, not answer quality.`,
-      taskType,
-      currentModel: model,
-      currentProvider: provider,
-      suggestedModel: target.model,
-      suggestedProvider: target.provider,
-      requestCount: g.requests,
-      replayableCount: g.replayable || 0,
-      currentCost: g.currentCost,
-      projectedCost: projected.totalCost,
-      projectedSavings,
-      dedupeKey,
-    };
-
+  const emittedKeys = [];
+  for (const doc of planned) {
+    emittedKeys.push(doc.dedupeKey);
     // Upsert by dedupeKey, but never clobber a human decision (accepted/dismissed).
-    const existing = await Recommendation.findOne({ dedupeKey });
-    if (existing && existing.status !== "pending") {
-      results.push(existing);
-      continue;
-    }
+    const existing = await Recommendation.findOne({ dedupeKey: doc.dedupeKey });
+    if (existing && existing.status !== "pending") { results.push(existing); continue; }
     const saved = await Recommendation.findOneAndUpdate(
-      { dedupeKey },
+      { dedupeKey: doc.dedupeKey },
       { $set: { ...doc, status: "pending" } },
       { upsert: true, new: true, setDefaultsOnInsert: true }
     );
     results.push(saved);
   }
+  // Drop stale PENDING recs that current traffic no longer supports (keeps accepted/dismissed).
+  // Also clears old global recs superseded by app-scoped ones after this change.
+  await Recommendation.deleteMany({ status: "pending", dedupeKey: { $nin: emittedKeys } });
 
   return results.sort((a, b) => b.projectedSavings - a.projectedSavings);
 }
@@ -157,4 +199,4 @@ async function analyze() {
   return { ...a, cheapTaskTypes: [...policy.cheapTaskTypes] };
 }
 
-module.exports = { recompute, analyze, analyzeGroups };
+module.exports = { recompute, analyze, analyzeGroups, planRecommendations };

--- a/server/test/unit/recommendPlan.test.js
+++ b/server/test/unit/recommendPlan.test.js
@@ -1,0 +1,48 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { planRecommendations } = require("../../src/recommend/engine");
+
+const deps = {
+  isPremium: (m) => m === "premium",
+  suggestLightTarget: (m) => (m === "premium" ? { provider: "x", model: "light" } : null),
+  costFor: () => ({ totalCost: 1 }),
+  minRequests: 20,
+};
+const g = (o) => ({ application: null, taskType: "classification", model: "premium", provider: "openai",
+  requests: 0, promptTokens: 10, completionTokens: 10, currentCost: 10, replayable: 0, ...o });
+
+test("emits an app-scoped rec per app that clears the volume threshold", () => {
+  const out = planRecommendations([
+    g({ application: "app-a", requests: 100, currentCost: 10 }),
+    g({ application: "app-b", requests: 50, currentCost: 6 }),
+  ], new Set(["classification"]), deps);
+  assert.equal(out.length, 2);
+  assert.deepEqual(new Set(out.map((r) => r.application)), new Set(["app-a", "app-b"]));
+  assert.ok(out.every((r) => r.dedupeKey.startsWith("premium_overuse:app-")));
+});
+
+test("falls back to ONE global rec only when no single app qualifies", () => {
+  const out = planRecommendations([
+    g({ application: "app-a", requests: 12, currentCost: 4 }),
+    g({ application: "app-b", requests: 15, currentCost: 5 }), // both < 20, combined 27 >= 20
+  ], new Set(["classification"]), deps);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].application, null);
+  assert.equal(out[0].requestCount, 27);
+  assert.equal(out[0].dedupeKey, "premium_overuse:classification:premium");
+});
+
+test("no overlap: when an app qualifies, thin apps do not also produce a global rec", () => {
+  const out = planRecommendations([
+    g({ application: "app-a", requests: 100, currentCost: 10 }), // qualifies -> app-scoped
+    g({ application: "app-b", requests: 5, currentCost: 1 }),    // thin -> dropped, NOT global
+  ], new Set(["classification"]), deps);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].application, "app-a");
+});
+
+test("skips non-premium models and non-cheap task types", () => {
+  assert.equal(planRecommendations([g({ application: "a", requests: 100, model: "light" })], new Set(["classification"]), deps).length, 0);
+  assert.equal(planRecommendations([g({ application: "a", requests: 100, taskType: "reasoning" })], new Set(["classification"]), deps).length, 0);
+});

--- a/web/src/pages/Recommendations.jsx
+++ b/web/src/pages/Recommendations.jsx
@@ -63,6 +63,7 @@ function RecCard({ rec, models, onChange }) {
           </div>
           <p className="mt-2 text-sm text-gray-600">{rec.reason}</p>
           <div className="mt-3 flex flex-wrap gap-2 text-xs">
+            {rec.application && <Badge tone="charcoal">app: {rec.application}</Badge>}
             <Badge tone="charcoal">{rec.currentModel} → {rec.suggestedModel}</Badge>
             <Badge tone="gray">{fmt.num(rec.requestCount)} requests</Badge>
             {rec.replayableCount != null && (


### PR DESCRIPTION
Closes the asymmetry you spotted: **routing is app-aware** (per-app AI policy overrides + app-scoped rules), but **recommendations were global** (grouped by `taskType, model` across all apps) — so a downgrade proven for one app would silently apply org-wide, and Accept defaulted to a global rule.

### What changed
- `recompute` aggregates by **(application, taskType, model, provider)**.
- New pure **`planRecommendations()`**: for each (taskType, model), emit an **app-scoped** rec for every app that individually clears `MIN_REQUESTS`; only when *no single app* qualifies but combined volume does, fall back to **one global** rec — so app-scoped and global never overlap.
- App-scoped recs carry `application`, so the **accept flow scopes the rule** and the **dataset builder scopes the eval** to that app's traffic automatically (uses the #88 groundwork). Recommendation, eval, and rule now line up with what routing can actually do.
- Stale pending recs are pruned each recompute (also clears old global recs superseded by app-scoped ones). Accepted/dismissed preserved.
- UI: `app: X` badge on app-scoped recommendations.

### Tradeoff (as discussed)
App-scoped recs are more precise but there are more of them, and each `(app × task × model)` group is smaller — sub-20-request slices don't surface. The global fallback covers the thin-spread case.

No architecture change (single-tenant, self-host). Lint 0 errors, unit **95/95** (4 new for app-scoped / global-fallback / no-overlap), web build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)