### PR TITLE
Evals: delete a run + replayable-traffic count on baseline select

### DIFF
--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -800,6 +800,28 @@ router.post("/evals", async (req, res, next) => {
   } catch (e) { next(e); }
 });
 
+// Estimate how many replayable requests exist for an application + baseline model, so the New
+// eval form can tell the user up front whether there's enough traffic to evaluate. Same
+// eligibility proxy as the recommendation "replayable" count (captured prompt + response,
+// non-cache); single-shot is refined at dataset build, so this is an upper-bound estimate.
+router.get("/evals/replayable-count", async (req, res, next) => {
+  try {
+    const { application, baselineModel, taskType } = req.query;
+    if (!application || !baselineModel) return res.status(400).json({ error: "application and baselineModel are required" });
+    const days = Math.max(1, parseInt(req.query.windowDays, 10) || 60);
+    const since = new Date(Date.now() - days * 86400000);
+    const q = {
+      status: "success", cacheHit: { $ne: true },
+      application, model: baselineModel,
+      messages: { $ne: null },
+      responseText: { $exists: true, $nin: [null, ""] },
+      timestamp: { $gte: since },
+    };
+    if (taskType) q.taskType = taskType;
+    res.json({ count: await RequestRecord.countDocuments(q), windowDays: days });
+  } catch (e) { next(e); }
+});
+
 // ── Eval datasets / runs (read views) ─────────────────────────────────────────
 router.get("/evals/datasets", async (req, res, next) => {
   try {
@@ -839,6 +861,34 @@ router.post("/evals/runs/:id/cancel", async (req, res, next) => {
     res.json(run);
   } catch (e) { next(e); }
 });
+// Delete an eval run and its results. Also drops the dataset + its items when no other run
+// references them (a manual eval owns its dataset), and clears a linked recommendation's pointer
+// so its recorded verdict isn't left dangling.
+router.delete("/evals/runs/:id", async (req, res, next) => {
+  try {
+    const run = await EvalRun.findById(req.params.id).lean().catch(() => null);
+    if (!run) return res.status(404).json({ error: "not found" });
+    await EvalResult.deleteMany({ evalRunId: run._id });
+    await EvalRun.deleteOne({ _id: run._id });
+
+    let datasetDeleted = false;
+    if (run.datasetId && (await EvalRun.countDocuments({ datasetId: run.datasetId })) === 0) {
+      await EvalItem.deleteMany({ datasetId: run.datasetId });
+      await EvalDataset.deleteOne({ _id: run.datasetId });
+      datasetDeleted = true;
+    }
+    if (run.recommendationId) {
+      await Recommendation.updateOne(
+        { _id: run.recommendationId, evalRunId: run._id },
+        { $set: { evalRunId: null, qualitySummary: null, evalStatus: datasetDeleted ? "not_started" : "dataset_ready",
+          ...(datasetDeleted ? { evalDatasetId: null } : {}) } }
+      ).catch(() => {});
+    }
+    setImmediate(() => logAction("eval.run.delete", "evalRun", String(run._id), { candidateModel: run.candidateModel }));
+    res.json({ ok: true });
+  } catch (e) { next(e); }
+});
+
 // Worst candidate examples first (worse verdicts + critical failures), for the evidence view.
 router.get("/evals/runs/:id/results", async (req, res, next) => {
   try {

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -79,8 +79,10 @@ export const api = {
   evalDatasets: (recommendationId) => req(`/evals/datasets${qs({ recommendationId })}`),
   evalDataset: (id) => req(`/evals/datasets/${id}`),
   createEval: (body) => req("/evals", { method: "POST", body: JSON.stringify(body) }),
+  evalReplayableCount: ({ application, baselineModel, taskType } = {}) => req(`/evals/replayable-count${qs({ application, baselineModel, taskType })}`),
   evalRuns: (recommendationId) => req(`/evals/runs${qs({ recommendationId })}`),
   evalRun: (id) => req(`/evals/runs/${id}`),
+  deleteEvalRun: (id) => req(`/evals/runs/${id}`, { method: "DELETE" }),
   evalRunResults: (id) => req(`/evals/runs/${id}/results`),
 
   // Routing experiments (canary rollout).

--- a/web/src/pages/ModelEvals.jsx
+++ b/web/src/pages/ModelEvals.jsx
@@ -247,7 +247,22 @@ function NewEval({ models, apps, onCreated }) {
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState(null);
   const [notice, setNotice] = useState(null);
+  const [avail, setAvail] = useState(null); // replayable-request count for the chosen app + baseline
   const set = (k, v) => setForm((f) => ({ ...f, [k]: v }));
+
+  // Once an application + baseline are picked, show how much replayable traffic exists to evaluate.
+  useEffect(() => {
+    const app = form.application.trim();
+    if (!app || !form.baselineModel) { setAvail(null); return; }
+    let cancelled = false;
+    setAvail("loading");
+    const t = setTimeout(() => {
+      api.evalReplayableCount({ application: app, baselineModel: form.baselineModel })
+        .then((r) => { if (!cancelled) setAvail(r.count); })
+        .catch(() => { if (!cancelled) setAvail(null); });
+    }, 350);
+    return () => { cancelled = true; clearTimeout(t); };
+  }, [form.application, form.baselineModel]);
 
   const submit = async () => {
     setErr(null); setNotice(null); setBusy(true);
@@ -301,6 +316,13 @@ function NewEval({ models, apps, onCreated }) {
           </select>
         </div>
       </div>
+      {avail === "loading" && <div className="mt-2 text-xs text-gray-400">Checking available traffic…</div>}
+      {typeof avail === "number" && (
+        <div className={`mt-2 text-xs ${avail === 0 ? "text-amber-600" : "text-gray-500"}`}>
+          ≈ <b>{fmt.num(avail)}</b> replayable request{avail === 1 ? "" : "s"} for <b>{form.application.trim()}</b> on <b>{form.baselineModel}</b> (last 60 days)
+          {avail === 0 && " — nothing to evaluate yet. Needs traffic logged with payload capture on."}
+        </div>
+      )}
       {err && <div className="mt-3 text-sm text-red-600">{err}</div>}
       {notice && <div className="mt-3 text-sm text-arbr-green-700">{notice}</div>}
       <div className="mt-3">
@@ -316,8 +338,10 @@ function NewEval({ models, apps, onCreated }) {
 function EvalRunsSection({ models, apps }) {
   const [runs, setRuns] = useState(null);
   const [openId, setOpenId] = useState(null);
+  const [confirmDel, setConfirmDel] = useState(null);
   const load = useCallback(() => { api.evalRuns().then(setRuns).catch(() => setRuns([])); }, []);
   useEffect(() => { load(); }, [load]);
+  const del = async (r) => { setConfirmDel(null); await api.deleteEvalRun(r._id).catch(() => {}); load(); };
   const cols = [
     { key: "candidateModel", header: "Baseline → candidate", render: (r) => <span>{r.baselineModel} → <b>{r.candidateModel}</b></span> },
     { key: "application", header: "Application", render: (r) => r.application || <span className="text-gray-400">any</span> },
@@ -330,13 +354,27 @@ function EvalRunsSection({ models, apps }) {
     { key: "worse", header: "Worse-rate", render: (r) => pct(r.summary?.worseRate) },
     { key: "saving", header: "Cost saving", render: (r) => pct(r.summary?.costSavingPct) },
     { key: "risk", header: "Risk", render: (r) => r.riskTier },
-    { key: "actions", header: "", render: (r) => <button className="btn-outline text-xs" onClick={(e) => { e.stopPropagation(); setOpenId(r._id); }}>Evidence</button> },
+    { key: "actions", header: "", render: (r) => (
+      <span className="flex gap-2" onClick={(e) => e.stopPropagation()}>
+        <button className="btn-outline text-xs" onClick={() => setOpenId(r._id)}>Evidence</button>
+        <button className="btn-outline text-xs text-red-600" onClick={() => setConfirmDel(r)}>Delete</button>
+      </span>
+    ) },
   ];
   return (
     <Card title="Evals" action={<RefreshButton onClick={load} />}>
       <NewEval models={models} apps={apps} onCreated={load} />
       {runs === null ? <Spinner /> : <Table columns={cols} rows={runs} empty="No evals yet — create one above, or run one from a recommendation." onRowClick={(r) => setOpenId(r._id)} />}
       {openId && <RunDetail id={openId} onClose={() => setOpenId(null)} />}
+      {confirmDel && (
+        <ConfirmDialog
+          title="Delete eval?"
+          message={`This removes the eval ${confirmDel.baselineModel} → ${confirmDel.candidateModel} and its results.`}
+          confirmLabel="Delete"
+          onConfirm={() => del(confirmDel)}
+          onCancel={() => setConfirmDel(null)}
+        />
+      )}
     </Card>
   );
 }


### PR DESCRIPTION
Two small Model Evals additions.

## Delete an eval
There was no way to remove an eval run. Adds:
- **`DELETE /api/evals/runs/:id`** — deletes the run + its results, drops the dataset + items when no other run references them, and resets a linked recommendation's eval pointer so it isn't left dangling.
- A **Delete** button (with confirmation) in the Evals table.

## Replayable-traffic count on baseline select
When you pick an **application + baseline model**, the New eval form now shows **"≈ N replayable requests"** so you know up front whether there's enough traffic — and warns when it's **0** (nothing to evaluate; needs traffic logged with payload capture on).
- **`GET /api/evals/replayable-count`** — same eligibility proxy as the recommendation "replayable" count (captured prompt + response, non-cache); single-shot is refined at dataset build, so it's an upper-bound estimate.

Build + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)