### PR TITLE
"Disprove it" judge pass — drop false "worse" verdicts (eval precision)

### DIFF
--- a/server/src/eval/replay.js
+++ b/server/src/eval/replay.js
@@ -9,7 +9,7 @@ const EvalRun = require("../models/EvalRun");
 const EvalResult = require("../models/EvalResult");
 const Recommendation = require("../models/Recommendation");
 const { clampText, maskPii } = require("../logging/piiFilter");
-const { judgeItem, runValidators, lastUserText } = require("./rubricJudge");
+const { judgeItem, disproveWorse, runValidators, lastUserText } = require("./rubricJudge");
 const { evaluateRun } = require("./thresholds");
 
 function percentile(sorted, p) {
@@ -30,6 +30,7 @@ function aggregate(entries) {
   const worse = judged.filter((e) => e.verdict === "worse").length;
   const critical = ok.filter((e) => e.criticalFailure).length;
   const formatPasses = ok.filter((e) => e.formatPass).length;
+  const disprovedWorse = ok.filter((e) => e.disproved).length; // "worse" calls overturned on falsification
 
   const prodCost = sum(ok, (e) => e.productionCost);
   const candCost = sum(ok, (e) => e.candidateCost);
@@ -46,6 +47,7 @@ function aggregate(entries) {
     total, judged: judged.length,
     candidateBetter: better, candidateEqual: equal, candidateWorse: worse,
     worseRate: judged.length ? worse / judged.length : 0,
+    disprovedWorse,
     criticalFailRate: ok.length ? critical / ok.length : 0,
     formatPassRate: ok.length ? formatPasses / ok.length : 1,
     prodCost, candidateCost: candCost,
@@ -168,24 +170,38 @@ async function executeRun(runId) {
       const judgeError = verdict && verdict.error ? verdict.error : null;
       const scored = verdict && !judgeError ? verdict : null;
 
+      // "Disprove it": re-examine a "worse" verdict; drop it if it doesn't survive falsification.
+      let finalVerdict = scored ? scored.verdict : null;
+      let disproved = false;
+      let disproveReason = null;
+      if (scored && scored.verdict === "worse" && run.disprovePass !== false) {
+        const dp = await disproveWorse({
+          router, eff, judgeModel: run.judgeModel,
+          userText: lastUserText(item.messages), baselineText: item.productionResponse, candidateText: candidate.text,
+        });
+        if (dp.overturned) { finalVerdict = "equal"; disproved = true; disproveReason = dp.reason; }
+      }
+
       const storedResp = clampText(maskEnabled ? maskPii(candidate.text || "", customPatterns) : (candidate.text || ""));
       await EvalResult.create({
         evalRunId: run._id, evalItemId: item._id, requestId: item.requestId,
         baselineModel: dataset.baselineModel, candidateModel: run.candidateModel,
         candidateResponse: storedResp, candidateCost: candCost, candidateLatencyMs: candidate.latencyMs || 0,
-        judgeVerdict: scored ? scored.verdict : null,
+        judgeVerdict: finalVerdict,
+        preDisproveVerdict: scored ? scored.verdict : null,
+        disproved,
         dimensionScores: scored ? scored.dimensionScores : {},
         criticalFailure: scored ? !!scored.criticalFailure : false,
         validatorResults: results, formatPass,
         abFlipped: scored ? !!scored.abFlipped : false,
-        judgeRationale: scored ? scored.judgeRationale : judgeError,
+        judgeRationale: disproved ? `[disprove pass overturned "worse"] ${disproveReason || ""}`.trim() : (scored ? scored.judgeRationale : judgeError),
       });
       entries.push({
-        verdict: scored ? scored.verdict : null,
+        verdict: finalVerdict,
         criticalFailure: scored ? !!scored.criticalFailure : false,
         formatPass, candidateCost: candCost, candidateLatencyMs: candidate.latencyMs || 0,
         productionCost: item.productionCost || 0, productionLatencyMs: item.productionLatencyMs || 0,
-        errored: false, judgeError,
+        errored: false, judgeError, disproved,
       });
     } catch (err) {
       await EvalResult.create({

--- a/server/src/eval/rubricJudge.js
+++ b/server/src/eval/rubricJudge.js
@@ -146,6 +146,45 @@ async function judgeItem({ router, eff, judgeModel, userText, baselineText, cand
   }
 }
 
+// "Disprove it": a second pass over an item the judge called WORSE, which argues the OPPOSITE
+// and re-decides. Only worse verdicts that survive this falsification count — cutting false
+// "worse" (judge noise) that would unfairly fail a good candidate. (DoorDash's precision pass:
+// "attempt to falsify its own conclusions" — their single most important design decision.)
+// Returns { overturned: bool, reason }. overturned=true means the "worse" verdict did NOT hold.
+async function disproveWorse({ router, eff, judgeModel, userText, baselineText, candidateText }) {
+  if (!judgeModel) return { overturned: false };
+  const jm = pricing.getModel(judgeModel);
+  if (!jm || !eff?.liveIds?.includes(jm.provider)) return { overturned: false };
+  const prompt = [
+    "A first reviewer judged RESPONSE B to be WORSE than RESPONSE A for the same user request.",
+    "Challenge that: make the strongest honest case that B is actually AS GOOD AS or better than A",
+    "(equally correct, complete, and instruction-following), then decide.",
+    "",
+    "USER REQUEST:",
+    userText,
+    "",
+    "RESPONSE A (baseline):",
+    String(baselineText || "").slice(0, 6000),
+    "",
+    "RESPONSE B (candidate):",
+    String(candidateText || "").slice(0, 6000),
+    "",
+    'Reply with ONLY JSON: {"b_is_worse": true | false, "reason": "<one sentence>"}',
+    'Set "b_is_worse": false if the original "worse" verdict is not clearly justified.',
+  ].join("\n");
+  try {
+    const res = await router.complete({
+      messages: [{ role: "user", content: prompt }], providerOverride: jm.provider, modelOverride: judgeModel, temperature: 0,
+    });
+    const m = String(res.text || "").match(/\{[\s\S]*\}/);
+    if (!m) return { overturned: false };
+    const j = JSON.parse(m[0]);
+    return { overturned: j.b_is_worse === false, reason: String(j.reason || "").slice(0, 300) };
+  } catch {
+    return { overturned: false };
+  }
+}
+
 module.exports = {
   buildRubricPrompt,
   parseRubricVerdict,
@@ -154,6 +193,7 @@ module.exports = {
   sameFamily,
   runValidators,
   judgeItem,
+  disproveWorse,
   RUBRIC_DIMS,
   lastUserText,
 };

--- a/server/src/models/EvalResult.js
+++ b/server/src/models/EvalResult.js
@@ -15,6 +15,9 @@ const evalResultSchema = new mongoose.Schema(
     candidateLatencyMs: { type: Number, default: 0 },
 
     judgeVerdict: { type: String, enum: ["better", "equal", "worse", null], default: null },
+    // The judge's FIRST-pass verdict, kept when the "disprove it" pass overturned a "worse" call.
+    preDisproveVerdict: { type: String, enum: ["better", "equal", "worse", null], default: null },
+    disproved: { type: Boolean, default: false }, // a "worse" verdict was overturned on falsification
     dimensionScores: {
       correctness: { type: Number, default: null },
       completeness: { type: Number, default: null },

--- a/server/src/models/EvalRun.js
+++ b/server/src/models/EvalRun.js
@@ -27,6 +27,11 @@ const evalRunSchema = new mongoose.Schema(
     // signal on a small sample, NOT a promotion-grade result. The UI labels it as such.
     exploratory: { type: Boolean, default: false },
 
+    // "Disprove it" precision pass: re-examine every "worse" verdict and drop the ones that don't
+    // survive falsification (judge noise). On by default; the count of overturned verdicts is in
+    // summary.disprovedWorse.
+    disprovePass: { type: Boolean, default: true },
+
     // Cost guardrail — replay + judge calls are real spend. Estimated up front; the run aborts
     // (status:failed) rather than exceed maxRunCostUsd.
     estimatedCostUsd: { type: Number, default: 0 },

--- a/web/src/pages/ModelEvals.jsx
+++ b/web/src/pages/ModelEvals.jsx
@@ -277,6 +277,7 @@ function RunDetail({ id, onClose }) {
         <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-xs text-gray-600">
           {run.baselineModel} → {run.candidateModel} · judge {run.judgeModel || "none"} · {run.riskTier} risk · est. cost {fmt.usd(run.estimatedCostUsd)} · actual {fmt.usd(run.actualCostUsd)}
           {run.fidelity === "masked" && <span className="ml-1 text-amber-600">· masked dataset (lower-fidelity: candidate saw redacted prompts vs the original baseline)</span>}
+          {s.disprovedWorse > 0 && <span className="ml-1 text-arbr-green-700">· disprove pass overturned {fmt.num(s.disprovedWorse)} false “worse” verdict{s.disprovedWorse === 1 ? "" : "s"}</span>}
         </div>
         <div className="flex items-center justify-between">
           <div className="label">Worst candidate examples</div>


### PR DESCRIPTION
First of the plan's **good-to-haves** (#4). DoorDash's *single most important design decision*: before a finding counts, a pass tries to falsify it.

## What it does
Every **"worse"** verdict (evidence against a candidate) is re-examined by a second judge pass that argues the candidate is actually as-good-or-better. Only "worse" calls that **survive** count as worse. This cuts judge noise that would otherwise unfairly fail a good candidate — lifting the precision of the **worse-rate**, the metric that gates every eval and benchmark.

## Implementation
- `rubricJudge.disproveWorse()` — the falsification pass (`{ overturned, reason }`).
- `replay.executeRun` — runs it on each "worse" item *only* when `run.disprovePass` (default true); an overturned verdict becomes `equal`, with `preDisproveVerdict` + `disproved` on the `EvalResult` and a `summary.disprovedWorse` count.
- Schema: `EvalRun.disprovePass`, `EvalResult.preDisproveVerdict` + `disproved`.
- UI: run drawer notes *"disprove pass overturned N false 'worse' verdict(s)."*
- **Bounded cost**: the extra judge call fires only on items first judged "worse" (a minority).

## Testing
Lint + full unit suite (102) + web build pass. The disprove behavior will be verified on prod after deploy (it needs live judge calls on "worse" items) — I'll re-run the `gyde-chat-client` eval (which had ~40% worse-rate) and confirm the overturned count.

Next good-to-haves: benchmark curation (human verdicts + severity + pin cases), then the acceptance-rate feedback loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)