### PR TITLE
fix(web): routing dropdowns show only connected providers/models

### DIFF
--- a/web/src/pages/Routing.jsx
+++ b/web/src/pages/Routing.jsx
@@ -457,14 +457,18 @@ export default function Routing({ onChange }) {
   const [tab, setTab] = useTabParam(TABS);
   const [rules, setRules] = useState(null);
   const [models, setModels] = useState([]);
+  const [loadingModels, setLoadingModels] = useState(true);
   const [mode, setMode] = useState("off");
   const [cacheMsg, setCacheMsg] = useState(null);
   const [err, setErr] = useState(null);
 
   const load = () =>
-    Promise.all([api.rules(), api.routingMode(), api.models()])
+    // Only connected providers' models — a rule/policy targeting an unconnected provider would
+    // never route. (The Models page manages the full registry; routing targets the live ones.)
+    Promise.all([api.rules(), api.routingMode(), api.models({ live: true })])
       .then(([r, rm, m]) => { setRules(r); setMode(rm.routingMode); setModels(m); })
-      .catch((e) => setErr(e.message));
+      .catch((e) => setErr(e.message))
+      .finally(() => setLoadingModels(false));
   useEffect(() => { load(); }, []);
 
   const toggleRule = async (id, enabled) => { await api.updateRule(id, { enabled }); await load(); };
@@ -492,7 +496,11 @@ export default function Routing({ onChange }) {
               Map a condition to a target model. The gateway applies it deterministically — no quality guess.
               Rules always override automated routing.
             </p>
-            {models.length === 0 ? <Spinner /> : <CreateRuleForm models={models} onCreated={load} />}
+            {loadingModels ? <Spinner /> : models.length === 0 ? (
+              <div className="py-4 text-sm text-gray-500">
+                No connected providers yet. Connect one under <span className="font-medium text-arbr-charcoal">Models</span> to create routing rules.
+              </div>
+            ) : <CreateRuleForm models={models} onCreated={load} />}
           </Card>
 
           <Card title="Rules">


### PR DESCRIPTION
The Routing page loaded the **full model registry** (`api.models()`), so the *Create a rule* provider dropdown listed **unconnected** providers (anthropic, deepseek, moonshot…) and the model dropdown showed seeded built-ins for a provider that isn't connected. A rule targeting an unconnected provider would never route.

- Load `api.models({ live: true })` so the rule form + AI-policy assignment dropdowns only offer **connected** providers and their registered models.
- Handle no-connected-providers (e.g. demo mode) gracefully: show a "connect a provider under Models" hint instead of a perpetual spinner.

The Models page still manages the full registry (unchanged); routing just targets the live ones.

Web build passes. (Related minor follow-up: the guardrail policy's "downgrade target per provider" list still shows all providers with a default target, not just live ones.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)