### PR TITLE
fix(gateway): capture gatewayOverheadMs on all openaiCompat success paths

### DIFF
--- a/server/src/gateway/openaiCompat.js
+++ b/server/src/gateway/openaiCompat.js
@@ -593,7 +593,7 @@ async function handleOpenAICompat(req, res) {
           provider: served.provider, model: served.model, modelRequested,
           taskType, classifiedBy, difficulty, difficultyScore, confidence,
           promptTokens, completionTokens, totalTokens, cachedReadTokens, cacheWriteTokens,
-          latencyMs: Date.now() - start, status: "success", routingDecision, routingExplain: explain, cacheHit: false,
+          latencyMs: Date.now() - start, gatewayOverheadMs: start - _reqStart, status: "success", routingDecision, routingExplain: explain, cacheHit: false,
           knownPricing: served.knownPricing,
           messages: body.messages, responseText: chunkText(aiMsg) || null,
         })
@@ -730,7 +730,7 @@ async function handleOpenAICompat(req, res) {
         provider: result.providerId, model: result.modelId, modelRequested,
         taskType, classifiedBy, difficulty, difficultyScore, confidence,
         promptTokens, completionTokens, totalTokens, cachedReadTokens, cacheWriteTokens,
-        latencyMs: Date.now() - start, status: "success", routingDecision, routingExplain: explain, cacheHit: false,
+        latencyMs: Date.now() - start, gatewayOverheadMs: start - _reqStart, status: "success", routingDecision, routingExplain: explain, cacheHit: false,
         knownPricing: served.knownPricing,
         messages: body.messages, responseText: result.text,
       })
@@ -741,6 +741,7 @@ async function handleOpenAICompat(req, res) {
   // — Non-streaming ——————————————————————————————————————————————————————————————
   setGatewayHeaders(res, { requestId, model: served.model, provider: served.provider,
     routing: routingDecision, taskType });
+  const _llmStart = Date.now();
   let invocation;
   try {
     invocation = await invokeWithFallback(router, eff, {
@@ -810,7 +811,7 @@ async function handleOpenAICompat(req, res) {
       totalTokens:      result.usage?.totalTokens  || 0,
       cachedReadTokens: result.usage?.cachedReadTokens || 0,
       cacheWriteTokens: result.usage?.cacheWriteTokens || 0,
-      latencyMs: result.latencyMs, status: "success", routingDecision, routingExplain: explain, cacheHit: false,
+      latencyMs: result.latencyMs, gatewayOverheadMs: _llmStart - _reqStart, status: "success", routingDecision, routingExplain: explain, cacheHit: false,
       knownPricing: served.knownPricing,
       messages: body.messages, responseText: result.text,
     });


### PR DESCRIPTION
## Summary

PR #113 only captured `gatewayOverheadMs` on the `proxyOpenAICompat` (fetch-proxy) path. Three other paths in `handleOpenAICompat` log success records but were missing it:

- **Native tool model path** — `isNativeToolModel` (Bedrock/Anthropic tool calls): now uses `start - _reqStart`
- **SSE streaming via LangChain** (`invokeWithFallback` stream path): now uses `start - _reqStart`
- **Non-streaming via LangChain** (`invokeWithFallback` non-stream path): adds `_llmStart = Date.now()` before the call, uses `_llmStart - _reqStart`

All four paths now consistently record gateway overhead as the time from request entry to just before the LLM call is dispatched.

## Test plan

- [ ] Send a non-streaming request via `/v1/chat/completions` — check the logged `RequestRecord` has a non-null `gatewayOverheadMs`
- [ ] Docs → Gateway performance — "Gateway overhead" row shows ms values instead of "—"

🤖 Generated with [Claude Code](https://claude.com/claude-code)