### PR TITLE
Reusable benchmarks + model leaderboard + quality-per-dollar (DashBench must-haves)

### DIFF
--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -38,6 +38,7 @@ const { summarizeEvalPairs } = require("../eval/logic");
 const evalDatasetBuilder = require("../eval/dataset");
 const evalReplay = require("../eval/replay");
 const evalThresholds = require("../eval/thresholds");
+const { efficiencyOf } = require("../eval/efficiency");
 const { sameFamily } = require("../eval/rubricJudge");
 const { tierForTask } = require("../classify/classifier");
 const RoutingExperiment = require("../models/RoutingExperiment");
@@ -820,6 +821,90 @@ router.get("/evals/traffic-models", async (req, res, next) => {
       { $sort: { count: -1 } },
     ]);
     res.json(rows.map((r) => ({ model: r._id.model, provider: r._id.provider, count: r.count })));
+  } catch (e) { next(e); }
+});
+
+// ── Reusable benchmarks ("DashBench") ─────────────────────────────────────────
+// A benchmark is a NAMED, frozen set of an application's traffic. Run many candidate models
+// against the SAME set and rank them by quality-per-dollar on your own workload — the point
+// DoorDash's DashBench proved: generic leaderboards don't predict your traffic.
+
+// Build a benchmark from an application's replayable traffic (candidate-agnostic).
+router.post("/eval-benchmarks", async (req, res, next) => {
+  try {
+    const { name, application, taskType, baselineModel, targetCount, windowDays } = req.body || {};
+    if (!name || !name.trim()) return res.status(400).json({ error: "name is required" });
+    if (!application) return res.status(400).json({ error: "application is required" });
+    if (!baselineModel) return res.status(400).json({ error: "baselineModel is required" });
+    // rec-shaped scope with no candidate — the benchmark is scored against many candidates later.
+    const scope = { _id: null, application, taskType: taskType || null, currentModel: baselineModel, suggestedModel: null };
+    const dataset = await evalDatasetBuilder.createFromTraffic({ rec: scope, targetCount, windowDays, isBenchmark: true, name: name.trim() });
+    if (dataset.status !== "ready") {
+      const body = dataset.toObject ? dataset.toObject() : dataset;
+      return res.status(422).json({ ...body, error: "no_replayable_traffic", message: dataset.error });
+    }
+    setImmediate(() => logAction("benchmark.create", "evalDataset", String(dataset._id), { name: name.trim(), application, baselineModel, itemCount: dataset.itemCount }));
+    res.status(201).json(dataset);
+  } catch (e) { next(e); }
+});
+
+// List benchmarks with their run counts.
+router.get("/eval-benchmarks", async (req, res, next) => {
+  try {
+    const benches = await EvalDataset.find({ isBenchmark: true }).sort({ createdAt: -1 }).lean();
+    const withCounts = await Promise.all(benches.map(async (b) => ({
+      ...b, runCount: await EvalRun.countDocuments({ datasetId: b._id }),
+    })));
+    res.json(withCounts);
+  } catch (e) { next(e); }
+});
+
+// One benchmark + its leaderboard: every candidate run, ranked by quality-per-dollar.
+router.get("/eval-benchmarks/:id", async (req, res, next) => {
+  try {
+    const bench = await EvalDataset.findById(req.params.id).lean().catch(() => null);
+    if (!bench || !bench.isBenchmark) return res.status(404).json({ error: "not found" });
+    const runs = await EvalRun.find({ datasetId: bench._id }).sort({ createdAt: -1 }).lean();
+    const leaderboard = runs.map((r) => ({
+      ...r, efficiency: efficiencyOf(r.summary, r.actualCostUsd),
+    })).sort((a, b) => (b.efficiency.qualityPerDollar ?? -1) - (a.efficiency.qualityPerDollar ?? -1));
+    res.json({ ...bench, leaderboard });
+  } catch (e) { next(e); }
+});
+
+// Score a candidate model against the benchmark (a new EvalRun over the same frozen items).
+router.post("/eval-benchmarks/:id/run", async (req, res, next) => {
+  try {
+    const bench = await EvalDataset.findById(req.params.id).catch(() => null);
+    if (!bench || !bench.isBenchmark) return res.status(404).json({ error: "not found" });
+    if (bench.status !== "ready") return res.status(409).json({ error: "benchmark not ready" });
+    const { candidateModel, judgeModel, maxRunCostUsd } = req.body || {};
+    if (!candidateModel) return res.status(400).json({ error: "candidateModel is required" });
+    if (candidateModel === bench.baselineModel) return res.status(400).json({ error: "candidate must differ from the benchmark baseline" });
+    if (bench.riskTier === "high" && judgeModel && sameFamily(judgeModel, candidateModel)) {
+      return res.status(422).json({ error: "judge_same_family", message: "For high-risk tasks the judge must not be from the candidate's model family." });
+    }
+    // The benchmark IS the sample, so don't gate on the promotion floor — score whatever it holds.
+    const thresholds = evalThresholds.defaultThresholds(evalThresholds.riskForTier(tierForTask(bench.scope?.taskType)));
+    thresholds.minItems = Math.max(1, bench.itemCount || 1);
+    const run = await evalReplay.startRun({ rec: null, dataset: bench, judgeModel: judgeModel || null, thresholds, candidateModel, maxRunCostUsd: maxRunCostUsd ?? null });
+    setImmediate(() => logAction("benchmark.run", "evalRun", String(run._id), { benchmarkId: String(bench._id), candidateModel, judgeModel: judgeModel || null }));
+    res.status(run.status === "failed" ? 422 : 201).json(run);
+  } catch (e) { next(e); }
+});
+
+// Delete a benchmark and everything derived from it (items, its runs, their results).
+router.delete("/eval-benchmarks/:id", async (req, res, next) => {
+  try {
+    const bench = await EvalDataset.findById(req.params.id).lean().catch(() => null);
+    if (!bench || !bench.isBenchmark) return res.status(404).json({ error: "not found" });
+    const runs = await EvalRun.find({ datasetId: bench._id }, { _id: 1 }).lean();
+    await EvalResult.deleteMany({ evalRunId: { $in: runs.map((r) => r._id) } });
+    await EvalRun.deleteMany({ datasetId: bench._id });
+    await EvalItem.deleteMany({ datasetId: bench._id });
+    await EvalDataset.deleteOne({ _id: bench._id });
+    setImmediate(() => logAction("benchmark.delete", "evalDataset", String(req.params.id), { name: bench.name }));
+    res.json({ ok: true });
   } catch (e) { next(e); }
 });
 

--- a/server/src/eval/dataset.js
+++ b/server/src/eval/dataset.js
@@ -109,7 +109,7 @@ function projectText(record, piiMode, maskEnabled, customPatterns) {
 }
 
 // Create a dataset from traffic. Returns the persisted EvalDataset (status "ready" or "failed").
-async function createFromTraffic({ rec, targetCount, piiMode = "masked", windowDays = DEFAULT_WINDOW_DAYS, createdBy = "console" } = {}) {
+async function createFromTraffic({ rec, targetCount, piiMode = "masked", windowDays = DEFAULT_WINDOW_DAYS, createdBy = "console", isBenchmark = false, name = null } = {}) {
   const risk = riskForTier(tierForTask(rec.taskType));
   const target = targetCount || targetCountForRisk(risk);
   const settings = await Settings.get().catch(() => ({}));
@@ -120,8 +120,10 @@ async function createFromTraffic({ rec, targetCount, piiMode = "masked", windowD
 
   const since = new Date(Date.now() - windowDays * 86400000);
   const dataset = await EvalDataset.create({
-    name: `${rec.taskType || "task"}: ${rec.currentModel} → ${rec.suggestedModel}`,
-    recommendationId: rec._id,
+    // A benchmark is user-named and candidate-agnostic (candidates are chosen per run).
+    name: name || `${rec.taskType || "task"}: ${rec.currentModel} → ${rec.suggestedModel}`,
+    isBenchmark: !!isBenchmark,
+    recommendationId: rec._id || null,
     scope: {
       application: rec.application || null, workflow: null, taskType: rec.taskType || null,
       currentModel: rec.currentModel || null, department: null, difficulty: null,

--- a/server/src/eval/efficiency.js
+++ b/server/src/eval/efficiency.js
@@ -1,0 +1,35 @@
+// Quality-per-dollar — the one legible "intelligence per dollar" number for a benchmark run.
+// Pure + dependency-free so it unit-tests without a DB. (DoorDash's DashBench lesson: rank
+// candidates on YOUR traffic by quality vs cost, and price the model on cost-per-SUCCESSFUL
+// response — retries/format failures included — not the sticker rate.)
+//
+//   summary       — an EvalRun.summary: { judged, worseRate, formatPassRate, ... }
+//   actualCostUsd — the candidate's real spend over the replayed items (excludes the judge)
+//
+// Returns { qualityScore, costPer1kUsd, qualityPerDollar } — any field null when it can't be
+// computed (nothing judged, or zero cost). Higher qualityPerDollar is better.
+function efficiencyOf(summary, actualCostUsd) {
+  const s = summary || {};
+  const judged = Number(s.judged) || 0;
+  if (judged <= 0) return { qualityScore: null, costPer1kUsd: null, qualityPerDollar: null };
+
+  // Quality = share of judged items where the candidate was NOT worse than the baseline, discounted
+  // by how often it produced a usable (format-valid) response. A model that's "as good" but emits
+  // malformed output half the time should not rank as high-quality.
+  const notWorse = 1 - Math.max(0, Math.min(1, Number(s.worseRate) || 0));
+  const formatPass = s.formatPassRate == null ? 1 : Math.max(0, Math.min(1, Number(s.formatPassRate)));
+  const qualityScore = +(notWorse * formatPass).toFixed(4);
+
+  // Cost per 1,000 requests = the candidate's average real cost per replayed item, scaled up.
+  const cost = Number(actualCostUsd) || 0;
+  const costPer1kUsd = cost > 0 ? +((cost / judged) * 1000).toFixed(4) : 0;
+
+  // Quality per dollar (per 1k requests). Free models (cost 0) rank by quality alone → Infinity,
+  // which sorts them first; that's intended (free + good is the best deal).
+  const qualityPerDollar = costPer1kUsd > 0 ? +(qualityScore / costPer1kUsd).toFixed(4)
+    : (qualityScore > 0 ? Infinity : 0);
+
+  return { qualityScore, costPer1kUsd, qualityPerDollar };
+}
+
+module.exports = { efficiencyOf };

--- a/server/src/eval/replay.js
+++ b/server/src/eval/replay.js
@@ -72,9 +72,12 @@ function estimateRunCost(items, baselineModel, candidateModel, judgeModel, getMo
 }
 
 // Kick off a run in the background. Validates cost ceiling up front. Returns the created EvalRun.
-async function startRun({ rec, dataset, judgeModel, thresholds, maxRunCostUsd = null, createdBy = "console", exploratory = false }) {
+async function startRun({ rec, dataset, judgeModel, thresholds, maxRunCostUsd = null, createdBy = "console", exploratory = false, candidateModel = null }) {
+  // The candidate can be supplied per-run (a reusable benchmark tests many candidates against one
+  // frozen set); it falls back to the dataset's own candidate for the classic one-shot eval.
+  const candidate = candidateModel || dataset.candidateModel;
   const items = await EvalItem.find({ datasetId: dataset._id }).lean();
-  const estimatedCostUsd = estimateRunCost(items, dataset.baselineModel, dataset.candidateModel, judgeModel);
+  const estimatedCostUsd = estimateRunCost(items, dataset.baselineModel, candidate, judgeModel);
 
   const run = await EvalRun.create({
     recommendationId: rec ? rec._id : null,
@@ -84,7 +87,7 @@ async function startRun({ rec, dataset, judgeModel, thresholds, maxRunCostUsd = 
     workflow: dataset.scope?.workflow || null,
     taskType: dataset.scope?.taskType || null,
     baselineModel: dataset.baselineModel,
-    candidateModel: dataset.candidateModel,
+    candidateModel: candidate,
     judgeModel: judgeModel || null,
     riskTier: dataset.riskTier,
     fidelity: dataset.piiMode === "raw_allowed" ? "high" : (dataset.piiMode === "metadata_only" ? "metadata_only" : "masked"),
@@ -127,9 +130,9 @@ async function executeRun(runId) {
   const settings = await require("../models/Settings").get().catch(() => ({}));
   const maskEnabled = !!settings.piiMaskingEnabled;
   const customPatterns = settings.customPiiPatterns || [];
-  const cm = pricing.getModel(dataset.candidateModel);
+  const cm = pricing.getModel(run.candidateModel);
   if (!cm || !eff.liveIds.includes(cm.provider)) {
-    return finish(run, [], `candidate model "${dataset.candidateModel}" is not on a live provider`);
+    return finish(run, [], `candidate model "${run.candidateModel}" is not on a live provider`);
   }
 
   const entries = [];
@@ -151,9 +154,9 @@ async function executeRun(runId) {
     }
     try {
       const candidate = await router.complete({
-        messages: item.messages, providerOverride: cm.provider, modelOverride: dataset.candidateModel,
+        messages: item.messages, providerOverride: cm.provider, modelOverride: run.candidateModel,
       });
-      const candCost = pricing.costFor(dataset.candidateModel, candidate.usage?.inputTokens || 0, candidate.usage?.outputTokens || 0).totalCost;
+      const candCost = pricing.costFor(run.candidateModel, candidate.usage?.inputTokens || 0, candidate.usage?.outputTokens || 0).totalCost;
       actualCost += candCost;
       const { formatPass, results } = runValidators(candidate.text, item.validators);
       const flip = Math.random() < 0.5; // A/B position de-bias
@@ -168,7 +171,7 @@ async function executeRun(runId) {
       const storedResp = clampText(maskEnabled ? maskPii(candidate.text || "", customPatterns) : (candidate.text || ""));
       await EvalResult.create({
         evalRunId: run._id, evalItemId: item._id, requestId: item.requestId,
-        baselineModel: dataset.baselineModel, candidateModel: dataset.candidateModel,
+        baselineModel: dataset.baselineModel, candidateModel: run.candidateModel,
         candidateResponse: storedResp, candidateCost: candCost, candidateLatencyMs: candidate.latencyMs || 0,
         judgeVerdict: scored ? scored.verdict : null,
         dimensionScores: scored ? scored.dimensionScores : {},
@@ -187,7 +190,7 @@ async function executeRun(runId) {
     } catch (err) {
       await EvalResult.create({
         evalRunId: run._id, evalItemId: item._id, requestId: item.requestId,
-        baselineModel: dataset.baselineModel, candidateModel: dataset.candidateModel, error: err.message,
+        baselineModel: dataset.baselineModel, candidateModel: run.candidateModel, error: err.message,
       });
       entries.push({ errored: true });
     }

--- a/server/src/models/EvalDataset.js
+++ b/server/src/models/EvalDataset.js
@@ -7,6 +7,10 @@ const mongoose = require("mongoose");
 const evalDatasetSchema = new mongoose.Schema(
   {
     name: { type: String, default: "" },
+    // A benchmark is a NAMED, REUSABLE dataset: candidateModel is null (each candidate is chosen
+    // per run), and many EvalRuns reference it so models are scored against the same frozen set.
+    // Ephemeral one-shot eval datasets have isBenchmark=false.
+    isBenchmark: { type: Boolean, default: false, index: true },
     recommendationId: { type: mongoose.Schema.Types.ObjectId, ref: "Recommendation", default: null, index: true },
     scope: {
       application: { type: String, default: null },

--- a/server/test/unit/evalEfficiency.test.js
+++ b/server/test/unit/evalEfficiency.test.js
@@ -1,0 +1,40 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { efficiencyOf } = require("../../src/eval/efficiency");
+
+test("nothing judged → all null", () => {
+  const e = efficiencyOf({ judged: 0, worseRate: 0 }, 5);
+  assert.equal(e.qualityScore, null);
+  assert.equal(e.costPer1kUsd, null);
+  assert.equal(e.qualityPerDollar, null);
+});
+
+test("quality discounts worse-rate and format failures", () => {
+  // 10% worse, 100% format pass → quality 0.9
+  assert.equal(efficiencyOf({ judged: 100, worseRate: 0.1, formatPassRate: 1 }, 1).qualityScore, 0.9);
+  // 0% worse but only 80% format pass → quality 0.8
+  assert.equal(efficiencyOf({ judged: 100, worseRate: 0, formatPassRate: 0.8 }, 1).qualityScore, 0.8);
+});
+
+test("cost per 1k scales avg cost per judged item", () => {
+  // $2 over 100 items = $0.02/item = $20 / 1k
+  const e = efficiencyOf({ judged: 100, worseRate: 0, formatPassRate: 1 }, 2);
+  assert.equal(e.costPer1kUsd, 20);
+  assert.equal(e.qualityPerDollar, +(1 / 20).toFixed(4)); // 0.05
+});
+
+test("free candidate (zero cost) ranks first via Infinity, unless quality is zero", () => {
+  assert.equal(efficiencyOf({ judged: 50, worseRate: 0, formatPassRate: 1 }, 0).qualityPerDollar, Infinity);
+  assert.equal(efficiencyOf({ judged: 50, worseRate: 1, formatPassRate: 1 }, 0).qualityPerDollar, 0); // all-worse, free → 0
+});
+
+test("cheaper wins when quality is equal; better quality wins when cost is equal", () => {
+  const cheap = efficiencyOf({ judged: 100, worseRate: 0.1, formatPassRate: 1 }, 1);   // q .9, $10/1k
+  const pricey = efficiencyOf({ judged: 100, worseRate: 0.1, formatPassRate: 1 }, 4);  // q .9, $40/1k
+  assert.ok(cheap.qualityPerDollar > pricey.qualityPerDollar);
+
+  const better = efficiencyOf({ judged: 100, worseRate: 0.02, formatPassRate: 1 }, 2); // q .98
+  const worse = efficiencyOf({ judged: 100, worseRate: 0.20, formatPassRate: 1 }, 2);  // q .80
+  assert.ok(better.qualityPerDollar > worse.qualityPerDollar);
+});

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -81,6 +81,13 @@ export const api = {
   createEval: (body) => req("/evals", { method: "POST", body: JSON.stringify(body) }),
   evalTrafficModels: ({ application } = {}) => req(`/evals/traffic-models${qs({ application })}`),
   evalRuns: (recommendationId) => req(`/evals/runs${qs({ recommendationId })}`),
+
+  // Reusable benchmarks ("DashBench"): a named frozen set, scored against many candidates.
+  benchmarks: () => req("/eval-benchmarks"),
+  benchmark: (id) => req(`/eval-benchmarks/${id}`),
+  createBenchmark: (body) => req("/eval-benchmarks", { method: "POST", body: JSON.stringify(body) }),
+  runBenchmark: (id, body) => req(`/eval-benchmarks/${id}/run`, { method: "POST", body: JSON.stringify(body) }),
+  deleteBenchmark: (id) => req(`/eval-benchmarks/${id}`, { method: "DELETE" }),
   evalRun: (id) => req(`/evals/runs/${id}`),
   deleteEvalRun: (id) => req(`/evals/runs/${id}`, { method: "DELETE" }),
   evalRunResults: (id) => req(`/evals/runs/${id}/results`),

--- a/web/src/pages/ModelEvals.jsx
+++ b/web/src/pages/ModelEvals.jsx
@@ -525,6 +525,177 @@ function OverrideDialog({ title, message, onConfirm, onCancel }) {
   );
 }
 
+// Leaderboard for one benchmark: score any model against the frozen set, ranked by quality/$.
+function BenchmarkDetail({ id, models, onClose }) {
+  const [bench, setBench] = useState(null);
+  const [cand, setCand] = useState("");
+  const [judge, setJudge] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState(null);
+  const [notice, setNotice] = useState(null);
+  const load = useCallback(() => { api.benchmark(id).then(setBench).catch((e) => setBench({ _error: e.message })); }, [id]);
+  useEffect(() => { load(); }, [load]);
+
+  const runCand = async () => {
+    setBusy(true); setErr(null); setNotice(null);
+    try {
+      await api.runBenchmark(id, { candidateModel: cand, judgeModel: judge || null });
+      setNotice("Scoring started — refresh in a moment for the verdict.");
+      setCand(""); load();
+    } catch (e) { setErr(e.message); } finally { setBusy(false); }
+  };
+
+  if (!bench) return <Drawer title="Benchmark" onClose={onClose}><Spinner /></Drawer>;
+  if (bench._error) return <Drawer title="Benchmark" onClose={onClose}><div className="text-sm text-red-600">{bench._error}</div></Drawer>;
+  const qpd = (e) => (e?.qualityPerDollar == null ? "—" : e.qualityPerDollar === null ? "—" : (!isFinite(e.qualityPerDollar) ? "free" : e.qualityPerDollar.toFixed(2)));
+  const rows = (bench.leaderboard || []).map((r, i) => ({ ...r, _rank: i + 1 }));
+  const cols = [
+    { key: "_rank", header: "#" },
+    { key: "candidateModel", header: "Candidate", render: (r) => <span className="font-medium">{r.candidateModel}</span> },
+    { key: "quality", header: "Quality", render: (r) => (r.efficiency?.qualityScore == null ? "—" : pct(r.efficiency.qualityScore)) },
+    { key: "cost1k", header: "Cost / 1k", render: (r) => (r.efficiency?.costPer1kUsd == null ? "—" : fmt.usd(r.efficiency.costPer1kUsd)) },
+    { key: "qpd", header: "Quality / $", render: (r) => <b>{qpd(r.efficiency)}</b> },
+    { key: "worse", header: "Worse-rate", render: (r) => pct(r.summary?.worseRate) },
+    { key: "status", header: "Outcome", render: (r) => { const o = runOutcome(r); return <Badge tone={o.tone}>{o.label}</Badge>; } },
+  ];
+
+  return (
+    <Drawer title={`Benchmark · ${bench.name}`} onClose={onClose}>
+      <div className="space-y-4">
+        <div className="flex items-center justify-between gap-2">
+          <div className="text-xs text-gray-500">{bench.scope?.application} · baseline <b>{bench.baselineModel}</b> · {fmt.num(bench.itemCount)} items</div>
+          <RefreshButton onClick={load} />
+        </div>
+
+        <div className="rounded-lg border border-gray-200 bg-gray-50/70 p-3">
+          <div className="text-sm font-semibold text-arbr-charcoal">Score a model</div>
+          <div className="mt-2 flex flex-wrap items-end gap-2">
+            <div>
+              <div className="label mb-1">Candidate</div>
+              <select className="input" value={cand} onChange={(e) => setCand(e.target.value)}>
+                <option value="">Select…</option>
+                {models.filter((m) => m.id !== bench.baselineModel).map((m) => <option key={m.id} value={m.id}>{m.label || m.id}</option>)}
+              </select>
+            </div>
+            <div>
+              <div className="label mb-1">Judge <span className="text-gray-400">(optional)</span></div>
+              <select className="input" value={judge} onChange={(e) => setJudge(e.target.value)}>
+                <option value="">No judge (format checks only)</option>
+                {models.map((m) => <option key={m.id} value={m.id}>{m.label || m.id}</option>)}
+              </select>
+            </div>
+            <button className="btn-secondary text-sm" disabled={busy || !cand} onClick={runCand}>{busy ? "Starting…" : "Run"}</button>
+          </div>
+          {err && <div className="mt-2 text-sm text-red-600">{err}</div>}
+          {notice && <div className="mt-2 text-sm text-arbr-green-700">{notice}</div>}
+        </div>
+
+        <div>
+          <div className="label mb-2">Leaderboard — ranked by quality per dollar (per 1k requests)</div>
+          <Table columns={cols} rows={rows} empty="No models scored yet — run one above." />
+        </div>
+      </div>
+    </Drawer>
+  );
+}
+
+// Reusable benchmarks: a named, frozen set of an app's traffic, scored against many candidates.
+function BenchmarksSection({ models, apps }) {
+  const [benches, setBenches] = useState(null);
+  const [openId, setOpenId] = useState(null);
+  const [confirmDel, setConfirmDel] = useState(null);
+  const [form, setForm] = useState({ name: "", application: "", baselineModel: "" });
+  const [baseOpts, setBaseOpts] = useState(null);
+  const [loadingBase, setLoadingBase] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState(null);
+  const set = (k, v) => setForm((f) => ({ ...f, [k]: v }));
+  const load = useCallback(() => { api.benchmarks().then(setBenches).catch(() => setBenches([])); }, []);
+  useEffect(() => { load(); }, [load]);
+
+  // Baseline options come from the models that actually served the chosen app's traffic.
+  useEffect(() => {
+    const app = form.application.trim();
+    setForm((f) => (f.baselineModel ? { ...f, baselineModel: "" } : f));
+    if (!app) { setBaseOpts(null); return; }
+    let cancelled = false; setLoadingBase(true);
+    const t = setTimeout(() => {
+      api.evalTrafficModels({ application: app })
+        .then((rows) => { if (!cancelled) setBaseOpts(rows || []); })
+        .catch(() => { if (!cancelled) setBaseOpts([]); })
+        .finally(() => { if (!cancelled) setLoadingBase(false); });
+    }, 350);
+    return () => { cancelled = true; clearTimeout(t); };
+  }, [form.application]);
+
+  const create = async () => {
+    setBusy(true); setErr(null);
+    try {
+      await api.createBenchmark({ name: form.name.trim(), application: form.application.trim(), baselineModel: form.baselineModel });
+      setForm({ name: "", application: "", baselineModel: "" });
+      load();
+    } catch (e) { setErr(e.message); } finally { setBusy(false); }
+  };
+  const del = async (b) => { setConfirmDel(null); await api.deleteBenchmark(b._id).catch(() => {}); load(); };
+  const valid = form.name.trim() && form.application.trim() && form.baselineModel;
+
+  const cols = [
+    { key: "name", header: "Benchmark", render: (b) => <span className="font-medium">{b.name}</span> },
+    { key: "application", header: "Application", render: (b) => b.scope?.application || "—" },
+    { key: "baselineModel", header: "Baseline", render: (b) => b.baselineModel || "—" },
+    { key: "itemCount", header: "Items", render: (b) => fmt.num(b.itemCount) },
+    { key: "runCount", header: "Models scored", render: (b) => fmt.num(b.runCount) },
+    { key: "actions", header: "", render: (b) => (
+      <span className="flex gap-2" onClick={(e) => e.stopPropagation()}>
+        <button className="btn-outline text-xs" onClick={() => setOpenId(b._id)}>Leaderboard</button>
+        <button className="btn-outline text-xs text-red-600" onClick={() => setConfirmDel(b)}>Delete</button>
+      </span>
+    ) },
+  ];
+  return (
+    <Card title="Benchmarks" action={<RefreshButton onClick={load} />}>
+      <p className="mb-3 text-xs text-gray-500">
+        A named, frozen set of an application's traffic. Score any model against the same set and rank them by
+        quality-per-dollar on your own workload — generic leaderboards don't predict your traffic.
+      </p>
+      <div className="mb-4 rounded-lg border border-gray-200 bg-gray-50/70 p-4">
+        <div className="text-sm font-semibold text-arbr-charcoal">New benchmark</div>
+        <div className="mt-3 grid grid-cols-2 gap-3 md:grid-cols-3">
+          <div>
+            <div className="label mb-1">Name</div>
+            <input className="input w-full" placeholder="e.g. Support replies v1" value={form.name} onChange={(e) => set("name", e.target.value)} />
+          </div>
+          <div>
+            <div className="label mb-1">Application</div>
+            <input className="input w-full" list="bench-apps" placeholder="e.g. gyde-chat-client" value={form.application} onChange={(e) => set("application", e.target.value)} />
+            <datalist id="bench-apps">{apps.map((a) => <option key={a} value={a} />)}</datalist>
+          </div>
+          <div>
+            <div className="label mb-1">Baseline (reference)</div>
+            <select className="input w-full" value={form.baselineModel}
+              disabled={!form.application.trim() || loadingBase || (baseOpts != null && baseOpts.length === 0)}
+              onChange={(e) => set("baselineModel", e.target.value)}>
+              <option value="">{!form.application.trim() ? "Pick an application first" : loadingBase ? "Loading…" : "Select…"}</option>
+              {(baseOpts || []).map((o) => <option key={o.model} value={o.model}>{o.model} ({fmt.num(o.count)} replayable)</option>)}
+            </select>
+          </div>
+        </div>
+        {form.application.trim() && !loadingBase && baseOpts != null && baseOpts.length === 0 && (
+          <div className="mt-2 text-xs text-amber-600">No replayable traffic for <b>{form.application.trim()}</b> — nothing to benchmark yet.</div>
+        )}
+        {err && <div className="mt-3 text-sm text-red-600">{err}</div>}
+        <div className="mt-3"><button className="btn-secondary text-sm" disabled={busy || !valid} onClick={create}>{busy ? "Building…" : "Create benchmark"}</button></div>
+      </div>
+      {benches === null ? <Spinner /> : <Table columns={cols} rows={benches} empty="No benchmarks yet — create one above." onRowClick={(b) => setOpenId(b._id)} />}
+      {openId && <BenchmarkDetail id={openId} models={models} onClose={() => setOpenId(null)} />}
+      {confirmDel && (
+        <ConfirmDialog title="Delete benchmark?" message={`This removes "${confirmDel.name}", its items, and all model scores against it.`}
+          confirmLabel="Delete" onConfirm={() => del(confirmDel)} onCancel={() => setConfirmDel(null)} />
+      )}
+    </Card>
+  );
+}
+
 // Pipeline stage header, so the page order reads as the actual flow:
 // offline eval → shadow → canary → promote.
 function StageHeading({ n, title, desc }) {
@@ -611,6 +782,7 @@ export default function ModelEvals() {
       </div>
 
       <StageHeading n="1" title="Offline eval" desc="Replay past traffic through a candidate and judge it against the baseline. No production impact." />
+      <BenchmarksSection models={models} apps={apps} />
       <EvalRunsSection models={models} apps={apps} />
 
       <StageHeading n="2" title="Shadow" desc="Mirror a sample of live traffic to the candidate without serving it, judged against the current model — a real-traffic check with no user impact." />


### PR DESCRIPTION
Implements the three **must-haves** from the DoorDash DashBench pick-list (plan: `idempotent-wiggling-acorn.md`). DoorDash hand-built a private benchmark from their own PRs to rank model combos by intelligence-per-dollar; this generalizes that layer for any LLM workload on Arbr.

## What you can now do
1. **Create a benchmark** — a named, frozen sample of an application's real traffic (Stage 1 → Benchmarks → New benchmark).
2. **Score many models against the same set** — open a benchmark, pick a candidate (+ optional judge), Run. Repeat for as many models as you like.
3. **Read the leaderboard** — candidates ranked by **quality per dollar**, with quality %, **cost / 1k requests**, worse-rate, and outcome.

## Why quality-per-dollar (not sticker price)
`quality = (1 − worseRate) × formatPassRate` over **cost per successful response** — a model that's "as good" but emits malformed output half the time shouldn't rank as cheap. Free + good sorts first. (DoorDash: *"the cheapest model is not always the cheapest review."*)

## Implementation notes
- **`EvalDataset.isBenchmark`** — reusable, candidate-agnostic dataset.
- **`replay.startRun`** takes a per-run `candidateModel`; **`executeRun`** now reads `run.candidateModel` (was `dataset.candidateModel`) so one frozen set scores many candidates. Back-compat preserved for one-shot evals.
- **`eval/efficiency.js`** — pure, unit-tested metric.
- Endpoints under **`/api/eval-benchmarks`** (deliberately namespaced away from the existing catalog-sync `/benchmarks/*`): create / list / get-with-leaderboard / run / delete.

## Testing
`evalEfficiency.test.js` added; full unit suite **102 pass**; lint clean; web build ok.

Next from the plan (separate PRs): good-to-haves — "disprove-it" judge pass, human-curated verdicts, severity weighting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)