### PR TITLE
Application picker is a real dropdown on eval/benchmark forms (fixes dead-end)

### DIFF
--- a/web/src/pages/ModelEvals.jsx
+++ b/web/src/pages/ModelEvals.jsx
@@ -51,9 +51,10 @@ function NewCampaign({ models, apps, onCreated }) {
       <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
         <div>
           <div className="label mb-1">Application</div>
-          <input className="input w-full" list="eval-apps" placeholder="e.g. my-pipeline"
-            value={form.application} onChange={(e) => set("application", e.target.value)} />
-          <datalist id="eval-apps">{apps.map((a) => <option key={a} value={a} />)}</datalist>
+          <select className="input w-full" value={form.application} onChange={(e) => set("application", e.target.value)}>
+            <option value="">{apps.length ? "Select an application…" : "No applications with traffic"}</option>
+            {apps.map((a) => <option key={a} value={a}>{a}</option>)}
+          </select>
         </div>
         <div>
           <div className="label mb-1">Candidate model</div>
@@ -356,9 +357,10 @@ function NewEval({ models, apps, onCreated }) {
       <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
         <div>
           <div className="label mb-1">Application</div>
-          <input className="input w-full" list="eval-run-apps" placeholder="e.g. gyde-chat-client"
-            value={form.application} onChange={(e) => set("application", e.target.value)} />
-          <datalist id="eval-run-apps">{apps.map((a) => <option key={a} value={a} />)}</datalist>
+          <select className="input w-full" value={form.application} onChange={(e) => set("application", e.target.value)}>
+            <option value="">{apps.length ? "Select an application…" : "No applications with traffic"}</option>
+            {apps.map((a) => <option key={a} value={a}>{a}</option>)}
+          </select>
         </div>
         <div>
           <div className="label mb-1">Baseline (current)</div>
@@ -667,8 +669,10 @@ function BenchmarksSection({ models, apps }) {
           </div>
           <div>
             <div className="label mb-1">Application</div>
-            <input className="input w-full" list="bench-apps" placeholder="e.g. gyde-chat-client" value={form.application} onChange={(e) => set("application", e.target.value)} />
-            <datalist id="bench-apps">{apps.map((a) => <option key={a} value={a} />)}</datalist>
+            <select className="input w-full" value={form.application} onChange={(e) => set("application", e.target.value)}>
+              <option value="">{apps.length ? "Select an application…" : "No applications with traffic"}</option>
+              {apps.map((a) => <option key={a} value={a}>{a}</option>)}
+            </select>
           </div>
           <div>
             <div className="label mb-1">Baseline (reference)</div>
@@ -727,7 +731,7 @@ export default function ModelEvals() {
     load();
     // Candidate + judge get CALLED during a run, so only offer connected, chat-capable models.
     api.models({ live: true, routable: true }).then((m) => setModels(m || [])).catch(() => {});
-    api.facets().then((f) => setApps(f?.applications || [])).catch(() => {});
+    api.facets().then((f) => setApps([...new Set(f?.applications || [])])).catch(() => {});
   }, [load]);
 
   // Activating a shadow campaign is gated on a passed offline eval (or an override). If the gate


### PR DESCRIPTION
Follow-up to #115. Reported: on the New benchmark form, clicking **BASELINE ("Pick an application first")** does nothing.

## Cause
`APPLICATION` was a free-text `<input>` with a `<datalist>` — no visible dropdown affordance. `BASELINE` is (correctly) disabled until an app is chosen, so with an empty Application field the baseline looks clickable but is inert. The user had no clear signal to type in Application first.

## Fix
Replaced Application with a real **`<select>`** of apps that have traffic, on all three eval forms (New benchmark, New eval, New shadow-eval campaign). Deduped the app list at the source (facets was returning duplicates).

## Actually tested this time
Beyond build+lint, I exercised the full backend against **prod** (deployed #115):
- create benchmark (gyde-chat-client, baseline nova-lite, 5 items) → `ready`
- score two candidates against the same set → leaderboard ranks by quality-per-dollar: `gpt-4o-mini` q/$ **10.14** (judged 5/5, quality 0.6, cost/1k $0.059)
- cancel in-flight run + delete benchmark → cascade cleanup, list back to 0

(Aside, not a bug: `qwen3-next-80b` via nvidia-nim is very slow per call — a benchmark against a slow provider takes a while. Worth a note in the UI later.)

Build + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)