### PR TITLE
Create evals directly, not only from recommendations

### DIFF
--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -764,6 +764,38 @@ router.post("/recommendations/:id/override", async (req, res, next) => {
   } catch (e) { next(e); }
 });
 
+// Create an eval directly (not from a recommendation): build a dataset from an application's
+// recent single-shot traffic and start an offline run comparing a candidate model against the
+// baseline. Lets users test ANY candidate, recommended or not. Mirrors the recommendation
+// create-dataset + run-eval flow in one call, reusing the same builder/runner with a
+// recommendation-shaped scope (recommendationId stays null).
+router.post("/evals", async (req, res, next) => {
+  try {
+    const { application, taskType, baselineModel, candidateModel, judgeModel, targetCount, piiMode, windowDays, maxRunCostUsd } = req.body || {};
+    if (!application) return res.status(400).json({ error: "application is required" });
+    if (!baselineModel) return res.status(400).json({ error: "baselineModel is required" });
+    if (!candidateModel) return res.status(400).json({ error: "candidateModel is required" });
+    if (baselineModel === candidateModel) return res.status(400).json({ error: "baselineModel and candidateModel must differ" });
+
+    // Scope shaped like a recommendation so the existing builder/runner work unchanged.
+    const scope = { _id: null, application, taskType: taskType || null, currentModel: baselineModel, suggestedModel: candidateModel };
+    const dataset = await evalDatasetBuilder.createFromTraffic({ rec: scope, targetCount, piiMode, windowDays });
+    if (dataset.status !== "ready") {
+      const body = dataset.toObject ? dataset.toObject() : dataset;
+      return res.status(422).json({ ...body, error: "no_replayable_traffic", message: dataset.error });
+    }
+    if (dataset.riskTier === "high" && judgeModel && sameFamily(judgeModel, candidateModel)) {
+      return res.status(422).json({ error: "judge_same_family", message: "For high-risk tasks the judge must not be from the candidate's model family." });
+    }
+
+    const risk = evalThresholds.riskForTier(tierForTask(taskType));
+    const thresholds = evalThresholds.defaultThresholds(risk);
+    const run = await evalReplay.startRun({ rec: null, dataset, judgeModel: judgeModel || null, thresholds, maxRunCostUsd: maxRunCostUsd ?? null });
+    setImmediate(() => logAction("eval.create", "evalRun", String(run._id), { application, baselineModel, candidateModel, judgeModel: judgeModel || null }));
+    res.status(run.status === "failed" ? 422 : 201).json({ dataset, run });
+  } catch (e) { next(e); }
+});
+
 // ── Eval datasets / runs (read views) ─────────────────────────────────────────
 router.get("/evals/datasets", async (req, res, next) => {
   try {

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -78,6 +78,7 @@ export const api = {
   overrideRecommendation: (id, body) => req(`/recommendations/${id}/override`, { method: "POST", body: JSON.stringify(body) }),
   evalDatasets: (recommendationId) => req(`/evals/datasets${qs({ recommendationId })}`),
   evalDataset: (id) => req(`/evals/datasets/${id}`),
+  createEval: (body) => req("/evals", { method: "POST", body: JSON.stringify(body) }),
   evalRuns: (recommendationId) => req(`/evals/runs${qs({ recommendationId })}`),
   evalRun: (id) => req(`/evals/runs/${id}`),
   evalRunResults: (id) => req(`/evals/runs/${id}/results`),

--- a/web/src/pages/ModelEvals.jsx
+++ b/web/src/pages/ModelEvals.jsx
@@ -221,13 +221,87 @@ function RunDetail({ id, onClose }) {
   );
 }
 
-// Offline eval runs across all recommendations.
-function EvalRunsSection() {
+// Create an eval directly — replay an application's traffic through any candidate model, judged
+// against the baseline. Doesn't require a recommendation, so users can test models on a hunch.
+function NewEval({ models, apps, onCreated }) {
+  const [form, setForm] = useState({ application: "", baselineModel: "", candidateModel: "", judgeModel: "" });
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState(null);
+  const [notice, setNotice] = useState(null);
+  const set = (k, v) => setForm((f) => ({ ...f, [k]: v }));
+
+  const submit = async () => {
+    setErr(null); setNotice(null); setBusy(true);
+    try {
+      const { run } = await api.createEval({
+        application: form.application.trim(),
+        baselineModel: form.baselineModel,
+        candidateModel: form.candidateModel,
+        judgeModel: form.judgeModel || null,
+      });
+      setNotice(`Eval started (${run.status}) — it appears below; refresh in a moment for the verdict.`);
+      setForm({ application: "", baselineModel: "", candidateModel: "", judgeModel: "" });
+      onCreated();
+    } catch (e) { setErr(e.message); } finally { setBusy(false); }
+  };
+
+  const valid = form.application.trim() && form.baselineModel && form.candidateModel && form.baselineModel !== form.candidateModel;
+  return (
+    <div className="mb-4 rounded-lg border border-gray-200 bg-gray-50/70 p-4">
+      <div className="text-sm font-semibold text-arbr-charcoal">New eval</div>
+      <p className="mb-3 mt-0.5 text-xs text-gray-500">
+        Replay an application's recent single-shot traffic through a candidate model and judge it against the
+        baseline. Works for any candidate — it doesn't have to be recommended.
+      </p>
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <div>
+          <div className="label mb-1">Application</div>
+          <input className="input w-full" list="eval-run-apps" placeholder="e.g. gyde-chat-client"
+            value={form.application} onChange={(e) => set("application", e.target.value)} />
+          <datalist id="eval-run-apps">{apps.map((a) => <option key={a} value={a} />)}</datalist>
+        </div>
+        <div>
+          <div className="label mb-1">Baseline (current)</div>
+          <select className="input w-full" value={form.baselineModel} onChange={(e) => set("baselineModel", e.target.value)}>
+            <option value="">Select…</option>
+            {models.map((m) => <option key={m.id} value={m.id}>{m.label || m.id}</option>)}
+          </select>
+        </div>
+        <div>
+          <div className="label mb-1">Candidate (to test)</div>
+          <select className="input w-full" value={form.candidateModel} onChange={(e) => set("candidateModel", e.target.value)}>
+            <option value="">Select…</option>
+            {models.map((m) => <option key={m.id} value={m.id}>{m.label || m.id}</option>)}
+          </select>
+        </div>
+        <div>
+          <div className="label mb-1">Judge <span className="text-gray-400">(optional)</span></div>
+          <select className="input w-full" value={form.judgeModel} onChange={(e) => set("judgeModel", e.target.value)}>
+            <option value="">No judge (format checks only)</option>
+            {models.map((m) => <option key={m.id} value={m.id}>{m.label || m.id}</option>)}
+          </select>
+        </div>
+      </div>
+      {err && <div className="mt-3 text-sm text-red-600">{err}</div>}
+      {notice && <div className="mt-3 text-sm text-arbr-green-700">{notice}</div>}
+      <div className="mt-3">
+        <button className="btn-secondary text-sm" disabled={busy || !valid} onClick={submit}>
+          {busy ? "Starting…" : "Run eval"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// All evals — created here directly or from a recommendation.
+function EvalRunsSection({ models, apps }) {
   const [runs, setRuns] = useState(null);
   const [openId, setOpenId] = useState(null);
-  useEffect(() => { api.evalRuns().then(setRuns).catch(() => setRuns([])); }, []);
+  const load = useCallback(() => { api.evalRuns().then(setRuns).catch(() => setRuns([])); }, []);
+  useEffect(() => { load(); }, [load]);
   const cols = [
     { key: "candidateModel", header: "Baseline → candidate", render: (r) => <span>{r.baselineModel} → <b>{r.candidateModel}</b></span> },
+    { key: "application", header: "Application", render: (r) => r.application || <span className="text-gray-400">any</span> },
     { key: "status", header: "Status", render: (r) => <Badge tone={RUN_TONE[r.status]}>{r.status}</Badge> },
     { key: "worse", header: "Worse-rate", render: (r) => pct(r.summary?.worseRate) },
     { key: "saving", header: "Cost saving", render: (r) => pct(r.summary?.costSavingPct) },
@@ -235,8 +309,9 @@ function EvalRunsSection() {
     { key: "actions", header: "", render: (r) => <button className="btn-outline text-xs" onClick={(e) => { e.stopPropagation(); setOpenId(r._id); }}>Evidence</button> },
   ];
   return (
-    <Card title="Offline eval runs">
-      {runs === null ? <Spinner /> : <Table columns={cols} rows={runs} empty="No eval runs yet — run one from a recommendation." onRowClick={(r) => setOpenId(r._id)} />}
+    <Card title="Evals">
+      <NewEval models={models} apps={apps} onCreated={load} />
+      {runs === null ? <Spinner /> : <Table columns={cols} rows={runs} empty="No evals yet — create one above, or run one from a recommendation." onRowClick={(r) => setOpenId(r._id)} />}
       {openId && <RunDetail id={openId} onClose={() => setOpenId(null)} />}
     </Card>
   );
@@ -345,7 +420,7 @@ export default function ModelEvals() {
         <p className="mt-1 text-sm text-gray-500">Prove a cheaper model is no worse than the current one (safe substitution) — offline replay, live shadow, then a guarded canary — before it becomes a rule.</p>
       </div>
 
-      <EvalRunsSection />
+      <EvalRunsSection models={models} apps={apps} />
       <CanarySection />
 
       <NewCampaign models={models} apps={apps} onCreated={load} />


### PR DESCRIPTION
Lets users run an eval on **any candidate model directly**, not only from a recommendation — so you can test a hunch (e.g. `nova-pro` for `gyde-chat-client`). Evals are now unified: they come from a recommendation **or** are created manually, and both appear in the same list.

## Server
- **`POST /api/evals`** — builds a dataset from an application's recent single-shot traffic and starts an offline run (candidate vs baseline) in one call. Reuses the existing `createFromTraffic` + `startRun` with a recommendation-shaped scope; `recommendationId` stays null (the run starter/finisher already guard for that). Same risk-tiered thresholds and same-family judge guard as the recommendation path. Returns **422 with the reason** when there's no replayable traffic (e.g. payload capture was off).

## Web (Model Evals)
- **"New eval"** form: application (autocomplete) + baseline + candidate + optional judge.
- Section renamed **"Offline eval runs" → "Evals"**; empty state now points to both sources; runs table shows the application.

## Why it matters
This is the missing entry point that was blocking direct evaluation — and a passed eval here can unblock a shadow campaign (via its override) without needing a recommendation first.

## Testing
- `npm run web:build` + lint pass (0 errors). Reused builder/runner internals are unchanged and already unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)