### PR TITLE
feat(ui): sidebar redesign, Recommendations page overhaul, and gateway benchmarks

### DIFF
--- a/server/src/analytics/aggregate.js
+++ b/server/src/analytics/aggregate.js
@@ -211,25 +211,31 @@ async function latencyPercentiles(filter) {
     {
       $group: {
         _id: null,
-        p50:     { $percentile: { input: "$latencyMs", p: [0.5],  method: "approximate" } },
-        p95:     { $percentile: { input: "$latencyMs", p: [0.95], method: "approximate" } },
-        p99:     { $percentile: { input: "$latencyMs", p: [0.99], method: "approximate" } },
-        ttftP50: { $percentile: { input: "$ttftMs",    p: [0.5],  method: "approximate" } },
-        ttftP95: { $percentile: { input: "$ttftMs",    p: [0.95], method: "approximate" } },
+        p50:         { $percentile: { input: "$latencyMs",        p: [0.5],  method: "approximate" } },
+        p95:         { $percentile: { input: "$latencyMs",        p: [0.95], method: "approximate" } },
+        p99:         { $percentile: { input: "$latencyMs",        p: [0.99], method: "approximate" } },
+        ttftP50:     { $percentile: { input: "$ttftMs",           p: [0.5],  method: "approximate" } },
+        ttftP95:     { $percentile: { input: "$ttftMs",           p: [0.95], method: "approximate" } },
+        overheadP50: { $percentile: { input: "$gatewayOverheadMs", p: [0.5],  method: "approximate" } },
+        overheadP95: { $percentile: { input: "$gatewayOverheadMs", p: [0.95], method: "approximate" } },
+        overheadP99: { $percentile: { input: "$gatewayOverheadMs", p: [0.99], method: "approximate" } },
       },
     },
     {
       $project: {
         _id: 0,
-        p50:     { $round: [{ $first: "$p50" },     0] },
-        p95:     { $round: [{ $first: "$p95" },     0] },
-        p99:     { $round: [{ $first: "$p99" },     0] },
-        ttftP50: { $round: [{ $first: "$ttftP50" }, 0] },
-        ttftP95: { $round: [{ $first: "$ttftP95" }, 0] },
+        p50:         { $round: [{ $first: "$p50" },         0] },
+        p95:         { $round: [{ $first: "$p95" },         0] },
+        p99:         { $round: [{ $first: "$p99" },         0] },
+        ttftP50:     { $round: [{ $first: "$ttftP50" },     0] },
+        ttftP95:     { $round: [{ $first: "$ttftP95" },     0] },
+        overheadP50: { $round: [{ $first: "$overheadP50" }, 0] },
+        overheadP95: { $round: [{ $first: "$overheadP95" }, 0] },
+        overheadP99: { $round: [{ $first: "$overheadP99" }, 0] },
       },
     },
   ]);
-  return row || { p50: null, p95: null, p99: null, ttftP50: null, ttftP95: null };
+  return row || { p50: null, p95: null, p99: null, ttftP50: null, ttftP95: null, overheadP50: null, overheadP95: null, overheadP99: null };
 }
 
 module.exports = {

--- a/web/src/components/Layout.jsx
+++ b/web/src/components/Layout.jsx
@@ -82,13 +82,13 @@ const icons = {
 
 // ── Navigation definition ─────────────────────────────────────────────────────
 const NAV_GROUPS = [
-  { section: "Connect", hint: "Wire apps & providers to the gateway", items: [
-    { to: "/models",   label: "Models",   icon: icons.models },
-    { to: "/settings", label: "Settings", icon: icons.settings },
-  ] },
   { section: "See", hint: "Know what you're spending, and where", items: [
     { to: "/", label: "Overview", end: true, icon: icons.overview },
     { to: "/applications", label: "Applications", icon: icons.applications },
+  ] },
+  { section: "Connect", hint: "Wire apps & providers to the gateway", items: [
+    { to: "/models",   label: "Models",   icon: icons.models },
+    { to: "/settings", label: "Settings", icon: icons.settings },
   ] },
   { section: "Recommend", hint: "Where a cheaper model fits", items: [
     { to: "/recommendations", label: "Recommendations", icon: icons.recommend },

--- a/web/src/components/Layout.jsx
+++ b/web/src/components/Layout.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { NavLink } from "react-router-dom";
 import { getAdminToken } from "../api.js";
 
@@ -81,8 +81,6 @@ const icons = {
 };
 
 // ── Navigation definition ─────────────────────────────────────────────────────
-// Grouped by the path a request takes through Arbr: Connect → See → Recommend → Route → Govern.
-// The `hint` is a one-line, plain-language descriptor of what each stage is for.
 const NAV_GROUPS = [
   { section: "Connect", hint: "Wire apps & providers to the gateway", items: [
     { to: "/models",   label: "Models",   icon: icons.models },
@@ -108,10 +106,10 @@ const NAV_GROUPS = [
 const FOOTER_LINK = { to: "/docs", label: "Docs", icon: icons.docs };
 
 function navClass({ isActive }) {
-  return `mx-1 my-0.5 flex items-center gap-2.5 rounded-lg px-3 py-2 text-[13.5px] font-medium transition-colors ${
+  return `mx-1 my-0.5 flex items-center gap-2.5 rounded-lg px-3 py-2 text-[13px] font-medium transition-colors ${
     isActive
       ? "bg-arbr-green-50 text-arbr-green-700"
-      : "text-gray-700 hover:bg-gray-100 hover:text-gray-900"
+      : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
   }`;
 }
 
@@ -125,35 +123,62 @@ function Wordmark() {
 }
 
 export default function Layout({ status, onSignOut, children }) {
+  const [collapsed, setCollapsed] = useState(new Set());
+
+  function toggleSection(section) {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(section)) next.delete(section);
+      else next.add(section);
+      return next;
+    });
+  }
+
   return (
     <div className="flex min-h-full">
-      <aside className="sticky top-0 flex h-screen w-56 flex-col border-r border-gray-100 bg-white">
+      <aside className="sticky top-0 flex h-screen w-60 flex-col border-r border-gray-100 bg-white">
         <div className="px-5 py-5">
           <Wordmark />
           <div className="mt-1 font-mono text-[10px] text-gray-400">control-plane</div>
         </div>
 
         <nav className="min-h-0 flex-1 overflow-y-auto px-2 py-1">
-          {NAV_GROUPS.map((group, gi) => (
-            <div key={group.section} className={gi > 0 ? "mt-3 border-t border-gray-100 pt-3" : ""}>
-              <div className="px-3">
-                <div className="text-xs font-bold uppercase tracking-wider text-gray-600">
-                  {group.section}
-                </div>
-                {group.hint && (
-                  <div className="mt-0.5 text-[11px] leading-snug text-gray-400">{group.hint}</div>
+          {NAV_GROUPS.map((group, gi) => {
+            const isCollapsed = collapsed.has(group.section);
+            return (
+              <div key={group.section} className={gi > 0 ? "mt-1" : ""}>
+                <button
+                  onClick={() => toggleSection(group.section)}
+                  title={group.hint}
+                  className="group flex w-full items-center justify-between rounded-md px-3 py-1.5 text-left transition-colors hover:bg-gray-50"
+                >
+                  <span className="text-[10.5px] font-semibold uppercase tracking-widest text-gray-400 transition-colors group-hover:text-gray-600">
+                    {group.section}
+                  </span>
+                  <svg
+                    className={`h-3 w-3 flex-shrink-0 text-gray-300 transition-transform duration-200 group-hover:text-gray-400 ${
+                      isCollapsed ? "-rotate-90" : ""
+                    }`}
+                    viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                    strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+                  >
+                    <polyline points="6 9 12 15 18 9"/>
+                  </svg>
+                </button>
+
+                {!isCollapsed && (
+                  <div className="mt-0.5 mb-1.5">
+                    {group.items.map((item) => (
+                      <NavLink key={item.to} to={item.to} end={item.end} className={navClass}>
+                        {item.icon}
+                        {item.label}
+                      </NavLink>
+                    ))}
+                  </div>
                 )}
               </div>
-              <div className="mt-1.5">
-                {group.items.map((item) => (
-                  <NavLink key={item.to} to={item.to} end={item.end} className={navClass}>
-                    {item.icon}
-                    {item.label}
-                  </NavLink>
-                ))}
-              </div>
-            </div>
-          ))}
+            );
+          })}
         </nav>
 
         <div className="px-2 pb-2">
@@ -164,7 +189,7 @@ export default function Layout({ status, onSignOut, children }) {
           {getAdminToken() && onSignOut && (
             <button
               onClick={onSignOut}
-              className="mx-1 mt-0.5 flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-900"
+              className="mx-1 mt-0.5 flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium text-gray-400 transition-colors hover:bg-gray-50 hover:text-gray-900"
             >
               <svg className="h-4 w-4 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/>

--- a/web/src/pages/Docs.jsx
+++ b/web/src/pages/Docs.jsx
@@ -29,7 +29,11 @@ const SCREENS = [
 
 export default function Docs() {
   const [status, setStatus] = useState(null);
-  useEffect(() => { api.status().then(setStatus).catch(() => {}); }, []);
+  const [latency, setLatency] = useState(null);
+  useEffect(() => {
+    api.status().then(setStatus).catch(() => {});
+    api.latencyPercentiles().then(setLatency).catch(() => {});
+  }, []);
 
   const base = typeof window !== "undefined" ? window.location.origin : "http://localhost:4100";
   const live = status?.liveProviders || [];
@@ -82,6 +86,54 @@ res = arbr.chat("Summarise this ticket: ...", model="auto", max_tokens=300)   # 
           model that fits the task. Every call is logged, costed, and governed — with
           <strong> human-approved</strong> rules and an AI policy, all reversible from these screens.
         </p>
+      </Card>
+
+      <Card title="Gateway performance">
+        <p className="mb-3 text-sm text-gray-600">
+          Live latency figures from your traffic — the same data shown on the Overview dashboard,
+          with gateway overhead broken out separately so you can see exactly what Arbr adds on top
+          of provider time.
+        </p>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-100">
+                <th className="pb-2 text-left text-xs font-semibold uppercase tracking-wider text-gray-400">Metric</th>
+                <th className="pb-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-400">P50</th>
+                <th className="pb-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-400">P95</th>
+                <th className="pb-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-400">P99</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-50">
+              {[
+                { label: "Total latency", p50: latency?.p50, p95: latency?.p95, p99: latency?.p99 },
+                { label: "Gateway overhead", p50: latency?.overheadP50, p95: latency?.overheadP95, p99: latency?.overheadP99 },
+                { label: "TTFT (streaming)", p50: latency?.ttftP50, p95: latency?.ttftP95, p99: null },
+              ].map(({ label, p50, p95, p99 }) => {
+                const fmt = (v) => v != null ? `${v.toLocaleString()} ms` : "—";
+                return (
+                  <tr key={label}>
+                    <td className="py-2.5 text-gray-700">{label}</td>
+                    <td className="py-2.5 text-right font-mono text-gray-600">{latency ? fmt(p50) : "…"}</td>
+                    <td className="py-2.5 text-right font-mono text-gray-600">{latency ? fmt(p95) : "…"}</td>
+                    <td className="py-2.5 text-right font-mono text-gray-600">{latency ? fmt(p99) : "…"}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+        <div className="mt-4 space-y-1 text-xs text-gray-400">
+          <p><strong className="text-gray-500">Total latency</strong> — wall-clock time from request received to full response delivered, including provider processing. Success requests only, last 30 days.</p>
+          <p><strong className="text-gray-500">Gateway overhead</strong> — time Arbr spends before dispatching to the LLM: routing decision, auth, classification, logging. This is what the gateway itself costs, excluding provider time.</p>
+          <p><strong className="text-gray-500">TTFT</strong> — time to first streaming token; only captured on streaming calls.</p>
+        </div>
+        <div className="mt-4">
+          <p className="mb-2 text-xs text-gray-500">Run the latency benchmark against your own instance:</p>
+          <CodeBlock lang="bash" code={`ARBR_GATEWAY_URL=http://localhost:4100 ARBR_API_KEY=ab_... \\
+  node server/scripts/latency-bench.js --requests 50 --concurrency 5
+# Add --stream to also measure TTFT. Results saved to bench/results/latency-YYYY-MM-DD.json`} />
+        </div>
       </Card>
 
       <Card title="Getting started — the Connect stage">

--- a/web/src/pages/Recommendations.jsx
+++ b/web/src/pages/Recommendations.jsx
@@ -2,20 +2,71 @@ import React, { useEffect, useState } from "react";
 import { api, fmt } from "../api.js";
 import { Card, Badge, Spinner } from "../components/ui.jsx";
 
-const EVAL_TONE = { not_started: "gray", dataset_ready: "gray", running: "amber", passed: "green", failed: "red", overridden: "amber" };
+const EVAL_TONE  = { not_started: "gray", dataset_ready: "gray", running: "amber", passed: "green", failed: "red", overridden: "amber" };
 const EVAL_LABEL = { not_started: "No eval", dataset_ready: "Dataset ready", running: "Evaluating…", passed: "Eval passed", failed: "Eval failed", overridden: "Overridden" };
+
 const pct = (n) => (n == null ? "—" : `${(n * 100).toFixed(1)}%`);
 
-// Evidence summary line from a run/quality summary.
+// Derive 3-step workflow state from evalStatus.
+function stepsFromEvalStatus(evalStatus) {
+  const s = evalStatus || "not_started";
+  return [
+    {
+      id: "dataset", label: "Build dataset",
+      status: ["dataset_ready", "running", "passed", "failed", "overridden"].includes(s) ? "done" : "active",
+    },
+    {
+      id: "eval", label: "Run eval",
+      status: s === "running" ? "running" : s === "failed" ? "failed" : ["passed", "overridden"].includes(s) ? "done" : s === "dataset_ready" ? "active" : "idle",
+    },
+    {
+      id: "canary", label: "Start canary",
+      status: s === "passed" ? "active" : "idle",
+    },
+  ];
+}
+
+const DOT_CLASS = {
+  done:    "w-6 h-6 rounded-full bg-arbr-green-600 text-white flex items-center justify-center text-xs font-medium",
+  active:  "w-6 h-6 rounded-full border-2 border-arbr-green-600 text-arbr-green-600 flex items-center justify-center text-xs font-medium",
+  running: "w-6 h-6 rounded-full border-2 border-amber-400 text-amber-500 flex items-center justify-center text-xs font-medium animate-pulse",
+  failed:  "w-6 h-6 rounded-full border-2 border-red-400 text-red-500 flex items-center justify-center text-xs font-medium",
+  idle:    "w-6 h-6 rounded-full border-2 border-gray-200 text-gray-300 flex items-center justify-center text-xs font-medium",
+};
+const DOT_TEXT = {
+  done: "text-arbr-green-700 font-medium", active: "text-arbr-green-600 font-medium",
+  running: "text-amber-600", failed: "text-red-600", idle: "text-gray-300",
+};
+
+function StepTracker({ steps }) {
+  return (
+    <div className="flex items-center">
+      {steps.map((step, i) => (
+        <React.Fragment key={step.id}>
+          <div className="flex items-center gap-2 shrink-0">
+            <div className={DOT_CLASS[step.status]}>
+              {step.status === "done" ? "✓" : i + 1}
+            </div>
+            <span className={`text-xs ${DOT_TEXT[step.status]}`}>{step.label}</span>
+          </div>
+          {i < steps.length - 1 && (
+            <div className={`flex-1 h-px mx-3 min-w-8 ${step.status === "done" ? "bg-arbr-green-200" : "bg-gray-100"}`} />
+          )}
+        </React.Fragment>
+      ))}
+    </div>
+  );
+}
+
 function QualitySummary({ s }) {
   if (!s) return null;
   return (
-    <div className="mt-3 flex flex-wrap gap-2 text-xs">
+    <div className="flex flex-wrap gap-2">
       <Badge tone="gray">{fmt.num(s.judged)} judged</Badge>
       <Badge tone={s.worseRate > 0.05 ? "red" : "green"}>worse {pct(s.worseRate)}</Badge>
       {s.criticalFailRate != null && <Badge tone={s.criticalFailRate > 0 ? "red" : "gray"}>critical {pct(s.criticalFailRate)}</Badge>}
       <Badge tone="gray">format {pct(s.formatPassRate)}</Badge>
-      <Badge tone="green">cost −{pct(s.costSavingPct)}</Badge>
+      <Badge tone="green">cost -{pct(s.costSavingPct)}</Badge>
       {s.avgLatencyDeltaPct != null && <Badge tone="gray">latency {s.avgLatencyDeltaPct > 0 ? "+" : ""}{pct(s.avgLatencyDeltaPct)}</Badge>}
     </div>
   );
@@ -50,90 +101,146 @@ function RecCard({ rec, models, onChange }) {
     } finally { setBusy(false); }
   };
 
+  // Collapsed card for accepted/dismissed recommendations.
+  if (rec.status !== "pending") {
+    const tone = rec.status === "accepted" ? "green" : "gray";
+    return (
+      <Card>
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3 min-w-0 overflow-hidden">
+            <Badge tone={tone}>{rec.status === "accepted" ? "Accepted" : "Dismissed"}</Badge>
+            <span className="text-sm text-arbr-charcoal font-mono truncate">
+              {rec.currentModel} → {rec.suggestedModel}
+            </span>
+            {rec.taskType && <span className="text-xs text-gray-400 truncate hidden sm:block">· {rec.taskType}</span>}
+            {rec.application && <span className="text-xs text-gray-400 truncate hidden sm:block">· {rec.application}</span>}
+          </div>
+          <span className="shrink-0 text-sm font-semibold text-arbr-green-600">{fmt.usd(rec.projectedSavings)} saved</span>
+        </div>
+      </Card>
+    );
+  }
+
+  const steps = stepsFromEvalStatus(evalStatus);
+  const noReplayable = rec.replayableCount === 0;
+
   return (
     <Card>
+      {/* Section 1: Header */}
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
-          <div className="flex items-center gap-2">
-            <h3 className="text-base font-semibold text-arbr-charcoal">{rec.title}</h3>
-            {rec.status === "accepted" && <Badge tone="green">Accepted</Badge>}
-            {rec.status === "dismissed" && <Badge tone="gray">Dismissed</Badge>}
-            {rec.status === "pending" && <Badge tone="amber">Pending</Badge>}
-            <Badge tone={EVAL_TONE[evalStatus]}>{EVAL_LABEL[evalStatus]}</Badge>
-          </div>
-          <p className="mt-2 text-sm text-gray-600">{rec.reason}</p>
-          <div className="mt-3 flex flex-wrap gap-2 text-xs">
-            {rec.application && <Badge tone="charcoal">app: {rec.application}</Badge>}
-            <Badge tone="charcoal">{rec.currentModel} → {rec.suggestedModel}</Badge>
-            <Badge tone="gray">{fmt.num(rec.requestCount)} requests</Badge>
+          <div className="label mb-1">Recommendation</div>
+          <h3 className="text-base font-semibold text-arbr-charcoal">
+            {rec.taskType || rec.title}
+          </h3>
+          <p className="mt-0.5 text-xs text-gray-400">
+            {fmt.num(rec.requestCount)} requests
+            {rec.application ? ` · ${rec.application}` : ""}
             {rec.replayableCount != null && (
-              <Badge tone={rec.replayableCount === 0 ? "red" : "gray"}>{fmt.num(rec.replayableCount)} replayable</Badge>
+              <span className={rec.replayableCount === 0 ? " text-red-500" : ""}>
+                {" "}· {fmt.num(rec.replayableCount)} replayable
+              </span>
             )}
-          </div>
-          <QualitySummary s={rec.qualitySummary} />
+          </p>
         </div>
-        <div className="shrink-0 text-right">
-          <div className="label">Projected saving</div>
-          <div className="text-2xl font-bold text-arbr-green-600">{fmt.usd(rec.projectedSavings)}</div>
-          <div className="text-xs text-gray-500">{fmt.usd(rec.currentCost)} → {fmt.usd(rec.projectedCost)}</div>
+        <div className="flex items-center gap-2 shrink-0">
+          <Badge tone="amber">Pending</Badge>
+          <Badge tone={EVAL_TONE[evalStatus]}>{EVAL_LABEL[evalStatus]}</Badge>
         </div>
       </div>
 
-      {rec.status === "pending" && (
-        <div className="mt-4 border-t border-gray-100 pt-4">
-          {/* Eval-backed flow: prove quality, then roll out under control. */}
-          <div className="flex flex-wrap items-center gap-2">
-            {(evalStatus === "not_started") && (
-              rec.replayableCount === 0 ? (
-                <span className="text-sm text-gray-500">
-                  No replayable traffic yet — this recommendation's requests have no captured prompts.
-                  Turn on payload capture (Settings → Observability); only traffic logged after it is enabled can be evaluated.
-                </span>
-              ) : (
-                <button className="btn-secondary text-sm" disabled={busy}
-                  onClick={() => run(() => api.createEvalDataset(rec._id), (d) => `Dataset built: ${d.itemCount} items (${d.riskTier} risk).`)}>
-                  Build eval dataset
-                </button>
-              )
-            )}
-            {(evalStatus === "dataset_ready" || evalStatus === "failed") && (
-              <>
-                <select className="input text-sm" value={judge} onChange={(e) => setJudge(e.target.value)} title="Judge model">
-                  <option value="">Judge: none</option>
-                  {models.map((m) => <option key={m.id} value={m.id}>Judge: {m.label || m.id}</option>)}
-                </select>
-                <button className="btn-secondary text-sm" disabled={busy}
-                  onClick={() => run(() => api.runEval(rec._id, { judgeModel: judge || null }), () => "Offline eval started — refresh in a moment.")}>
-                  Run offline eval
-                </button>
-              </>
-            )}
-            {evalStatus === "running" && <span className="text-sm text-amber-600">Evaluating… refresh to see the result.</span>}
-            {evalStatus === "passed" && (
-              <>
-                <input className="input text-sm" placeholder="application for rollout" value={application} onChange={(e) => setApplication(e.target.value)} />
-                <button className="btn-secondary text-sm" disabled={busy || !application.trim()}
-                  onClick={() => run(() => api.createCanary(rec._id, { application: application.trim() }), (x) => `Canary started at ${x.rolloutPct}%.`)}>
-                  Start canary
-                </button>
-              </>
-            )}
-            <button className="btn-outline text-sm" disabled={busy} onClick={accept}>Accept as rule</button>
-            <button className="btn-outline text-sm" disabled={busy} onClick={() => run(() => api.dismissRecommendation(rec._id))}>Dismiss</button>
+      {/* Section 2: Model substitution + Savings */}
+      <div className="mt-4 pt-4 border-t border-gray-100 flex gap-6">
+        <div className="flex-1 min-w-0">
+          <div className="label mb-2">Model substitution</div>
+          <div className="flex flex-col items-start gap-1.5">
+            <span className="inline-block bg-gray-100 text-arbr-charcoal rounded px-2 py-1 text-xs font-mono">
+              {rec.currentModel}
+            </span>
+            <span className="text-xs text-arbr-green-600 pl-2 leading-none select-none">↓</span>
+            <span className="inline-block bg-arbr-green-50 text-arbr-green-700 border border-arbr-green-200 rounded px-2 py-1 text-xs font-mono">
+              {rec.suggestedModel}
+            </span>
           </div>
-          <p className="mt-2 text-xs text-gray-400">
-            Accepting creates a routing rule (off until you switch it on). It is gated on a passed eval; without one you'll be asked for an override reason.
-          </p>
-          {notice && <div className="mt-2 text-sm text-arbr-green-700">{notice}</div>}
-          {err && <div className="mt-2 text-sm text-red-600">{err}</div>}
         </div>
-      )}
+        <div className="border-l border-gray-100 pl-6 shrink-0 text-right">
+          <div className="label mb-1">Projected saving</div>
+          <div className="text-3xl font-bold text-arbr-green-600">{fmt.usd(rec.projectedSavings)}</div>
+          <div className="mt-0.5 text-xs text-gray-500">{fmt.usd(rec.currentCost)} → {fmt.usd(rec.projectedCost)}</div>
+          <div className="mt-0.5 text-xs text-gray-400">{fmt.num(rec.requestCount)} requests</div>
+        </div>
+      </div>
+
+      {/* Section 3: Evaluation workflow */}
+      <div className="mt-4 pt-4 border-t border-gray-100">
+        <div className="label mb-3">Evaluation workflow</div>
+        <StepTracker steps={steps} />
+        <div className="mt-4">
+          {evalStatus === "not_started" && (
+            noReplayable ? (
+              <p className="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+                No replayable traffic yet — captured prompts are required to build a dataset.
+                Turn on payload capture in <strong>Settings → Observability</strong>; only traffic logged after it is enabled can be evaluated.
+              </p>
+            ) : (
+              <button className="btn-secondary text-sm" disabled={busy}
+                onClick={() => run(() => api.createEvalDataset(rec._id), (d) => `Dataset built: ${d.itemCount} items (${d.riskTier} risk).`)}>
+                Build eval dataset
+              </button>
+            )
+          )}
+          {(evalStatus === "dataset_ready" || evalStatus === "failed") && (
+            <div className="flex flex-wrap items-center gap-2">
+              <select className="input text-sm" value={judge} onChange={(e) => setJudge(e.target.value)}>
+                <option value="">Judge: none</option>
+                {models.map((m) => <option key={m.id} value={m.id}>Judge: {m.label || m.id}</option>)}
+              </select>
+              <button className="btn-secondary text-sm" disabled={busy}
+                onClick={() => run(() => api.runEval(rec._id, { judgeModel: judge || null }), () => "Offline eval started — refresh in a moment.")}>
+                Run offline eval
+              </button>
+            </div>
+          )}
+          {evalStatus === "running" && (
+            <span className="text-sm text-amber-600">Evaluating… refresh to see the result.</span>
+          )}
+          {evalStatus === "passed" && (
+            <div className="flex flex-wrap items-center gap-2">
+              <input className="input text-sm" placeholder="application for rollout" value={application}
+                onChange={(e) => setApplication(e.target.value)} />
+              <button className="btn-secondary text-sm" disabled={busy || !application.trim()}
+                onClick={() => run(() => api.createCanary(rec._id, { application: application.trim() }), (x) => `Canary started at ${x.rolloutPct}%.`)}>
+                Start canary
+              </button>
+            </div>
+          )}
+          {notice && <p className="mt-2 text-sm text-arbr-green-700">{notice}</p>}
+          {err    && <p className="mt-2 text-sm text-red-600">{err}</p>}
+        </div>
+        {rec.qualitySummary && (
+          <div className="mt-3 pt-3 border-t border-gray-100">
+            <QualitySummary s={rec.qualitySummary} />
+          </div>
+        )}
+      </div>
+
+      {/* Section 4: Decisions */}
+      <div className="mt-4 pt-4 border-t border-gray-100 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <button className="btn-outline text-sm" disabled={busy} onClick={accept}>Accept as rule</button>
+          <button className="btn-outline text-sm" disabled={busy}
+            onClick={() => run(() => api.dismissRecommendation(rec._id))}>Dismiss</button>
+        </div>
+        <p className="text-xs text-gray-400">
+          Accepting creates a routing rule (off until you switch it on).
+          Gated on a passed eval; without one you'll be asked for an override reason.
+        </p>
+      </div>
     </Card>
   );
 }
 
-// Self-diagnosing empty state: instead of a dead end, explain what was analyzed and surface
-// high-spend task types that are excluded only because they aren't marked cheap — with a
+// Self-diagnosing empty state: surface high-spend task types not yet marked cheap — with a
 // one-click "mark cheap & recompute". Falls back gracefully if the analysis endpoint is absent.
 function EmptyState({ analysis, busy, onMarkCheap }) {
   if (!analysis) {
@@ -153,7 +260,7 @@ function EmptyState({ analysis, busy, onMarkCheap }) {
       <Card>
         <div className="py-8 text-center text-gray-500">
           <div className="text-arbr-charcoal font-medium">Nothing to optimise right now.</div>
-          <p className="mt-1 text-sm text-gray-400">{analyzed} No premium model is overused on a cheap task — cheap-task traffic is already on lighter models.</p>
+          <p className="mt-1 text-sm text-gray-400">{analyzed} No premium model is overused on a cheap task.</p>
         </div>
       </Card>
     );
@@ -224,7 +331,6 @@ export default function Recommendations({ embedded = false }) {
     finally { setBusy(false); }
   };
 
-  // One-click: mark the given task types cheap (union with the current set), then recompute.
   const markCheapAndRecompute = async (taskTypes) => {
     setBusy(true); setErr(null);
     try {
@@ -241,7 +347,9 @@ export default function Recommendations({ embedded = false }) {
       <div className="flex items-start justify-between">
         <div>
           {!embedded && <h1 className="text-2xl font-bold text-arbr-charcoal">Recommendations</h1>}
-          <p className="text-sm text-gray-500">Costed suggestions. Prove a cheaper model is no worse than the current one, then roll out under control — the system proposes, the human decides.</p>
+          <p className="text-sm text-gray-500">
+            Costed suggestions. Prove a cheaper model is no worse than the current one, then roll out under control — the system proposes, the human decides.
+          </p>
         </div>
         <button className="btn-primary" onClick={recompute} disabled={busy}>
           {busy ? "Recomputing…" : "Recompute"}
@@ -249,7 +357,10 @@ export default function Recommendations({ embedded = false }) {
       </div>
 
       {err && <div className="text-red-600">{err}</div>}
-      {recs === null ? <Spinner /> : recs.length === 0 ? (
+
+      {recs === null ? (
+        <Spinner />
+      ) : recs.length === 0 ? (
         <EmptyState analysis={analysis} busy={busy} onMarkCheap={markCheapAndRecompute} />
       ) : (
         <div className="space-y-4">


### PR DESCRIPTION
## Summary

- **Sidebar**: Section headers (Connect / See / Recommend / Route / Govern) are now clickable collapse/expand toggles with an animated chevron. Inline hint text moved to native browser tooltips — cleaner layout, same discoverability. Width bumped `w-56` → `w-60`. Section order fixed to: See → Connect → Recommend → Route → Govern.
- **Recommendations page**: Full card redesign into 4 structured sections (Header · Model Substitution + Savings · Workflow Stepper · Decisions). 3-step `StepTracker` component derived from `evalStatus`. Accepted/Dismissed recs collapse to a compact single-row format.
- **Eval dataset fix**: Relaxed `isSingleShot` to allow few-shot patterns (intermediate assistant turns before a final user turn), fixing the 422 error on "Build eval dataset".
- **Docs — Gateway performance**: New live benchmarks card showing P50/P95/P99 for total latency, gateway overhead, and TTFT — sourced from real traffic via the existing `/api/analytics/latency-percentiles` endpoint. Gateway overhead percentiles added to `aggregate.js`. Includes a self-benchmark shell command.

## Test plan

- [ ] Sidebar: all 5 sections visible, no description text inline
- [ ] Click a section header — items collapse/expand, chevron rotates
- [ ] Hover section header — tooltip shows the description hint
- [ ] Section order: See → Connect → Recommend → Route → Govern
- [ ] Recommendations page renders 4 clear sections per card
- [ ] Step tracker shows correct active step based on `evalStatus`
- [ ] "Build eval dataset" no longer returns 422 for few-shot prompt patterns
- [ ] Docs → "Gateway performance" card loads live latency figures
- [ ] Gateway overhead row shows values (or "—" if `gatewayOverheadMs` not yet populated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)