### PR TITLE
feat(ui): redesign Recommendations page into structured sections

### DIFF
--- a/web/src/pages/Recommendations.jsx
+++ b/web/src/pages/Recommendations.jsx
@@ -2,20 +2,71 @@ import React, { useEffect, useState } from "react";
 import { api, fmt } from "../api.js";
 import { Card, Badge, Spinner } from "../components/ui.jsx";
 
-const EVAL_TONE = { not_started: "gray", dataset_ready: "gray", running: "amber", passed: "green", failed: "red", overridden: "amber" };
+const EVAL_TONE  = { not_started: "gray", dataset_ready: "gray", running: "amber", passed: "green", failed: "red", overridden: "amber" };
 const EVAL_LABEL = { not_started: "No eval", dataset_ready: "Dataset ready", running: "Evaluating…", passed: "Eval passed", failed: "Eval failed", overridden: "Overridden" };
+
 const pct = (n) => (n == null ? "—" : `${(n * 100).toFixed(1)}%`);
 
-// Evidence summary line from a run/quality summary.
+// Derive 3-step workflow state from evalStatus.
+function stepsFromEvalStatus(evalStatus) {
+  const s = evalStatus || "not_started";
+  return [
+    {
+      id: "dataset", label: "Build dataset",
+      status: ["dataset_ready", "running", "passed", "failed", "overridden"].includes(s) ? "done" : "active",
+    },
+    {
+      id: "eval", label: "Run eval",
+      status: s === "running" ? "running" : s === "failed" ? "failed" : ["passed", "overridden"].includes(s) ? "done" : s === "dataset_ready" ? "active" : "idle",
+    },
+    {
+      id: "canary", label: "Start canary",
+      status: s === "passed" ? "active" : "idle",
+    },
+  ];
+}
+
+const DOT_CLASS = {
+  done:    "w-6 h-6 rounded-full bg-arbr-green-600 text-white flex items-center justify-center text-xs font-medium",
+  active:  "w-6 h-6 rounded-full border-2 border-arbr-green-600 text-arbr-green-600 flex items-center justify-center text-xs font-medium",
+  running: "w-6 h-6 rounded-full border-2 border-amber-400 text-amber-500 flex items-center justify-center text-xs font-medium animate-pulse",
+  failed:  "w-6 h-6 rounded-full border-2 border-red-400 text-red-500 flex items-center justify-center text-xs font-medium",
+  idle:    "w-6 h-6 rounded-full border-2 border-gray-200 text-gray-300 flex items-center justify-center text-xs font-medium",
+};
+const DOT_TEXT = {
+  done: "text-arbr-green-700 font-medium", active: "text-arbr-green-600 font-medium",
+  running: "text-amber-600", failed: "text-red-600", idle: "text-gray-300",
+};
+
+function StepTracker({ steps }) {
+  return (
+    <div className="flex items-center">
+      {steps.map((step, i) => (
+        <React.Fragment key={step.id}>
+          <div className="flex items-center gap-2 shrink-0">
+            <div className={DOT_CLASS[step.status]}>
+              {step.status === "done" ? "✓" : i + 1}
+            </div>
+            <span className={`text-xs ${DOT_TEXT[step.status]}`}>{step.label}</span>
+          </div>
+          {i < steps.length - 1 && (
+            <div className={`flex-1 h-px mx-3 min-w-8 ${step.status === "done" ? "bg-arbr-green-200" : "bg-gray-100"}`} />
+          )}
+        </React.Fragment>
+      ))}
+    </div>
+  );
+}
+
 function QualitySummary({ s }) {
   if (!s) return null;
   return (
-    <div className="mt-3 flex flex-wrap gap-2 text-xs">
+    <div className="flex flex-wrap gap-2">
       <Badge tone="gray">{fmt.num(s.judged)} judged</Badge>
       <Badge tone={s.worseRate > 0.05 ? "red" : "green"}>worse {pct(s.worseRate)}</Badge>
       {s.criticalFailRate != null && <Badge tone={s.criticalFailRate > 0 ? "red" : "gray"}>critical {pct(s.criticalFailRate)}</Badge>}
       <Badge tone="gray">format {pct(s.formatPassRate)}</Badge>
-      <Badge tone="green">cost −{pct(s.costSavingPct)}</Badge>
+      <Badge tone="green">cost -{pct(s.costSavingPct)}</Badge>
       {s.avgLatencyDeltaPct != null && <Badge tone="gray">latency {s.avgLatencyDeltaPct > 0 ? "+" : ""}{pct(s.avgLatencyDeltaPct)}</Badge>}
     </div>
   );
@@ -50,90 +101,146 @@ function RecCard({ rec, models, onChange }) {
     } finally { setBusy(false); }
   };
 
+  // Collapsed card for accepted/dismissed recommendations.
+  if (rec.status !== "pending") {
+    const tone = rec.status === "accepted" ? "green" : "gray";
+    return (
+      <Card>
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3 min-w-0 overflow-hidden">
+            <Badge tone={tone}>{rec.status === "accepted" ? "Accepted" : "Dismissed"}</Badge>
+            <span className="text-sm text-arbr-charcoal font-mono truncate">
+              {rec.currentModel} → {rec.suggestedModel}
+            </span>
+            {rec.taskType && <span className="text-xs text-gray-400 truncate hidden sm:block">· {rec.taskType}</span>}
+            {rec.application && <span className="text-xs text-gray-400 truncate hidden sm:block">· {rec.application}</span>}
+          </div>
+          <span className="shrink-0 text-sm font-semibold text-arbr-green-600">{fmt.usd(rec.projectedSavings)} saved</span>
+        </div>
+      </Card>
+    );
+  }
+
+  const steps = stepsFromEvalStatus(evalStatus);
+  const noReplayable = rec.replayableCount === 0;
+
   return (
     <Card>
+      {/* Section 1: Header */}
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
-          <div className="flex items-center gap-2">
-            <h3 className="text-base font-semibold text-arbr-charcoal">{rec.title}</h3>
-            {rec.status === "accepted" && <Badge tone="green">Accepted</Badge>}
-            {rec.status === "dismissed" && <Badge tone="gray">Dismissed</Badge>}
-            {rec.status === "pending" && <Badge tone="amber">Pending</Badge>}
-            <Badge tone={EVAL_TONE[evalStatus]}>{EVAL_LABEL[evalStatus]}</Badge>
-          </div>
-          <p className="mt-2 text-sm text-gray-600">{rec.reason}</p>
-          <div className="mt-3 flex flex-wrap gap-2 text-xs">
-            {rec.application && <Badge tone="charcoal">app: {rec.application}</Badge>}
-            <Badge tone="charcoal">{rec.currentModel} → {rec.suggestedModel}</Badge>
-            <Badge tone="gray">{fmt.num(rec.requestCount)} requests</Badge>
+          <div className="label mb-1">Recommendation</div>
+          <h3 className="text-base font-semibold text-arbr-charcoal">
+            {rec.taskType || rec.title}
+          </h3>
+          <p className="mt-0.5 text-xs text-gray-400">
+            {fmt.num(rec.requestCount)} requests
+            {rec.application ? ` · ${rec.application}` : ""}
             {rec.replayableCount != null && (
-              <Badge tone={rec.replayableCount === 0 ? "red" : "gray"}>{fmt.num(rec.replayableCount)} replayable</Badge>
+              <span className={rec.replayableCount === 0 ? " text-red-500" : ""}>
+                {" "}· {fmt.num(rec.replayableCount)} replayable
+              </span>
             )}
-          </div>
-          <QualitySummary s={rec.qualitySummary} />
+          </p>
         </div>
-        <div className="shrink-0 text-right">
-          <div className="label">Projected saving</div>
-          <div className="text-2xl font-bold text-arbr-green-600">{fmt.usd(rec.projectedSavings)}</div>
-          <div className="text-xs text-gray-500">{fmt.usd(rec.currentCost)} → {fmt.usd(rec.projectedCost)}</div>
+        <div className="flex items-center gap-2 shrink-0">
+          <Badge tone="amber">Pending</Badge>
+          <Badge tone={EVAL_TONE[evalStatus]}>{EVAL_LABEL[evalStatus]}</Badge>
         </div>
       </div>
 
-      {rec.status === "pending" && (
-        <div className="mt-4 border-t border-gray-100 pt-4">
-          {/* Eval-backed flow: prove quality, then roll out under control. */}
-          <div className="flex flex-wrap items-center gap-2">
-            {(evalStatus === "not_started") && (
-              rec.replayableCount === 0 ? (
-                <span className="text-sm text-gray-500">
-                  No replayable traffic yet — this recommendation's requests have no captured prompts.
-                  Turn on payload capture (Settings → Observability); only traffic logged after it is enabled can be evaluated.
-                </span>
-              ) : (
-                <button className="btn-secondary text-sm" disabled={busy}
-                  onClick={() => run(() => api.createEvalDataset(rec._id), (d) => `Dataset built: ${d.itemCount} items (${d.riskTier} risk).`)}>
-                  Build eval dataset
-                </button>
-              )
-            )}
-            {(evalStatus === "dataset_ready" || evalStatus === "failed") && (
-              <>
-                <select className="input text-sm" value={judge} onChange={(e) => setJudge(e.target.value)} title="Judge model">
-                  <option value="">Judge: none</option>
-                  {models.map((m) => <option key={m.id} value={m.id}>Judge: {m.label || m.id}</option>)}
-                </select>
-                <button className="btn-secondary text-sm" disabled={busy}
-                  onClick={() => run(() => api.runEval(rec._id, { judgeModel: judge || null }), () => "Offline eval started — refresh in a moment.")}>
-                  Run offline eval
-                </button>
-              </>
-            )}
-            {evalStatus === "running" && <span className="text-sm text-amber-600">Evaluating… refresh to see the result.</span>}
-            {evalStatus === "passed" && (
-              <>
-                <input className="input text-sm" placeholder="application for rollout" value={application} onChange={(e) => setApplication(e.target.value)} />
-                <button className="btn-secondary text-sm" disabled={busy || !application.trim()}
-                  onClick={() => run(() => api.createCanary(rec._id, { application: application.trim() }), (x) => `Canary started at ${x.rolloutPct}%.`)}>
-                  Start canary
-                </button>
-              </>
-            )}
-            <button className="btn-outline text-sm" disabled={busy} onClick={accept}>Accept as rule</button>
-            <button className="btn-outline text-sm" disabled={busy} onClick={() => run(() => api.dismissRecommendation(rec._id))}>Dismiss</button>
+      {/* Section 2: Model substitution + Savings */}
+      <div className="mt-4 pt-4 border-t border-gray-100 flex gap-6">
+        <div className="flex-1 min-w-0">
+          <div className="label mb-2">Model substitution</div>
+          <div className="flex flex-col items-start gap-1.5">
+            <span className="inline-block bg-gray-100 text-arbr-charcoal rounded px-2 py-1 text-xs font-mono">
+              {rec.currentModel}
+            </span>
+            <span className="text-xs text-arbr-green-600 pl-2 leading-none select-none">↓</span>
+            <span className="inline-block bg-arbr-green-50 text-arbr-green-700 border border-arbr-green-200 rounded px-2 py-1 text-xs font-mono">
+              {rec.suggestedModel}
+            </span>
           </div>
-          <p className="mt-2 text-xs text-gray-400">
-            Accepting creates a routing rule (off until you switch it on). It is gated on a passed eval; without one you'll be asked for an override reason.
-          </p>
-          {notice && <div className="mt-2 text-sm text-arbr-green-700">{notice}</div>}
-          {err && <div className="mt-2 text-sm text-red-600">{err}</div>}
         </div>
-      )}
+        <div className="border-l border-gray-100 pl-6 shrink-0 text-right">
+          <div className="label mb-1">Projected saving</div>
+          <div className="text-3xl font-bold text-arbr-green-600">{fmt.usd(rec.projectedSavings)}</div>
+          <div className="mt-0.5 text-xs text-gray-500">{fmt.usd(rec.currentCost)} → {fmt.usd(rec.projectedCost)}</div>
+          <div className="mt-0.5 text-xs text-gray-400">{fmt.num(rec.requestCount)} requests</div>
+        </div>
+      </div>
+
+      {/* Section 3: Evaluation workflow */}
+      <div className="mt-4 pt-4 border-t border-gray-100">
+        <div className="label mb-3">Evaluation workflow</div>
+        <StepTracker steps={steps} />
+        <div className="mt-4">
+          {evalStatus === "not_started" && (
+            noReplayable ? (
+              <p className="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+                No replayable traffic yet — captured prompts are required to build a dataset.
+                Turn on payload capture in <strong>Settings → Observability</strong>; only traffic logged after it is enabled can be evaluated.
+              </p>
+            ) : (
+              <button className="btn-secondary text-sm" disabled={busy}
+                onClick={() => run(() => api.createEvalDataset(rec._id), (d) => `Dataset built: ${d.itemCount} items (${d.riskTier} risk).`)}>
+                Build eval dataset
+              </button>
+            )
+          )}
+          {(evalStatus === "dataset_ready" || evalStatus === "failed") && (
+            <div className="flex flex-wrap items-center gap-2">
+              <select className="input text-sm" value={judge} onChange={(e) => setJudge(e.target.value)}>
+                <option value="">Judge: none</option>
+                {models.map((m) => <option key={m.id} value={m.id}>Judge: {m.label || m.id}</option>)}
+              </select>
+              <button className="btn-secondary text-sm" disabled={busy}
+                onClick={() => run(() => api.runEval(rec._id, { judgeModel: judge || null }), () => "Offline eval started — refresh in a moment.")}>
+                Run offline eval
+              </button>
+            </div>
+          )}
+          {evalStatus === "running" && (
+            <span className="text-sm text-amber-600">Evaluating… refresh to see the result.</span>
+          )}
+          {evalStatus === "passed" && (
+            <div className="flex flex-wrap items-center gap-2">
+              <input className="input text-sm" placeholder="application for rollout" value={application}
+                onChange={(e) => setApplication(e.target.value)} />
+              <button className="btn-secondary text-sm" disabled={busy || !application.trim()}
+                onClick={() => run(() => api.createCanary(rec._id, { application: application.trim() }), (x) => `Canary started at ${x.rolloutPct}%.`)}>
+                Start canary
+              </button>
+            </div>
+          )}
+          {notice && <p className="mt-2 text-sm text-arbr-green-700">{notice}</p>}
+          {err    && <p className="mt-2 text-sm text-red-600">{err}</p>}
+        </div>
+        {rec.qualitySummary && (
+          <div className="mt-3 pt-3 border-t border-gray-100">
+            <QualitySummary s={rec.qualitySummary} />
+          </div>
+        )}
+      </div>
+
+      {/* Section 4: Decisions */}
+      <div className="mt-4 pt-4 border-t border-gray-100 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <button className="btn-outline text-sm" disabled={busy} onClick={accept}>Accept as rule</button>
+          <button className="btn-outline text-sm" disabled={busy}
+            onClick={() => run(() => api.dismissRecommendation(rec._id))}>Dismiss</button>
+        </div>
+        <p className="text-xs text-gray-400">
+          Accepting creates a routing rule (off until you switch it on).
+          Gated on a passed eval; without one you'll be asked for an override reason.
+        </p>
+      </div>
     </Card>
   );
 }
 
-// Self-diagnosing empty state: instead of a dead end, explain what was analyzed and surface
-// high-spend task types that are excluded only because they aren't marked cheap — with a
+// Self-diagnosing empty state: surface high-spend task types not yet marked cheap — with a
 // one-click "mark cheap & recompute". Falls back gracefully if the analysis endpoint is absent.
 function EmptyState({ analysis, busy, onMarkCheap }) {
   if (!analysis) {
@@ -153,7 +260,7 @@ function EmptyState({ analysis, busy, onMarkCheap }) {
       <Card>
         <div className="py-8 text-center text-gray-500">
           <div className="text-arbr-charcoal font-medium">Nothing to optimise right now.</div>
-          <p className="mt-1 text-sm text-gray-400">{analyzed} No premium model is overused on a cheap task — cheap-task traffic is already on lighter models.</p>
+          <p className="mt-1 text-sm text-gray-400">{analyzed} No premium model is overused on a cheap task.</p>
         </div>
       </Card>
     );
@@ -224,7 +331,6 @@ export default function Recommendations({ embedded = false }) {
     finally { setBusy(false); }
   };
 
-  // One-click: mark the given task types cheap (union with the current set), then recompute.
   const markCheapAndRecompute = async (taskTypes) => {
     setBusy(true); setErr(null);
     try {
@@ -241,7 +347,9 @@ export default function Recommendations({ embedded = false }) {
       <div className="flex items-start justify-between">
         <div>
           {!embedded && <h1 className="text-2xl font-bold text-arbr-charcoal">Recommendations</h1>}
-          <p className="text-sm text-gray-500">Costed suggestions. Prove a cheaper model is no worse than the current one, then roll out under control — the system proposes, the human decides.</p>
+          <p className="text-sm text-gray-500">
+            Costed suggestions. Prove a cheaper model is no worse than the current one, then roll out under control — the system proposes, the human decides.
+          </p>
         </div>
         <button className="btn-primary" onClick={recompute} disabled={busy}>
           {busy ? "Recomputing…" : "Recompute"}
@@ -249,7 +357,10 @@ export default function Recommendations({ embedded = false }) {
       </div>
 
       {err && <div className="text-red-600">{err}</div>}
-      {recs === null ? <Spinner /> : recs.length === 0 ? (
+
+      {recs === null ? (
+        <Spinner />
+      ) : recs.length === 0 ? (
         <EmptyState analysis={analysis} busy={busy} onMarkCheap={markCheapAndRecompute} />
       ) : (
         <div className="space-y-4">


### PR DESCRIPTION
## Summary

Replaces the flat log-entry card layout with a 4-section design that guides the eye from what's flagged → what you'd save → how to act → accept/dismiss.

**Card sections (pending recommendations):**
1. **Header** — task type as heading, request count + replayable count + app as sub-line, status + eval badges top-right
2. **Model substitution + Savings** — vertical current↓suggested model chips (monospace) on the left; projected saving hero number on the right
3. **Evaluation workflow** — 3-step tracker (Build dataset → Run eval → Start canary) with step state (done/active/running/failed/idle) and the active step's action form shown inline; `replayableCount === 0` shows an amber callout instead of the Build button
4. **Decisions** — Accept as rule / Dismiss with helper text

**Accepted/dismissed cards** collapse to a single compact row (badge + model arrow + task type + savings), keeping the list scannable once resolved.

All new fields from main are included: `replayableCount`, `application`, `EmptyState` with `markCheapAndRecompute`, `api.recommendationsAnalysis()`, and `api.models({ routable: true })`. No API or backend changes.

## Test plan

- [ ] Deploy + open Recommendations page — pending cards show all 4 sections
- [ ] Accepted/dismissed cards render as single compact rows
- [ ] Step tracker reflects evalStatus correctly (step 1 active for `not_started`, step 1 done + step 2 active for `dataset_ready`, etc.)
- [ ] `replayableCount === 0` shows amber callout instead of Build button
- [ ] EmptyState with "Mark cheap" opportunities still works
- [ ] Accept as rule / Dismiss / Build dataset / Run eval / Start canary actions all function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)