### PR TITLE
Model pickers outside the Models tab use the connected registry (audit)

### DIFF
--- a/web/src/pages/ApplicationDetail.jsx
+++ b/web/src/pages/ApplicationDetail.jsx
@@ -493,7 +493,9 @@ export default function ApplicationDetail() {
       .catch((e) => setErr(e.message));
 
   useEffect(() => {
-    Promise.all([loadConfig(), api.models({ live: true }).then(setModels).catch(() => {})]);
+    // Per-app routing pickers target chat models on connected providers; the saved per-app
+    // assignments/opt-out come from loadConfig(). Options are live + routable only.
+    Promise.all([loadConfig(), api.models({ live: true, routable: true }).then(setModels).catch(() => {})]);
   }, [appName]);
 
   const toggleKill = async (enabled) => {

--- a/web/src/pages/Settings.jsx
+++ b/web/src/pages/Settings.jsx
@@ -229,7 +229,8 @@ export default function Settings({ onChange }) {
 
   useEffect(() => {
     load();
-    api.models().then(setModels).catch(() => {});
+    // Default-model picker: only connected, chat-capable models (not the full registry).
+    api.models({ live: true, routable: true }).then(setModels).catch(() => {});
     api.about().then(setAbout).catch(() => {});
   }, []);
 


### PR DESCRIPTION
Audit + fix so model pickers are consistent, per the rule: **the Models tab shows the full saved registry; everywhere else shows only the connected, chat-capable subset**, and app-scoped surfaces reflect the app's saved config.

## Findings
| Surface | Before | Fix |
|---|---|---|
| **Models tab** | `api.models()` (all) | ✅ correct — it's the registry manager |
| Routing | live + routable | ✅ already correct |
| Model Evals | live + routable | ✅ (#104) |
| Recommendations judge | live + routable | ✅ already correct |
| **Settings** (default model) | `api.models()` — full catalog | **→ live + routable** |
| **ApplicationDetail** (per-app policy) | `api.models({ live:true })` | **→ add routable** |

## Notes
- No surface pulls the LiteLLM sync JSON directly. `/api/models` always returns the **saved registry**; `live`/`routable` just filter it (connected providers / chat-capable). So "everywhere else = what's saved in the Models tab" already holds structurally; these two were just under-filtered.
- App-scoped: per-app assignments and model opt-out still come from the app config (`loadConfig`); only the dropdown option list changed to live+routable.

Build + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)