### PR TITLE
feat(overview): latency breakdown table with gateway overhead in Summary tab

### DIFF
--- a/web/src/pages/Docs.jsx
+++ b/web/src/pages/Docs.jsx
@@ -29,11 +29,7 @@ const SCREENS = [
 
 export default function Docs() {
   const [status, setStatus] = useState(null);
-  const [latency, setLatency] = useState(null);
-  useEffect(() => {
-    api.status().then(setStatus).catch(() => {});
-    api.latencyPercentiles().then(setLatency).catch(() => {});
-  }, []);
+  useEffect(() => { api.status().then(setStatus).catch(() => {}); }, []);
 
   const base = typeof window !== "undefined" ? window.location.origin : "http://localhost:4100";
   const live = status?.liveProviders || [];
@@ -86,54 +82,6 @@ res = arbr.chat("Summarise this ticket: ...", model="auto", max_tokens=300)   # 
           model that fits the task. Every call is logged, costed, and governed — with
           <strong> human-approved</strong> rules and an AI policy, all reversible from these screens.
         </p>
-      </Card>
-
-      <Card title="Gateway performance">
-        <p className="mb-3 text-sm text-gray-600">
-          Live latency figures from your traffic — the same data shown on the Overview dashboard,
-          with gateway overhead broken out separately so you can see exactly what Arbr adds on top
-          of provider time.
-        </p>
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-gray-100">
-                <th className="pb-2 text-left text-xs font-semibold uppercase tracking-wider text-gray-400">Metric</th>
-                <th className="pb-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-400">P50</th>
-                <th className="pb-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-400">P95</th>
-                <th className="pb-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-400">P99</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-50">
-              {[
-                { label: "Total latency", p50: latency?.p50, p95: latency?.p95, p99: latency?.p99 },
-                { label: "Gateway overhead", p50: latency?.overheadP50, p95: latency?.overheadP95, p99: latency?.overheadP99 },
-                { label: "TTFT (streaming)", p50: latency?.ttftP50, p95: latency?.ttftP95, p99: null },
-              ].map(({ label, p50, p95, p99 }) => {
-                const fmt = (v) => v != null ? `${v.toLocaleString()} ms` : "—";
-                return (
-                  <tr key={label}>
-                    <td className="py-2.5 text-gray-700">{label}</td>
-                    <td className="py-2.5 text-right font-mono text-gray-600">{latency ? fmt(p50) : "…"}</td>
-                    <td className="py-2.5 text-right font-mono text-gray-600">{latency ? fmt(p95) : "…"}</td>
-                    <td className="py-2.5 text-right font-mono text-gray-600">{latency ? fmt(p99) : "…"}</td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-        <div className="mt-4 space-y-1 text-xs text-gray-400">
-          <p><strong className="text-gray-500">Total latency</strong> — wall-clock time from request received to full response delivered, including provider processing. Success requests only, last 30 days.</p>
-          <p><strong className="text-gray-500">Gateway overhead</strong> — time Arbr spends before dispatching to the LLM: routing decision, auth, classification, logging. This is what the gateway itself costs, excluding provider time.</p>
-          <p><strong className="text-gray-500">TTFT</strong> — time to first streaming token; only captured on streaming calls.</p>
-        </div>
-        <div className="mt-4">
-          <p className="mb-2 text-xs text-gray-500">Run the latency benchmark against your own instance:</p>
-          <CodeBlock lang="bash" code={`ARBR_GATEWAY_URL=http://localhost:4100 ARBR_API_KEY=ab_... \\
-  node server/scripts/latency-bench.js --requests 50 --concurrency 5
-# Add --stream to also measure TTFT. Results saved to bench/results/latency-YYYY-MM-DD.json`} />
-        </div>
       </Card>
 
       <Card title="Getting started — the Connect stage">

--- a/web/src/pages/Overview.jsx
+++ b/web/src/pages/Overview.jsx
@@ -28,12 +28,14 @@ function Summary() {
   if (err) return <div className="text-red-600">{err}</div>;
   if (!data) return <Spinner />;
 
-  const p50     = latency?.p50     != null ? fmt.ms(latency.p50)     : "—";
-  const p95     = latency?.p95     != null ? fmt.ms(latency.p95)     : "—";
-  const p99     = latency?.p99     != null ? fmt.ms(latency.p99)     : "—";
-  const ttftP50 = latency?.ttftP50 != null ? fmt.ms(latency.ttftP50) : "—";
-  const ttftP95 = latency?.ttftP95 != null ? fmt.ms(latency.ttftP95) : "—";
-  const hasttft = latency?.ttftP50 != null;
+  const ms = (v) => v != null ? fmt.ms(v) : "—";
+  const latRows = [
+    { label: "Total latency",     p50: latency?.p50,         p95: latency?.p95,         p99: latency?.p99         },
+    { label: "Gateway overhead",  p50: latency?.overheadP50, p95: latency?.overheadP95, p99: latency?.overheadP99 },
+    ...(latency?.ttftP50 != null
+      ? [{ label: "TTFT (streaming)", p50: latency?.ttftP50, p95: latency?.ttftP95, p99: null }]
+      : []),
+  ];
 
   return (
     <div className="space-y-6">
@@ -45,13 +47,34 @@ function Summary() {
         <Stat label="Realised savings" value={fmt.usd(savings?.totalSaved)} />
       </div>
 
-      <div className={`grid grid-cols-1 gap-4 sm:grid-cols-2 ${hasttft ? "lg:grid-cols-5" : "lg:grid-cols-3"}`}>
-        <Stat label="Latency p50" value={p50} sub="median (success)" />
-        <Stat label="Latency p95" value={p95} sub="95th percentile" />
-        <Stat label="Latency p99" value={p99} sub="99th percentile" />
-        {hasttft && <Stat label="TTFT p50" value={ttftP50} sub="streaming median" />}
-        {hasttft && <Stat label="TTFT p95" value={ttftP95} sub="streaming 95th pct" />}
-      </div>
+      <Card title="Latency breakdown">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-100">
+              <th className="pb-2 text-left text-xs font-semibold uppercase tracking-wider text-gray-400">Metric</th>
+              <th className="pb-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-400">Median</th>
+              <th className="pb-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-400">95%ile</th>
+              <th className="pb-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-400">99%ile</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-50">
+            {latRows.map(({ label, p50, p95, p99 }) => (
+              <tr key={label}>
+                <td className="py-2.5 text-gray-700">{label}</td>
+                <td className="py-2.5 text-right font-mono text-gray-600">{ms(p50)}</td>
+                <td className="py-2.5 text-right font-mono text-gray-600">{ms(p95)}</td>
+                <td className="py-2.5 text-right font-mono text-gray-600">{ms(p99)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {latency?.overheadP99 > 500 && (
+          <p className="mt-3 text-xs text-gray-400">
+            High 99%ile gateway overhead reflects AI task classification — the gateway makes a short LLM call to determine task type when AI routing is on.
+            Pin <code className="rounded bg-gray-100 px-1">taskType</code> in your requests to skip it.
+          </p>
+        )}
+      </Card>
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         <Stat label="Cache hit rate" value={`${((data.cacheHitRate || 0) * 100).toFixed(1)}%`} />


### PR DESCRIPTION
## Summary

- **Overview → Summary**: Replaces the individual Latency P50/P95/P99/TTFT stat tiles with a "Latency breakdown" card — a 3-row table (Total latency / Gateway overhead / TTFT) with Median / 95%ile / 99%ile columns, matching the LiteLLM benchmark format. Shows a contextual note when overhead P99 > 500ms explaining AI classification as the cause.
- **Docs**: Removes the Gateway performance card (now lives in Overview where it's more discoverable).

## Test plan

- [ ] Overview → Summary tab shows "Latency breakdown" card with all three rows
- [ ] Gateway overhead row shows numbers (requires PR #114 deployed)
- [ ] 99%ile overhead > 500ms triggers the AI classification note
- [ ] Docs page no longer has the Gateway performance card
- [ ] Terminology reads Median / 95%ile / 99%ile throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)