### PR TITLE
Evals: scope baseline to traffic models, candidate/judge to live+routable

### DIFF
--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -800,25 +800,26 @@ router.post("/evals", async (req, res, next) => {
   } catch (e) { next(e); }
 });
 
-// Estimate how many replayable requests exist for an application + baseline model, so the New
-// eval form can tell the user up front whether there's enough traffic to evaluate. Same
+// Models that have actually served an application's replayable traffic, with per-model counts —
+// the valid BASELINE choices for a new eval (you can't beat a model with no traffic). Same
 // eligibility proxy as the recommendation "replayable" count (captured prompt + response,
-// non-cache); single-shot is refined at dataset build, so this is an upper-bound estimate.
-router.get("/evals/replayable-count", async (req, res, next) => {
+// non-cache); single-shot is refined at dataset build, so counts are an upper-bound estimate.
+router.get("/evals/traffic-models", async (req, res, next) => {
   try {
-    const { application, baselineModel, taskType } = req.query;
-    if (!application || !baselineModel) return res.status(400).json({ error: "application and baselineModel are required" });
+    const { application } = req.query;
+    if (!application) return res.status(400).json({ error: "application is required" });
     const days = Math.max(1, parseInt(req.query.windowDays, 10) || 60);
     const since = new Date(Date.now() - days * 86400000);
-    const q = {
-      status: "success", cacheHit: { $ne: true },
-      application, model: baselineModel,
-      messages: { $ne: null },
-      responseText: { $exists: true, $nin: [null, ""] },
-      timestamp: { $gte: since },
-    };
-    if (taskType) q.taskType = taskType;
-    res.json({ count: await RequestRecord.countDocuments(q), windowDays: days });
+    const rows = await RequestRecord.aggregate([
+      { $match: {
+        application, status: "success", cacheHit: { $ne: true },
+        messages: { $ne: null }, responseText: { $exists: true, $nin: [null, ""] },
+        timestamp: { $gte: since },
+      } },
+      { $group: { _id: { model: "$model", provider: "$provider" }, count: { $sum: 1 } } },
+      { $sort: { count: -1 } },
+    ]);
+    res.json(rows.map((r) => ({ model: r._id.model, provider: r._id.provider, count: r.count })));
   } catch (e) { next(e); }
 });
 

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -79,7 +79,7 @@ export const api = {
   evalDatasets: (recommendationId) => req(`/evals/datasets${qs({ recommendationId })}`),
   evalDataset: (id) => req(`/evals/datasets/${id}`),
   createEval: (body) => req("/evals", { method: "POST", body: JSON.stringify(body) }),
-  evalReplayableCount: ({ application, baselineModel, taskType } = {}) => req(`/evals/replayable-count${qs({ application, baselineModel, taskType })}`),
+  evalTrafficModels: ({ application } = {}) => req(`/evals/traffic-models${qs({ application })}`),
   evalRuns: (recommendationId) => req(`/evals/runs${qs({ recommendationId })}`),
   evalRun: (id) => req(`/evals/runs/${id}`),
   deleteEvalRun: (id) => req(`/evals/runs/${id}`, { method: "DELETE" }),

--- a/web/src/pages/ModelEvals.jsx
+++ b/web/src/pages/ModelEvals.jsx
@@ -247,22 +247,26 @@ function NewEval({ models, apps, onCreated }) {
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState(null);
   const [notice, setNotice] = useState(null);
-  const [avail, setAvail] = useState(null); // replayable-request count for the chosen app + baseline
+  const [baselineOptions, setBaselineOptions] = useState(null); // models with replayable traffic for the app
+  const [loadingBase, setLoadingBase] = useState(false);
   const set = (k, v) => setForm((f) => ({ ...f, [k]: v }));
 
-  // Once an application + baseline are picked, show how much replayable traffic exists to evaluate.
+  // When the application changes, load the models that actually served its replayable traffic —
+  // those (and only those) are valid baselines. Reset any stale baseline pick.
   useEffect(() => {
     const app = form.application.trim();
-    if (!app || !form.baselineModel) { setAvail(null); return; }
+    setForm((f) => (f.baselineModel ? { ...f, baselineModel: "" } : f));
+    if (!app) { setBaselineOptions(null); return; }
     let cancelled = false;
-    setAvail("loading");
+    setLoadingBase(true);
     const t = setTimeout(() => {
-      api.evalReplayableCount({ application: app, baselineModel: form.baselineModel })
-        .then((r) => { if (!cancelled) setAvail(r.count); })
-        .catch(() => { if (!cancelled) setAvail(null); });
+      api.evalTrafficModels({ application: app })
+        .then((rows) => { if (!cancelled) setBaselineOptions(rows || []); })
+        .catch(() => { if (!cancelled) setBaselineOptions([]); })
+        .finally(() => { if (!cancelled) setLoadingBase(false); });
     }, 350);
     return () => { cancelled = true; clearTimeout(t); };
-  }, [form.application, form.baselineModel]);
+  }, [form.application]);
 
   const submit = async () => {
     setErr(null); setNotice(null); setBusy(true);
@@ -296,9 +300,13 @@ function NewEval({ models, apps, onCreated }) {
         </div>
         <div>
           <div className="label mb-1">Baseline (current)</div>
-          <select className="input w-full" value={form.baselineModel} onChange={(e) => set("baselineModel", e.target.value)}>
-            <option value="">Select…</option>
-            {models.map((m) => <option key={m.id} value={m.id}>{m.label || m.id}</option>)}
+          <select className="input w-full" value={form.baselineModel}
+            disabled={!form.application.trim() || loadingBase || (baselineOptions != null && baselineOptions.length === 0)}
+            onChange={(e) => set("baselineModel", e.target.value)}>
+            <option value="">{!form.application.trim() ? "Pick an application first" : loadingBase ? "Loading…" : "Select…"}</option>
+            {(baselineOptions || []).map((o) => (
+              <option key={o.model} value={o.model}>{o.model} ({fmt.num(o.count)} replayable)</option>
+            ))}
           </select>
         </div>
         <div>
@@ -316,11 +324,9 @@ function NewEval({ models, apps, onCreated }) {
           </select>
         </div>
       </div>
-      {avail === "loading" && <div className="mt-2 text-xs text-gray-400">Checking available traffic…</div>}
-      {typeof avail === "number" && (
-        <div className={`mt-2 text-xs ${avail === 0 ? "text-amber-600" : "text-gray-500"}`}>
-          ≈ <b>{fmt.num(avail)}</b> replayable request{avail === 1 ? "" : "s"} for <b>{form.application.trim()}</b> on <b>{form.baselineModel}</b> (last 60 days)
-          {avail === 0 && " — nothing to evaluate yet. Needs traffic logged with payload capture on."}
+      {form.application.trim() && !loadingBase && baselineOptions != null && baselineOptions.length === 0 && (
+        <div className="mt-2 text-xs text-amber-600">
+          No replayable traffic for <b>{form.application.trim()}</b> in the last 60 days — nothing to evaluate yet (needs requests logged with payload capture on).
         </div>
       )}
       {err && <div className="mt-3 text-sm text-red-600">{err}</div>}
@@ -427,7 +433,8 @@ export default function ModelEvals() {
 
   useEffect(() => {
     load();
-    api.models().then((m) => setModels(m || [])).catch(() => {});
+    // Candidate + judge get CALLED during a run, so only offer connected, chat-capable models.
+    api.models({ live: true, routable: true }).then((m) => setModels(m || [])).catch(() => {});
     api.facets().then((f) => setApps(f?.applications || [])).catch(() => {});
   }, [load]);
 


### PR DESCRIPTION
The New-eval model pickers were both drawn from the whole registry. Fixed to match what each field actually means:

## Baseline (current) → only models with traffic
Baseline now lists **only the models that actually served the selected application's replayable traffic**, each with its **replayable count** (e.g. `gpt-4o-mini (1,234 replayable)`). You can't "beat" a model that has no traffic. Pick an app and it loads that app's traffic models; an app with none shows a clear *"nothing to evaluate yet"* hint.
- New **`GET /api/evals/traffic-models`** (replaces the flat `/evals/replayable-count`, which is superseded by the per-model counts).

## Candidate + Judge → live + routable only
Both are **called** during the replay, so they now come from **connected, chat-capable** models (`api.models({ live: true, routable: true })`). Offering the entire registry let you pick a model that can't run (the run would just fail "not on a live provider"). Key-level allowlists are a serving concern; eval calls the provider directly, so connected + chat-capable is the right filter.

Build + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)