### PR TITLE
Orient console + docs around the 5 stages (Connect/See/Recommend/Route/Govern)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ automated policy a human enabled (cost guardrail or AI-generated task→model ma
 is reversible from the dashboard within seconds — and enforced budgets can block or downgrade
 spend that breaches its cap.
 
+**The five stages a request takes through Arbr** — the vocabulary the console and these docs are organised around:
+
+- **Connect** — one drop-in, OpenAI-compatible gateway; providers connected once, their keys held encrypted server-side.
+- **See** — every call logged and costed; spend legible by application, team, model, and task type.
+- **Recommend** — costed suggestions where a premium model is handling a cheap task, measured from your own traffic.
+- **Route** — a pinned model is honored; `auto` follows human-approved rules and policies, and a cheaper model can be proven no worse before it routes.
+- **Govern** — budgets, guardrails, PII masking, and an audit log keep spend and data under control.
+
 ![Arbr Control Plane — cost and usage overview](docs/media/dashboard.png)
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,23 +13,21 @@ hero:
       text: View on GitHub
       link: https://github.com/project-arbr/arbr-control-plane
 
+# The five stages a request takes through Arbr: Connect → See → Recommend → Route → Govern.
 features:
-  - icon: 🔍
-    title: Full visibility
-    details: Every LLM call logged with model, cost, latency, and routing decision. Spend legible by application, team, workflow, model, and task type — in a live dashboard.
-  - icon: 🎯
-    title: Human-approved routing
-    details: Developers pin the model they want; it's honored as-is. When they say "auto", the gateway applies human-approved rules and automated policies — all reversible in seconds.
-  - icon: 💰
-    title: Cost governance
-    details: Costed recommendations surface premium-model overuse on cheap tasks. Budgets block or downgrade spend that breaches its cap, enforced per application, team, or provider.
-  - icon: 🔗
-    title: Drop-in compatible
-    details: OpenAI-compatible endpoint (POST /v1/chat/completions) — any client that speaks the OpenAI spec works without modification. Real SSE streaming included.
-  - icon: 🛡️
-    title: Keys stay server-side
-    details: Your app never holds provider keys. The gateway holds them encrypted; attribution, rate limits, and governance all bind to your gateway API keys.
   - icon: 🔌
-    title: 8 providers, zero lock-in
-    details: Anthropic, OpenAI, Google Gemini, Amazon Bedrock, DeepSeek, Moonshot AI, xAI (Grok), and Groq. Or point the OpenAI provider at any LiteLLM proxy for hundreds more.
+    title: Connect
+    details: One drop-in, OpenAI-compatible gateway (POST /v1/chat/completions) every app calls without code changes — real SSE streaming included. Connect Anthropic, OpenAI, Gemini, Bedrock, DeepSeek, Moonshot, xAI (Grok) and Groq, or any LiteLLM proxy for hundreds more. Provider keys stay encrypted server-side, never in your app.
+  - icon: 🔍
+    title: See
+    details: Every call logged with model, cost, latency, and routing decision. Spend legible by application, team, workflow, model, and task type — in a live dashboard.
+  - icon: 💡
+    title: Recommend
+    details: Costed recommendations surface premium-model overuse on cheap tasks, with the dollar saving — measured from your own traffic, advisory until a human accepts.
+  - icon: 🎯
+    title: Route
+    details: Developers pin the model they want; it's honored as-is. On "auto", the gateway applies human-approved rules and policies — and you can prove a cheaper model is no worse before it routes. All reversible in seconds.
+  - icon: 🛡️
+    title: Govern
+    details: Budgets block or downgrade spend that breaches its cap, per application, team, or provider. Guardrails, PII masking, and an audit log keep it safe and accountable.
 ---

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -5,6 +5,7 @@ import { api, clearAdminToken } from "./api.js";
 import Login from "./pages/Login.jsx";
 import Overview from "./pages/Overview.jsx";
 import Routing from "./pages/Routing.jsx";
+import Recommendations from "./pages/Recommendations.jsx";
 import Requests from "./pages/Requests.jsx";
 import Settings from "./pages/Settings.jsx";
 import Docs from "./pages/Docs.jsx";
@@ -40,6 +41,7 @@ export default function App() {
         <Route path="/applications/:name" element={<ApplicationDetail />} />
         <Route path="/requests" element={<Requests />} />
         <Route path="/routing" element={<Routing onChange={refreshStatus} />} />
+        <Route path="/recommendations" element={<Recommendations />} />
         <Route path="/budgets" element={<Budgets onChange={refreshStatus} />} />
         <Route path="/models" element={<Models />} />
         <Route path="/evals" element={<ModelEvals />} />
@@ -48,9 +50,8 @@ export default function App() {
         <Route path="/audit" element={<Audit />} />
         <Route path="/docs" element={<Docs />} />
 
-        {/* Redirects for old / deep links — pages now live as sub-tabs. */}
+        {/* Redirects for old / deep links. */}
         <Route path="/rules" element={<Navigate to="/routing" replace />} />
-        <Route path="/recommendations" element={<Navigate to="/routing?tab=recommendations" replace />} />
         <Route path="/views" element={<Navigate to="/?tab=dimensions" replace />} />
       </Routes>
     </Layout>

--- a/web/src/components/Layout.jsx
+++ b/web/src/components/Layout.jsx
@@ -72,22 +72,35 @@ const icons = {
       <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/>
     </Icon>
   ),
+  recommend: (
+    <Icon>
+      <path d="M9 18h6M10 21h4"/>
+      <path d="M12 3a6 6 0 0 0-4 10.5c.6.6 1 1.4 1 2.5h6c0-1.1.4-1.9 1-2.5A6 6 0 0 0 12 3z"/>
+    </Icon>
+  ),
 };
 
 // ── Navigation definition ─────────────────────────────────────────────────────
+// Grouped by the path a request takes through Arbr: Connect → See → Recommend → Route → Govern.
+// The `hint` is a one-line, plain-language descriptor of what each stage is for.
 const NAV_GROUPS = [
-  { section: "Monitor", items: [
+  { section: "Connect", hint: "Wire apps & providers to the gateway", items: [
+    { to: "/models",   label: "Models",   icon: icons.models },
+    { to: "/settings", label: "Settings", icon: icons.settings },
+  ] },
+  { section: "See", hint: "Know what you're spending, and where", items: [
     { to: "/", label: "Overview", end: true, icon: icons.overview },
     { to: "/applications", label: "Applications", icon: icons.applications },
   ] },
-  { section: "Control", items: [
-    { to: "/routing",  label: "Routing",      icon: icons.routing },
-    { to: "/budgets",  label: "Budgets",       icon: icons.budgets },
-    { to: "/models",   label: "Models",        icon: icons.models },
-    { to: "/evals",    label: "Model Evals",   icon: icons.evals },
-    { to: "/settings", label: "Settings",      icon: icons.settings },
+  { section: "Recommend", hint: "Where a cheaper model fits", items: [
+    { to: "/recommendations", label: "Recommendations", icon: icons.recommend },
   ] },
-  { section: "Governance", items: [
+  { section: "Route", hint: "Send traffic to the right model", items: [
+    { to: "/routing", label: "Routing",     icon: icons.routing },
+    { to: "/evals",   label: "Model Evals", icon: icons.evals },
+  ] },
+  { section: "Govern", hint: "Limits, guardrails, and records", items: [
+    { to: "/budgets",    label: "Budgets",    icon: icons.budgets },
     { to: "/governance", label: "Governance", icon: icons.governance },
     { to: "/audit",      label: "Audit",      icon: icons.audit },
   ] },
@@ -123,8 +136,13 @@ export default function Layout({ status, onSignOut, children }) {
         <nav className="min-h-0 flex-1 overflow-y-auto px-2 py-1">
           {NAV_GROUPS.map((group, gi) => (
             <div key={group.section} className={gi > 0 ? "mt-5" : ""}>
-              <div className="mb-1 px-3 text-[10px] font-semibold uppercase tracking-widest text-gray-400">
-                {group.section}
+              <div className="mb-1 px-3">
+                <div className="text-[10px] font-semibold uppercase tracking-widest text-gray-400">
+                  {group.section}
+                </div>
+                {group.hint && (
+                  <div className="mt-0.5 text-[10px] leading-tight text-gray-300">{group.hint}</div>
+                )}
               </div>
               {group.items.map((item) => (
                 <NavLink key={item.to} to={item.to} end={item.end} className={navClass}>

--- a/web/src/pages/Docs.jsx
+++ b/web/src/pages/Docs.jsx
@@ -2,21 +2,27 @@ import React, { useEffect, useState } from "react";
 import { api } from "../api.js";
 import { Card, Badge, CodeBlock } from "../components/ui.jsx";
 
-// One row per left-nav menu — keep in sync with Layout.jsx NAV_GROUPS so the docs track the product.
+// Grouped by the path a request takes through Arbr — keep in sync with Layout.jsx NAV_GROUPS.
+// [stage, one-line purpose, [[screen, what it does], …]]
 const SCREENS = [
-  ["Monitor", [
+  ["Connect", "Wire your apps and providers to one gateway.", [
+    ["Models", "Connect providers (paste a key), or add any OpenAI-compatible provider (e.g. NVIDIA) and Discover + import its models. Prices/benchmarks sync from the catalog."],
+    ["Settings", "Gateway API keys (per application), default provider/model, and Require-API-keys."],
+  ]],
+  ["See", "Know what you're spending, and where.", [
     ["Overview", "Usage, spend, tokens, success rate and latency (incl. p50/p95), with a cost trend chart. Filter by period."],
     ["Applications", "Per-application view of the same metrics; click a request for the full drilldown (prompt, response, routing)."],
   ]],
-  ["Control", [
-    ["Routing", "Routing mode (off / cost guardrail / AI), human-approved rules, and the AI policy (task→model). Every request records why it was routed the way it was."],
-    ["Budgets", "Spend caps per application/provider/etc. with warning thresholds; a breached cap can alert, downgrade, or block."],
-    ["Models", "Connect providers (paste a key), or add any OpenAI-compatible provider (e.g. NVIDIA) and Discover + import its models. Prices/benchmarks sync from the catalog."],
-    ["Model Evals", "Shadow-evaluate a candidate model on your own live traffic (mirrored, not served), judged vs current, with a safe-to-switch verdict."],
-    ["Settings", "Gateway API keys (per application), default provider/model, Require-API-keys, and governance (webhook, retention, PII masking, max-tokens guardrail)."],
+  ["Recommend", "Surface where a cheaper model fits — measured from your own traffic.", [
+    ["Recommendations", "Costed suggestions where a premium model is handling a cheap task. Advisory until you accept; each can be proven with an eval before it ever routes."],
   ]],
-  ["Governance", [
-    ["Governance", "Kill switch / maintenance mode, PII masking, retention, and the alert webhook."],
+  ["Route", "Send traffic to the right model — on human approval, always reversible.", [
+    ["Routing", "Routing mode (off / cost guardrail / AI), human-approved rules, and the AI policy (task→model). Every request records why it was routed the way it was."],
+    ["Model Evals", "Prove a candidate before you switch: replay past traffic offline, shadow-evaluate on live traffic (mirrored, not served), then canary with auto-rollback."],
+  ]],
+  ["Govern", "Set the limits, protect data, and keep a record.", [
+    ["Budgets", "Spend caps per application/provider with warning thresholds; a breached cap can alert, downgrade, or block."],
+    ["Governance", "Kill switch / maintenance mode, PII masking, max-tokens guardrail, retention, and the alert webhook."],
     ["Audit", "A log of console actions (keys, rules, caps, connections) for accountability."],
   ]],
 ];
@@ -57,7 +63,8 @@ res = arbr.chat("Summarise this ticket: ...", model="auto", max_tokens=300)   # 
       <div>
         <h1 className="text-2xl font-bold text-arbr-charcoal">Documentation</h1>
         <p className="text-sm text-gray-500">
-          What Arbr is, how each screen works, and how to point an app at the gateway.
+          What Arbr is, and how the console works — following the path a request takes:
+          Connect → See → Recommend → Route → Govern.
         </p>
         <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
           <span className="text-gray-500">Gateway:</span>
@@ -77,7 +84,7 @@ res = arbr.chat("Summarise this ticket: ...", model="auto", max_tokens=300)   # 
         </p>
       </Card>
 
-      <Card title="Getting started">
+      <Card title="Getting started — the Connect stage">
         <ol className="ml-4 list-decimal space-y-3 text-sm text-gray-600">
           <li><strong>Run it</strong> — <code>docker compose up</code> (Mongo + app on :4100), or <code>npm run dev</code> locally.</li>
           <li><strong>Connect a provider</strong> — Settings → Connections, or the <strong>Models</strong> page. For any OpenAI-compatible provider (e.g. NVIDIA), add it there and <strong>Discover models</strong> to import them. Keys are stored encrypted.</li>
@@ -86,14 +93,21 @@ res = arbr.chat("Summarise this ticket: ...", model="auto", max_tokens=300)   # 
         </ol>
         <div className="mt-3"><CodeBlock lang="bash" code={compatCurl} /></div>
         <div className="mt-3"><CodeBlock lang="bash" code={nativeCurl} /></div>
+        <p className="mt-3 text-xs text-gray-400">
+          That's Connect. From there: <strong>See</strong> your spend, act on a <strong>Recommend</strong>ation,
+          shape how you <strong>Route</strong>, and set the guardrails to <strong>Govern</strong> it.
+        </p>
       </Card>
 
-      <Card title="The dashboard, screen by screen">
-        <p className="mb-3 text-sm text-gray-500">Every left-nav menu, and what it does:</p>
+      <Card title="The dashboard, stage by stage">
+        <p className="mb-3 text-sm text-gray-500">
+          The console follows the path a request takes: <strong>Connect → See → Recommend → Route → Govern</strong>.
+        </p>
         <div className="space-y-4">
-          {SCREENS.map(([group, items]) => (
-            <div key={group}>
-              <div className="label mb-1">{group}</div>
+          {SCREENS.map(([stage, hint, items]) => (
+            <div key={stage}>
+              <div className="label mb-0.5">{stage}</div>
+              <div className="mb-1 text-xs text-gray-400">{hint}</div>
               <ul className="space-y-1.5 text-sm text-gray-600">
                 {items.map(([name, desc]) => (
                   <li key={name}><strong className="text-arbr-charcoal">{name}</strong> — {desc}</li>

--- a/web/src/pages/Routing.jsx
+++ b/web/src/pages/Routing.jsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { api, fmt } from "../api.js";
 import { Card, Table, Stat, Toggle, Badge, Spinner, Tabs, useTabParam, ConfirmDialog } from "../components/ui.jsx";
-import Recommendations from "./Recommendations.jsx";
 
+// Recommendations moved to its own top-level page (/recommendations).
 const TABS = [
   ["rules", "Rules"],
   ["auto", "Automated routing"],
-  ["recommendations", "Recommendations"],
 ];
 
 function cond(c) {
@@ -454,6 +454,13 @@ const MODE_OPTIONS = [
 ];
 
 export default function Routing({ onChange }) {
+  const navigate = useNavigate();
+  // Recommendations is now its own page; send old ?tab=recommendations bookmarks there.
+  useEffect(() => {
+    if (new URLSearchParams(window.location.search).get("tab") === "recommendations") {
+      navigate("/recommendations", { replace: true });
+    }
+  }, [navigate]);
   const [tab, setTab] = useTabParam(TABS);
   const [rules, setRules] = useState(null);
   const [models, setModels] = useState([]);
@@ -569,8 +576,6 @@ export default function Routing({ onChange }) {
           )}
         </>
       )}
-
-      {tab === "recommendations" && <Recommendations embedded />}
 
       {err && <div className="text-red-600">{err}</div>}
     </div>


### PR DESCRIPTION
## Why

Orient the product's **operator-facing surfaces** around one vocabulary — the path a request takes through Arbr: **Connect → See → Recommend → Route → Govern**. The console previously grouped pages as Monitor/Control/Governance, "Recommendations" was buried as a tab inside Routing, and the docs used ad-hoc structure.

Scope was deliberately limited (chosen with the requester): **console navigation + docs only, no breaking changes.** The developer runtime — the npm/pip `client.chat()` call and the `/v1/*` endpoints — is untouched, because its value is being boringly OpenAI-shaped (the drop-in USP). Themes are the operator's mental model, not the developer's runtime call. The admin `/api/*` and the SDK are unchanged.

## What

**Console (`web/`)**
- `Layout.jsx`: `NAV_GROUPS` regrouped into the 5 stages, each with a one-line plain-language hint (supports the "self-explaining product" goal). New `recommend` icon.
  - **Connect** — Models, Settings
  - **See** — Overview, Applications
  - **Recommend** — Recommendations
  - **Route** — Routing, Model Evals
  - **Govern** — Budgets, Governance, Audit
- **Recommendations promoted** from a Routing tab to a top-level page (`/recommendations`). `Routing.jsx` drops the tab and redirects old `?tab=recommendations` bookmarks to the new page. Legacy `/rules → /routing` preserved.
- `Docs.jsx` restructured "stage by stage" with a per-stage purpose line and a new Recommendations entry; Getting-started reframed as the Connect stage.

**Docs**
- `docs/index.md` and `README.md` front doors restated around the same 5 stages (existing strong copy folded in, not lost).

## Page-placement judgment calls (easy to move)
- **Settings → Connect** (holds keys + gateway defaults; genuinely cross-theme, kept whole).
- **Budgets → Govern** (spend limits/enforcement).
- **Model Evals → Route** (the prove-before-you-route flow).
- **Applications → See** (its per-app routing sub-tab is cross-theme; primary job is monitoring).

## Testing
- `npm run web:build` passes; lint clean.
- No stale `tab=recommendations` links remain in `web/src`.
- Manual check to do on review: sidebar shows the 5 stages; `/recommendations` loads standalone; Routing shows only Rules + Automated; old `/rules` and `?tab=recommendations` links still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
