### PR TITLE
Stronger nav theme hierarchy + explain/override paused shadow campaigns

### DIFF
--- a/web/src/components/Layout.jsx
+++ b/web/src/components/Layout.jsx
@@ -108,7 +108,7 @@ const NAV_GROUPS = [
 const FOOTER_LINK = { to: "/docs", label: "Docs", icon: icons.docs };
 
 function navClass({ isActive }) {
-  return `mx-1 my-0.5 flex items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+  return `mx-1 my-0.5 flex items-center gap-2.5 rounded-md px-3 py-2 text-[13px] font-normal transition-colors ${
     isActive
       ? "bg-arbr-green-50 text-arbr-green-700"
       : "text-gray-500 hover:bg-gray-100 hover:text-gray-900"
@@ -136,8 +136,8 @@ export default function Layout({ status, onSignOut, children }) {
         <nav className="min-h-0 flex-1 overflow-y-auto px-2 py-1">
           {NAV_GROUPS.map((group, gi) => (
             <div key={group.section} className={gi > 0 ? "mt-5" : ""}>
-              <div className="mb-1 px-3">
-                <div className="text-[10px] font-semibold uppercase tracking-widest text-gray-400">
+              <div className="mb-1.5 px-3">
+                <div className="text-[15px] font-normal uppercase tracking-wide text-gray-500">
                   {group.section}
                 </div>
                 {group.hint && (

--- a/web/src/pages/ModelEvals.jsx
+++ b/web/src/pages/ModelEvals.jsx
@@ -294,14 +294,37 @@ export default function ModelEvals() {
     api.facets().then((f) => setApps(f?.applications || [])).catch(() => {});
   }, [load]);
 
-  const setStatus = async (c, status) => { await api.updateEvalCampaign(c._id, { status }); load(); };
+  // Activating a shadow campaign is gated on a passed offline eval (or an override). If the gate
+  // blocks it (409), explain why and offer to start it anyway with a recorded override reason.
+  const setStatus = async (c, status) => {
+    setErr(null);
+    try {
+      await api.updateEvalCampaign(c._id, { status });
+      load();
+    } catch (e) {
+      if (e.status === 409 && status === "active") {
+        const reason = window.prompt(`This shadow campaign can't start yet:\n\n${e.message}\n\nEnter an override reason to start it anyway (or Cancel):`);
+        if (!reason) return;
+        const approver = window.prompt("Approver name:") || "console";
+        try { await api.updateEvalCampaign(c._id, { status, override: { reason, approver } }); load(); }
+        catch (e2) { setErr(e2.message); }
+      } else setErr(e.message);
+    }
+  };
   const remove = async (c) => { setConfirmDel(null); await api.deleteEvalCampaign(c._id); load(); };
 
   const columns = [
     { key: "application", header: "Application", render: (c) => <span className="font-medium">{c.application}</span> },
     { key: "candidateModel", header: "Candidate" },
     { key: "judgeModel", header: "Judge", render: (c) => c.judgeModel || <span className="text-gray-400">none</span> },
-    { key: "status", header: "Status", render: (c) => <Badge tone={STATUS_TONE[c.status]}>{c.status}</Badge> },
+    { key: "status", header: "Status", render: (c) => (
+      <span className="flex flex-col gap-0.5">
+        <span><Badge tone={STATUS_TONE[c.status]}>{c.status}</Badge></span>
+        {c.status === "paused" && c.statusReason && (
+          <span className="max-w-[240px] text-[10px] leading-tight text-gray-400">{c.statusReason}</span>
+        )}
+      </span>
+    ) },
     { key: "pairCount", header: "Pairs", render: (c) => fmt.num(c.pairCount) },
     { key: "sampleRate", header: "Sample", render: (c) => pct(c.sampleRate) },
     { key: "actions", header: "", render: (c) => (


### PR DESCRIPTION
Two small console fixes reported after the 5-stage rollout (#98).

## 1. Nav theme hierarchy
The stage themes (Connect / See / Recommend / Route / Govern) weren't visually prominent enough — the menu items dominated. Adjusted `Layout.jsx`:
- **Section themes:** `10px semibold` → `15px normal`, uppercase, slightly higher contrast (`gray-400 → gray-500`). Bigger but lighter, so they read as the anchors.
- **Menu items:** `14px medium` → `13px normal`, so they recede beneath their theme.

## 2. Shadow campaign "Resume" appeared broken
Root cause (not a UI-only glitch): a shadow campaign is gated on a **passed offline eval** (`canActivateShadow`). A campaign created without one is created **paused** with a `statusReason`, and Resume re-hits the gate → **409**, which the client silently swallowed (no catch, no message). So it looked like Resume did nothing.

Fix (client only — the gate is intended behaviour):
- Show the **paused reason** in the campaigns table (e.g. *"shadow requires a passed offline eval…"*), so it's self-explaining.
- **Resume** now catches the 409 and offers an **override** (reason + approver), mirroring the Recommendations "Accept as rule" flow. A genuine failure surfaces via the existing error line.

## Testing
- `npm run web:build` passes; lint 0 errors.
- The server `PATCH /eval/campaigns/:id` gate + reset-on-activate logic is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
