### PR TITLE
Fix judge invocation (string vs messages array) + Re-run evals

### DIFF
--- a/server/src/eval/judge.js
+++ b/server/src/eval/judge.js
@@ -36,7 +36,7 @@ async function judge({ router, eff, judgeModel, messages, prodText, candidateTex
   ].join("\n");
   try {
     const res = await router.complete({
-      messages: prompt, providerOverride: jm.provider, modelOverride: judgeModel, temperature: 0,
+      messages: [{ role: "user", content: prompt }], providerOverride: jm.provider, modelOverride: judgeModel, temperature: 0,
     });
     return parseVerdict(res.text || "");
   } catch {

--- a/server/src/eval/rubricJudge.js
+++ b/server/src/eval/rubricJudge.js
@@ -136,7 +136,7 @@ async function judgeItem({ router, eff, judgeModel, userText, baselineText, cand
   // null is reserved for "no judge configured / not live" (an intentional capture-only run).
   try {
     const res = await router.complete({
-      messages: prompt, providerOverride: jm.provider, modelOverride: judgeModel, temperature: 0,
+      messages: [{ role: "user", content: prompt }], providerOverride: jm.provider, modelOverride: judgeModel, temperature: 0,
     });
     const parsed = parseRubricVerdict(res.text || "");
     if (!parsed) return { error: `judge "${judgeModel}" did not return a valid A/B/tie JSON verdict` };

--- a/web/src/pages/ModelEvals.jsx
+++ b/web/src/pages/ModelEvals.jsx
@@ -345,9 +345,18 @@ function EvalRunsSection({ models, apps }) {
   const [runs, setRuns] = useState(null);
   const [openId, setOpenId] = useState(null);
   const [confirmDel, setConfirmDel] = useState(null);
+  const [err, setErr] = useState(null);
   const load = useCallback(() => { api.evalRuns().then(setRuns).catch(() => setRuns([])); }, []);
   useEffect(() => { load(); }, [load]);
   const del = async (r) => { setConfirmDel(null); await api.deleteEvalRun(r._id).catch(() => {}); load(); };
+  // Re-run: start a fresh eval with the same application, baseline, candidate and judge.
+  const rerun = async (r) => {
+    setErr(null);
+    try {
+      await api.createEval({ application: r.application, baselineModel: r.baselineModel, candidateModel: r.candidateModel, judgeModel: r.judgeModel || null });
+      load();
+    } catch (e) { setErr(e.message); }
+  };
   const cols = [
     { key: "candidateModel", header: "Baseline → candidate", render: (r) => <span>{r.baselineModel} → <b>{r.candidateModel}</b></span> },
     { key: "application", header: "Application", render: (r) => r.application || <span className="text-gray-400">any</span> },
@@ -363,6 +372,7 @@ function EvalRunsSection({ models, apps }) {
     { key: "actions", header: "", render: (r) => (
       <span className="flex gap-2" onClick={(e) => e.stopPropagation()}>
         <button className="btn-outline text-xs" onClick={() => setOpenId(r._id)}>Evidence</button>
+        {r.application && <button className="btn-outline text-xs" onClick={() => rerun(r)}>Re-run</button>}
         <button className="btn-outline text-xs text-red-600" onClick={() => setConfirmDel(r)}>Delete</button>
       </span>
     ) },
@@ -370,6 +380,7 @@ function EvalRunsSection({ models, apps }) {
   return (
     <Card title="Evals" action={<RefreshButton onClick={load} />}>
       <NewEval models={models} apps={apps} onCreated={load} />
+      {err && <div className="mb-3 text-sm text-red-600">{err}</div>}
       {runs === null ? <Spinner /> : <Table columns={cols} rows={runs} empty="No evals yet — create one above, or run one from a recommendation." onRowClick={(r) => setOpenId(r._id)} />}
       {openId && <RunDetail id={openId} onClose={() => setOpenId(null)} />}
       {confirmDel && (


### PR DESCRIPTION
#106's clearer error message paid off immediately — it exposed the actual bug.

## The real bug: judging never worked
`router.complete` (llm-router) requires a **non-empty messages array**, but both judge call sites passed the rubric prompt as a raw **string** → `complete: messages array is required`. So LLM-as-judge failed for **every** judge model, in **both** offline replay (`rubricJudge.js`) and shadow eval (`judge.js`). The candidate replay worked only because it passes `item.messages` (already an array).

Fix: wrap the prompt as `[{ role: "user", content: prompt }]` in both call sites.

## Re-run (also requested)
Adds a **Re-run** action to each eval row — starts a fresh eval with the same application, baseline, candidate and judge (reuses `POST /api/evals`; errors surface inline). Shown when the run has an application.

## Testing
Eval unit suites + lint + web build pass. After deploy, re-running your `qwen → gemma` eval with `gpt-4o-mini` as judge should finally produce real verdicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)