### PR TITLE
Make the disprove pass conservative (it was overturning every "worse")

### DIFF
--- a/server/src/eval/rubricJudge.js
+++ b/server/src/eval/rubricJudge.js
@@ -146,19 +146,21 @@ async function judgeItem({ router, eff, judgeModel, userText, baselineText, cand
   }
 }
 
-// "Disprove it": a second pass over an item the judge called WORSE, which argues the OPPOSITE
-// and re-decides. Only worse verdicts that survive this falsification count — cutting false
-// "worse" (judge noise) that would unfairly fail a good candidate. (DoorDash's precision pass:
-// "attempt to falsify its own conclusions" — their single most important design decision.)
+// "Disprove it": a second pass over an item the judge called WORSE. It re-examines the verdict
+// and overturns it ONLY when the "worse" call is clearly a mistake — cutting false "worse" (judge
+// noise) without letting a genuinely worse candidate off the hook. (DoorDash's precision pass:
+// "attempt to falsify its own conclusions.") CONSERVATIVE BY DESIGN: unsure/tie → the verdict
+// STANDS, so this can't collapse the worse-rate and wave a bad candidate through.
 // Returns { overturned: bool, reason }. overturned=true means the "worse" verdict did NOT hold.
 async function disproveWorse({ router, eff, judgeModel, userText, baselineText, candidateText }) {
   if (!judgeModel) return { overturned: false };
   const jm = pricing.getModel(judgeModel);
   if (!jm || !eff?.liveIds?.includes(jm.provider)) return { overturned: false };
   const prompt = [
-    "A first reviewer judged RESPONSE B to be WORSE than RESPONSE A for the same user request.",
-    "Challenge that: make the strongest honest case that B is actually AS GOOD AS or better than A",
-    "(equally correct, complete, and instruction-following), then decide.",
+    "A first reviewer judged RESPONSE B WORSE than RESPONSE A for the same user request.",
+    "Re-examine strictly and impartially. Decide whether that WORSE verdict holds.",
+    "Overturn it ONLY if it is clearly a mistake — i.e. B is genuinely as correct, complete, and",
+    "instruction-following as A. If B is even slightly worse, or you are unsure, the WORSE verdict STANDS.",
     "",
     "USER REQUEST:",
     userText,
@@ -169,8 +171,8 @@ async function disproveWorse({ router, eff, judgeModel, userText, baselineText, 
     "RESPONSE B (candidate):",
     String(candidateText || "").slice(0, 6000),
     "",
-    'Reply with ONLY JSON: {"b_is_worse": true | false, "reason": "<one sentence>"}',
-    'Set "b_is_worse": false if the original "worse" verdict is not clearly justified.',
+    'Reply with ONLY JSON: {"worse_verdict_holds": true | false, "reason": "<one sentence>"}',
+    'Set "worse_verdict_holds": false ONLY when the "worse" verdict is clearly wrong.',
   ].join("\n");
   try {
     const res = await router.complete({
@@ -179,7 +181,8 @@ async function disproveWorse({ router, eff, judgeModel, userText, baselineText, 
     const m = String(res.text || "").match(/\{[\s\S]*\}/);
     if (!m) return { overturned: false };
     const j = JSON.parse(m[0]);
-    return { overturned: j.b_is_worse === false, reason: String(j.reason || "").slice(0, 300) };
+    // Overturn only on an explicit "does not hold"; missing/unsure → verdict stands (conservative).
+    return { overturned: j.worse_verdict_holds === false, reason: String(j.reason || "").slice(0, 300) };
   } catch {
     return { overturned: false };
   }


### PR DESCRIPTION
Follow-up to #117, caught by **testing it live on prod** (not just build/lint).

## What live testing showed
On a 6-item `gyde-chat-client` eval, the disprove pass overturned **all 3** "worse" verdicts → worse-rate collapsed to 0%. A disprove pass that overturns everything makes the gate toothless and would wave **bad** candidates through — the opposite of the intent.

## Two causes
1. **Lenient prompt** — it asked the judge to "make the strongest case B is fine" and defaulted to not-worse when "not clearly justified." Inherently biased toward overturning.
2. **Self-judging confound** — my test used `gpt-4o-mini` as both candidate *and* judge, so the judge was exonerating itself (the same-family guard only blocks that on high-risk).

## Fix (this PR)
Rewrite the pass as a **strict, impartial re-examination**: overturn a "worse" verdict **only when it's clearly wrong**; unsure/tie → the verdict **stands** (JSON `worse_verdict_holds`, overturn only on explicit `false`). It still strips genuine false-"worse" noise but can't zero the worse-rate.

Cause 2 is a usage note (don't judge a model with itself); extending the same-family judge guard beyond high-risk is a separate follow-up I can do if you want.

## Verification
Lint + eval unit suites pass. I'll **re-verify on prod after deploy** with candidate ≠ judge (e.g. candidate `gpt-oss-120b`, judge `gpt-4o-mini`) and report the real overturn rate — expecting it to be modest, not 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)