### PR TITLE
Explain why an eval judged 0 items (surface judge failures)

### DIFF
--- a/server/src/eval/replay.js
+++ b/server/src/eval/replay.js
@@ -161,25 +161,28 @@ async function executeRun(runId) {
         router, eff, judgeModel: run.judgeModel,
         userText: lastUserText(item.messages), baselineText: item.productionResponse, candidateText: candidate.text, flip,
       });
+      // { error } = judge was configured but produced no usable verdict (call failed / bad output).
+      const judgeError = verdict && verdict.error ? verdict.error : null;
+      const scored = verdict && !judgeError ? verdict : null;
 
       const storedResp = clampText(maskEnabled ? maskPii(candidate.text || "", customPatterns) : (candidate.text || ""));
       await EvalResult.create({
         evalRunId: run._id, evalItemId: item._id, requestId: item.requestId,
         baselineModel: dataset.baselineModel, candidateModel: dataset.candidateModel,
         candidateResponse: storedResp, candidateCost: candCost, candidateLatencyMs: candidate.latencyMs || 0,
-        judgeVerdict: verdict ? verdict.verdict : null,
-        dimensionScores: verdict ? verdict.dimensionScores : {},
-        criticalFailure: verdict ? !!verdict.criticalFailure : false,
+        judgeVerdict: scored ? scored.verdict : null,
+        dimensionScores: scored ? scored.dimensionScores : {},
+        criticalFailure: scored ? !!scored.criticalFailure : false,
         validatorResults: results, formatPass,
-        abFlipped: verdict ? !!verdict.abFlipped : false,
-        judgeRationale: verdict ? verdict.judgeRationale : null,
+        abFlipped: scored ? !!scored.abFlipped : false,
+        judgeRationale: scored ? scored.judgeRationale : judgeError,
       });
       entries.push({
-        verdict: verdict ? verdict.verdict : null,
-        criticalFailure: verdict ? !!verdict.criticalFailure : false,
+        verdict: scored ? scored.verdict : null,
+        criticalFailure: scored ? !!scored.criticalFailure : false,
         formatPass, candidateCost: candCost, candidateLatencyMs: candidate.latencyMs || 0,
         productionCost: item.productionCost || 0, productionLatencyMs: item.productionLatencyMs || 0,
-        errored: false,
+        errored: false, judgeError,
       });
     } catch (err) {
       await EvalResult.create({
@@ -209,6 +212,13 @@ async function finish(run, entries, hardError, actualCost = 0) {
     const { passed, failures } = evaluateRun(summary, run.thresholds || {});
     run.status = passed ? "passed" : "failed";
     run.failures = failures;
+    // If nothing got judged because the JUDGE itself failed, say so — otherwise "0 items judged"
+    // looks like a data problem when it's really a bad/unreachable judge model.
+    const judgeErrs = entries.filter((e) => e.judgeError);
+    if ((summary.judged || 0) === 0 && judgeErrs.length) {
+      run.error = `The judge produced no verdicts: ${judgeErrs[judgeErrs.length - 1].judgeError}. ` +
+        `Pick a judge on a connected provider that reliably returns JSON (e.g. gpt-4o-mini).`;
+    }
   }
   await run.save();
 

--- a/server/src/eval/rubricJudge.js
+++ b/server/src/eval/rubricJudge.js
@@ -132,15 +132,17 @@ async function judgeItem({ router, eff, judgeModel, userText, baselineText, cand
   const aText = flip ? candidateText : baselineText;
   const bText = flip ? baselineText : candidateText;
   const prompt = buildRubricPrompt({ userText, aText, bText });
+  // On failure return { error } (not null) so the run can explain WHY 0 items were judged.
+  // null is reserved for "no judge configured / not live" (an intentional capture-only run).
   try {
     const res = await router.complete({
       messages: prompt, providerOverride: jm.provider, modelOverride: judgeModel, temperature: 0,
     });
     const parsed = parseRubricVerdict(res.text || "");
-    const mapped = mapVerdictToCandidate(parsed, candidateSlot);
-    return mapped ? { ...mapped, abFlipped: !!flip } : null;
-  } catch {
-    return null;
+    if (!parsed) return { error: `judge "${judgeModel}" did not return a valid A/B/tie JSON verdict` };
+    return { ...mapVerdictToCandidate(parsed, candidateSlot), abFlipped: !!flip };
+  } catch (e) {
+    return { error: `judge "${judgeModel}" call failed: ${e.message}` };
   }
 }
 


### PR DESCRIPTION
Your eval failed with **"only 0 items judged, need 2"** — for the second time with a different judge (`zai.glm-5`, now `gemma-3-12b-it`). Root cause is a silent bug, not your data.

## Bug
`judgeItem()` swallowed **both** an upstream judge-call error **and** unparseable judge output, returning `null` — which is indistinguishable from "no judge configured". So a judge model that isn't actually callable (or doesn't return JSON) silently produced 0 verdicts, and the run reported a cryptic `0 items judged` with no reason.

## Fix
- `judgeItem` now returns `{ error }` on a failed/garbled judge call. `null` still means "no judge configured / not live" (an intentional capture-only run).
- The reason is stored per-item (`judgeRationale`) and, when nothing was judged because the judge failed, surfaced on `run.error`: *"The judge produced no verdicts: &lt;reason&gt;. Pick a judge on a connected provider that reliably returns JSON (e.g. gpt-4o-mini)."*
- The run drawer already renders `run.error`, so it shows up immediately.

No behaviour change when the judge works or when no judge is selected. Eval unit suites (22) + lint pass.

## Note on your run
Separately, that run's **-54.6% cost saving** is legit and correctly failed: `nova-pro` is *more expensive* than the `kimi-k2.5` baseline. For a judge that will actually work on your connected providers, use **`gpt-4o-mini`** (openai) — Gemma/z.ai weren't returning usable verdicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)