### PR TITLE
fix(overview): move all stat tiles above latency breakdown table

### DIFF
--- a/web/src/pages/Overview.jsx
+++ b/web/src/pages/Overview.jsx
@@ -47,6 +47,12 @@ function Summary() {
         <Stat label="Realised savings" value={fmt.usd(savings?.totalSaved)} />
       </div>
 
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <Stat label="Cache hit rate" value={`${((data.cacheHitRate || 0) * 100).toFixed(1)}%`} />
+        <Stat label="Cached tokens" value={fmt.num(data.cachedReadTokens)} />
+        <Stat label="Cache savings" value={fmt.usd(data.cacheSavingUsd)} />
+      </div>
+
       <Card title="Latency breakdown">
         <table className="w-full text-sm">
           <thead>
@@ -75,12 +81,6 @@ function Summary() {
           </p>
         )}
       </Card>
-
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <Stat label="Cache hit rate" value={`${((data.cacheHitRate || 0) * 100).toFixed(1)}%`} />
-        <Stat label="Cached tokens" value={fmt.num(data.cachedReadTokens)} />
-        <Stat label="Cache savings" value={fmt.usd(data.cacheSavingUsd)} />
-      </div>
 
       <TrendChart />
 


### PR DESCRIPTION
## Summary

Reorders the Overview → Summary tab so all number tiles come first, then the latency table:

1. Cost tiles (Total requests / Total cost / Avg cost / Realised savings)
2. Cache tiles (Cache hit rate / Cached tokens / Cache savings)
3. Latency breakdown table
4. Cost & request trend chart

## Test plan

- [ ] Overview → Summary: cost + cache tiles appear before the latency table
- [ ] All existing data still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)