### PR TITLE
Judge reliability (position-bias + decisiveness) on the benchmark leaderboard

### DIFF
--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -39,6 +39,7 @@ const evalDatasetBuilder = require("../eval/dataset");
 const evalReplay = require("../eval/replay");
 const evalThresholds = require("../eval/thresholds");
 const { efficiencyOf } = require("../eval/efficiency");
+const { judgeReliability } = require("../eval/judgeReliability");
 const { sameFamily } = require("../eval/rubricJudge");
 const { tierForTask } = require("../classify/classifier");
 const RoutingExperiment = require("../models/RoutingExperiment");
@@ -865,9 +866,12 @@ router.get("/eval-benchmarks/:id", async (req, res, next) => {
     const bench = await EvalDataset.findById(req.params.id).lean().catch(() => null);
     if (!bench || !bench.isBenchmark) return res.status(404).json({ error: "not found" });
     const runs = await EvalRun.find({ datasetId: bench._id }).sort({ createdAt: -1 }).lean();
-    const leaderboard = runs.map((r) => ({
-      ...r, efficiency: efficiencyOf(r.summary, r.actualCostUsd),
-    })).sort((a, b) => (b.efficiency.qualityPerDollar ?? -1) - (a.efficiency.qualityPerDollar ?? -1));
+    // Per-run judge reliability from the stored verdicts (position bias + decisiveness).
+    const leaderboard = await Promise.all(runs.map(async (r) => {
+      const verdicts = await EvalResult.find({ evalRunId: r._id }, { judgeVerdict: 1, abFlipped: 1 }).lean();
+      return { ...r, efficiency: efficiencyOf(r.summary, r.actualCostUsd), judge: judgeReliability(verdicts) };
+    }));
+    leaderboard.sort((a, b) => (b.efficiency.qualityPerDollar ?? -1) - (a.efficiency.qualityPerDollar ?? -1));
     res.json({ ...bench, leaderboard });
   } catch (e) { next(e); }
 });

--- a/server/src/eval/judgeReliability.js
+++ b/server/src/eval/judgeReliability.js
@@ -1,0 +1,32 @@
+// Judge-the-judge: reliability signals for the LLM-as-judge, computed from a run's per-item
+// results. Pure + dependency-free so it unit-tests without a DB. Answers "can I trust these
+// verdicts?" — the question DoorDash's whole post is about.
+//
+//   results: [{ judgeVerdict: "better"|"equal"|"worse"|null, abFlipped: bool }]
+//
+// Signals:
+//  - positionBias: we place the candidate in slot A or B at random per item (abFlipped=true → A),
+//    then map the verdict back to the candidate. An UNBIASED judge's candidate-win-rate shouldn't
+//    depend on the slot. positionBias = winRate(candidate in A) - winRate(candidate in B); a large
+//    magnitude means the judge favors a POSITION, not the better answer. null if a slot is empty.
+//  - decisiveness: share of judged items with a non-"equal" verdict. A judge that almost always
+//    says "equal" isn't discriminating (low signal), even if unbiased.
+//  - verdictDist: raw better/equal/worse counts.
+function judgeReliability(results) {
+  const judged = (results || []).filter((r) => r && r.judgeVerdict);
+  const n = judged.length;
+  const dist = { better: 0, equal: 0, worse: 0 };
+  for (const r of judged) if (dist[r.judgeVerdict] != null) dist[r.judgeVerdict]++;
+  if (!n) return { n: 0, verdictDist: dist, aWinRate: null, bWinRate: null, positionBias: null, decisiveness: null };
+
+  const winRate = (arr) => (arr.length ? arr.filter((r) => r.judgeVerdict === "better").length / arr.length : null);
+  const inA = judged.filter((r) => r.abFlipped);   // candidate placed in slot A
+  const inB = judged.filter((r) => !r.abFlipped);  // candidate placed in slot B
+  const aWinRate = winRate(inA);
+  const bWinRate = winRate(inB);
+  const positionBias = aWinRate == null || bWinRate == null ? null : +(aWinRate - bWinRate).toFixed(4);
+  const decisiveness = +(1 - dist.equal / n).toFixed(4);
+  return { n, verdictDist: dist, aWinRate, bWinRate, positionBias, decisiveness };
+}
+
+module.exports = { judgeReliability };

--- a/server/test/unit/evalJudgeReliability.test.js
+++ b/server/test/unit/evalJudgeReliability.test.js
@@ -1,0 +1,55 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { judgeReliability } = require("../../src/eval/judgeReliability");
+
+test("no judged items → all null", () => {
+  const r = judgeReliability([{ judgeVerdict: null, abFlipped: true }]);
+  assert.equal(r.n, 0);
+  assert.equal(r.positionBias, null);
+  assert.equal(r.decisiveness, null);
+});
+
+test("verdict distribution + decisiveness", () => {
+  const r = judgeReliability([
+    { judgeVerdict: "better", abFlipped: true },
+    { judgeVerdict: "equal", abFlipped: false },
+    { judgeVerdict: "worse", abFlipped: true },
+    { judgeVerdict: "equal", abFlipped: false },
+  ]);
+  assert.deepEqual(r.verdictDist, { better: 1, equal: 2, worse: 1 });
+  assert.equal(r.decisiveness, 0.5); // 2 of 4 non-equal
+});
+
+test("no position bias when win-rate is equal across slots", () => {
+  // candidate wins 1/2 in A and 1/2 in B → bias 0
+  const r = judgeReliability([
+    { judgeVerdict: "better", abFlipped: true },
+    { judgeVerdict: "worse", abFlipped: true },
+    { judgeVerdict: "better", abFlipped: false },
+    { judgeVerdict: "worse", abFlipped: false },
+  ]);
+  assert.equal(r.positionBias, 0);
+});
+
+test("detects a judge that favors slot A", () => {
+  // candidate wins every time it's in A, never when in B → bias +1 (favors position A)
+  const r = judgeReliability([
+    { judgeVerdict: "better", abFlipped: true },
+    { judgeVerdict: "better", abFlipped: true },
+    { judgeVerdict: "worse", abFlipped: false },
+    { judgeVerdict: "worse", abFlipped: false },
+  ]);
+  assert.equal(r.aWinRate, 1);
+  assert.equal(r.bWinRate, 0);
+  assert.equal(r.positionBias, 1);
+});
+
+test("bias is null when a slot has no items", () => {
+  const r = judgeReliability([
+    { judgeVerdict: "better", abFlipped: true },
+    { judgeVerdict: "worse", abFlipped: true },
+  ]);
+  assert.equal(r.bWinRate, null);
+  assert.equal(r.positionBias, null);
+});

--- a/web/src/pages/ModelEvals.jsx
+++ b/web/src/pages/ModelEvals.jsx
@@ -558,6 +558,19 @@ function BenchmarkDetail({ id, models, onClose }) {
     { key: "cost1k", header: "Cost / 1k", render: (r) => (r.efficiency?.costPer1kUsd == null ? "—" : fmt.usd(r.efficiency.costPer1kUsd)) },
     { key: "qpd", header: "Quality / $", render: (r) => <b>{qpd(r.efficiency)}</b> },
     { key: "worse", header: "Worse-rate", render: (r) => pct(r.summary?.worseRate) },
+    { key: "judge", header: "Judge check", render: (r) => {
+      const j = r.judge;
+      if (!j || j.positionBias == null) return <span className="text-gray-400">—</span>;
+      const mag = Math.abs(j.positionBias);
+      const tone = mag < 0.15 ? "green" : mag < 0.3 ? "amber" : "red";
+      const label = mag < 0.15 ? "unbiased" : mag < 0.3 ? "some bias" : "biased";
+      return (
+        <span className="flex items-center gap-1.5" title={`position bias ${signedPct(j.positionBias)} · decisiveness ${pct(j.decisiveness)} · n=${j.n}`}>
+          <Badge tone={tone}>{label}</Badge>
+          <span className="text-xs text-gray-400">{signedPct(j.positionBias)}</span>
+        </span>
+      );
+    } },
     { key: "status", header: "Outcome", render: (r) => { const o = runOutcome(r); return <Badge tone={o.tone}>{o.label}</Badge>; } },
   ];
 


### PR DESCRIPTION
Plan nice-to-have **#12** — "judge the judge," so a leaderboard ranking rests on a *trustworthy* judge (the post is literally about learning to trust the reviewer).

## Signal
The candidate is placed in slot A or B at random per item (`abFlipped`). An unbiased judge's candidate-win-rate shouldn't depend on the slot, so **position bias = winRate(candidate in A) − winRate(candidate in B)**. Plus **decisiveness** = share of non-"equal" verdicts (a judge that always says "equal" carries no signal). Computed from verdicts already stored on `EvalResult` — **no re-scoring, no extra token cost**.

- `eval/judgeReliability.js` — pure, unit-tested.
- `GET /api/eval-benchmarks/:id` attaches per-run `judge` reliability to each leaderboard row.
- Leaderboard gains a **"Judge check"** column: `unbiased / some bias / biased` + the signed bias %.

## Notes
Builds on merged benchmarks (#115); independent of the unmerged #117 (branched off main). Lint + web build + full unit suite pass. (Prod verification pending merge/deploy, like the other queued PRs.)

Next nice-to-have: **#9 auto-benchmark new models** (with a cost-safe design). **#10 cascade routing** + **#11 combo evals** are the big hot-path build — better done when we can integration-test and deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)