### PR TITLE
Benchmark curation: severity-weighted scoring (#6) + pin problem cases (#7)

### DIFF
--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -912,6 +912,70 @@ router.delete("/eval-benchmarks/:id", async (req, res, next) => {
   } catch (e) { next(e); }
 });
 
+// Curation: pin a specific logged request into a benchmark as a case (e.g. one that went wrong).
+router.post("/eval-benchmarks/:id/items", async (req, res, next) => {
+  try {
+    const bench = await EvalDataset.findById(req.params.id).catch(() => null);
+    if (!bench || !bench.isBenchmark) return res.status(404).json({ error: "not found" });
+    const { requestId, severity } = req.body || {};
+    if (!requestId) return res.status(400).json({ error: "requestId is required" });
+    const rec = await RequestRecord.findOne({ requestId }).lean().catch(() => null);
+    if (!rec) return res.status(404).json({ error: "request not found" });
+    if (!evalDatasetBuilder.isEligible(rec)) return res.status(422).json({ error: "not_replayable", message: "That request has no captured single-shot prompt + response to replay." });
+    if (await EvalItem.findOne({ datasetId: bench._id, requestId })) return res.status(409).json({ error: "already_in_benchmark", message: "That request is already a case in this benchmark." });
+
+    const settings = await Settings.get().catch(() => ({}));
+    const { messages, productionResponse } = evalDatasetBuilder.projectText(rec, bench.piiMode, !!settings.piiMaskingEnabled, settings.customPiiPatterns || []);
+    const sev = ["trivial", "normal", "critical"].includes(severity) ? severity : "normal";
+    const item = await EvalItem.create({
+      datasetId: bench._id, requestId: rec.requestId, application: rec.application || null,
+      workflow: rec.workflow || null, taskType: rec.taskType || null, currentModel: rec.model || null,
+      messages, productionResponse, productionCost: rec.totalCost || 0, productionLatencyMs: rec.latencyMs || 0,
+      promptHash: evalDatasetBuilder.promptHashOf(rec.messages), responseHash: evalDatasetBuilder.responseHashOf(rec.responseText),
+      severity: sev, pinned: true,
+    });
+    await EvalDataset.updateOne({ _id: bench._id }, { $inc: { itemCount: 1 } });
+    setImmediate(() => logAction("benchmark.item.add", "evalItem", String(item._id), { benchmarkId: String(bench._id), requestId, severity: sev }));
+    res.status(201).json(item);
+  } catch (e) { next(e); }
+});
+
+// List a benchmark's cases (for curation) — compact, with a response preview.
+router.get("/eval-benchmarks/:id/items", async (req, res, next) => {
+  try {
+    const bench = await EvalDataset.findById(req.params.id).lean().catch(() => null);
+    if (!bench || !bench.isBenchmark) return res.status(404).json({ error: "not found" });
+    const items = await EvalItem.find({ datasetId: bench._id },
+      { requestId: 1, taskType: 1, severity: 1, pinned: 1, productionResponse: 1 }).sort({ createdAt: -1 }).lean();
+    res.json(items.map((it) => ({
+      _id: it._id, requestId: it.requestId, taskType: it.taskType, severity: it.severity || "normal",
+      pinned: !!it.pinned, preview: String(it.productionResponse || "").slice(0, 140),
+    })));
+  } catch (e) { next(e); }
+});
+
+// Set a case's severity (weights the worse-rate on the next run).
+router.patch("/eval-items/:id", async (req, res, next) => {
+  try {
+    const { severity } = req.body || {};
+    if (!["trivial", "normal", "critical"].includes(severity)) return res.status(400).json({ error: "severity must be trivial | normal | critical" });
+    const item = await EvalItem.findByIdAndUpdate(req.params.id, { $set: { severity } }, { new: true }).lean().catch(() => null);
+    if (!item) return res.status(404).json({ error: "not found" });
+    res.json(item);
+  } catch (e) { next(e); }
+});
+
+// Remove a case from a benchmark.
+router.delete("/eval-items/:id", async (req, res, next) => {
+  try {
+    const item = await EvalItem.findById(req.params.id).lean().catch(() => null);
+    if (!item) return res.status(404).json({ error: "not found" });
+    await EvalItem.deleteOne({ _id: item._id });
+    await EvalDataset.updateOne({ _id: item.datasetId }, { $inc: { itemCount: -1 } });
+    res.json({ ok: true });
+  } catch (e) { next(e); }
+});
+
 // ── Eval datasets / runs (read views) ─────────────────────────────────────────
 router.get("/evals/datasets", async (req, res, next) => {
   try {

--- a/server/src/eval/replay.js
+++ b/server/src/eval/replay.js
@@ -12,6 +12,10 @@ const { clampText, maskPii } = require("../logging/piiFilter");
 const { judgeItem, disproveWorse, runValidators, lastUserText } = require("./rubricJudge");
 const { evaluateRun } = require("./thresholds");
 
+// Curation weights for the severity-weighted worse-rate. "normal" = 1 so uncurated benchmarks are
+// unchanged; a critical regression counts 3x, a trivial one 0.3x.
+const SEVERITY_WEIGHT = { trivial: 0.3, normal: 1, critical: 3 };
+
 function percentile(sorted, p) {
   if (!sorted.length) return 0;
   const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
@@ -32,6 +36,18 @@ function aggregate(entries) {
   const formatPasses = ok.filter((e) => e.formatPass).length;
   const disprovedWorse = ok.filter((e) => e.disproved).length; // "worse" calls overturned on falsification
 
+  // Severity-weighted worse-rate: a critical miss counts more than a trivial one. Uniform "normal"
+  // severity → identical to the raw rate, so uncurated benchmarks are unaffected.
+  const wt = (e) => SEVERITY_WEIGHT[e.severity] ?? 1;
+  const judgedWeight = sum(judged, wt);
+  const worseWeight = sum(judged.filter((e) => e.verdict === "worse"), wt);
+  const worseRateWeighted = judgedWeight ? worseWeight / judgedWeight : 0;
+  const severityBreakdown = {};
+  for (const sev of Object.keys(SEVERITY_WEIGHT)) {
+    const g = judged.filter((e) => (e.severity || "normal") === sev);
+    if (g.length) severityBreakdown[sev] = { judged: g.length, worse: g.filter((e) => e.verdict === "worse").length };
+  }
+
   const prodCost = sum(ok, (e) => e.productionCost);
   const candCost = sum(ok, (e) => e.candidateCost);
   const prodLat = sum(ok, (e) => e.productionLatencyMs);
@@ -46,7 +62,10 @@ function aggregate(entries) {
   return {
     total, judged: judged.length,
     candidateBetter: better, candidateEqual: equal, candidateWorse: worse,
-    worseRate: judged.length ? worse / judged.length : 0,
+    // worseRate is the severity-WEIGHTED rate (drives the gate); worseRateRaw is the plain count.
+    worseRate: worseRateWeighted,
+    worseRateRaw: judged.length ? worse / judged.length : 0,
+    severityBreakdown,
     disprovedWorse,
     criticalFailRate: ok.length ? critical / ok.length : 0,
     formatPassRate: ok.length ? formatPasses / ok.length : 1,
@@ -198,6 +217,7 @@ async function executeRun(runId) {
       });
       entries.push({
         verdict: finalVerdict,
+        severity: item.severity || "normal",
         criticalFailure: scored ? !!scored.criticalFailure : false,
         formatPass, candidateCost: candCost, candidateLatencyMs: candidate.latencyMs || 0,
         productionCost: item.productionCost || 0, productionLatencyMs: item.productionLatencyMs || 0,

--- a/server/src/models/EvalItem.js
+++ b/server/src/models/EvalItem.js
@@ -20,6 +20,13 @@ const evalItemSchema = new mongoose.Schema(
     promptHash: { type: String, default: null, index: true },
     responseHash: { type: String, default: null },
 
+    // Curation: how much a regression on THIS item matters. Weights the worse-rate so one critical
+    // miss counts more than several trivial ones (DoorDash's weighted recall). Human-set; default
+    // "normal" (weight 1) → an uncurated benchmark scores exactly as before.
+    severity: { type: String, enum: ["trivial", "normal", "critical"], default: "normal", index: true },
+    // Whether this case was hand-added (pinned) rather than sampled from traffic.
+    pinned: { type: Boolean, default: false },
+
     // Optional per-item output validators (json_schema | regex | contains | classification_label).
     validators: { type: [mongoose.Schema.Types.Mixed], default: [] },
     metadata: {

--- a/server/test/unit/evalSeverityWeighting.test.js
+++ b/server/test/unit/evalSeverityWeighting.test.js
@@ -1,0 +1,35 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { aggregate } = require("../../src/eval/replay");
+
+const item = (verdict, severity) => ({
+  verdict, severity, errored: false, criticalFailure: false, formatPass: true,
+  candidateCost: 0, candidateLatencyMs: 0, productionCost: 0, productionLatencyMs: 0,
+});
+
+test("uniform severity → weighted worse-rate equals the raw rate", () => {
+  const s = aggregate([item("worse", "normal"), item("better", "normal"), item("better", "normal"), item("better", "normal")]);
+  assert.equal(s.worseRateRaw, 0.25);
+  assert.equal(s.worseRate, 0.25); // weighted == raw when all normal
+});
+
+test("a critical miss outweighs trivial passes", () => {
+  // 1 critical worse (w=3) + 3 trivial better (w=0.3 each = 0.9). weighted = 3 / (3+0.9) ≈ 0.769
+  const s = aggregate([item("worse", "critical"), item("better", "trivial"), item("better", "trivial"), item("better", "trivial")]);
+  assert.equal(s.worseRateRaw, 0.25);          // 1 of 4 raw
+  assert.ok(s.worseRate > 0.75 && s.worseRate < 0.78); // weighted heavily by the critical miss
+});
+
+test("a trivial miss barely moves the weighted rate", () => {
+  // 1 trivial worse (w=0.3) + 3 critical better (w=9). weighted = 0.3 / 9.3 ≈ 0.032
+  const s = aggregate([item("worse", "trivial"), item("better", "critical"), item("better", "critical"), item("better", "critical")]);
+  assert.equal(s.worseRateRaw, 0.25);
+  assert.ok(s.worseRate < 0.05);
+});
+
+test("severity breakdown counts judged + worse per band", () => {
+  const s = aggregate([item("worse", "critical"), item("better", "critical"), item("equal", "normal")]);
+  assert.deepEqual(s.severityBreakdown.critical, { judged: 2, worse: 1 });
+  assert.deepEqual(s.severityBreakdown.normal, { judged: 1, worse: 0 });
+});

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -88,6 +88,11 @@ export const api = {
   createBenchmark: (body) => req("/eval-benchmarks", { method: "POST", body: JSON.stringify(body) }),
   runBenchmark: (id, body) => req(`/eval-benchmarks/${id}/run`, { method: "POST", body: JSON.stringify(body) }),
   deleteBenchmark: (id) => req(`/eval-benchmarks/${id}`, { method: "DELETE" }),
+  // Curation: pin cases + set per-case severity.
+  benchmarkItems: (id) => req(`/eval-benchmarks/${id}/items`),
+  addBenchmarkItem: (id, body) => req(`/eval-benchmarks/${id}/items`, { method: "POST", body: JSON.stringify(body) }),
+  setEvalItemSeverity: (itemId, severity) => req(`/eval-items/${itemId}`, { method: "PATCH", body: JSON.stringify({ severity }) }),
+  deleteEvalItem: (itemId) => req(`/eval-items/${itemId}`, { method: "DELETE" }),
   evalRun: (id) => req(`/evals/runs/${id}`),
   deleteEvalRun: (id) => req(`/evals/runs/${id}`, { method: "DELETE" }),
   evalRunResults: (id) => req(`/evals/runs/${id}/results`),

--- a/web/src/pages/ModelEvals.jsx
+++ b/web/src/pages/ModelEvals.jsx
@@ -536,8 +536,12 @@ function BenchmarkDetail({ id, models, onClose }) {
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState(null);
   const [notice, setNotice] = useState(null);
+  const [items, setItems] = useState(null);
+  const [newCase, setNewCase] = useState({ requestId: "", severity: "critical" });
+  const [caseErr, setCaseErr] = useState(null);
   const load = useCallback(() => { api.benchmark(id).then(setBench).catch((e) => setBench({ _error: e.message })); }, [id]);
-  useEffect(() => { load(); }, [load]);
+  const loadItems = useCallback(() => { api.benchmarkItems(id).then(setItems).catch(() => setItems([])); }, [id]);
+  useEffect(() => { load(); loadItems(); }, [load, loadItems]);
 
   const runCand = async () => {
     setBusy(true); setErr(null); setNotice(null);
@@ -547,6 +551,15 @@ function BenchmarkDetail({ id, models, onClose }) {
       setCand(""); load();
     } catch (e) { setErr(e.message); } finally { setBusy(false); }
   };
+  const addCase = async () => {
+    setCaseErr(null);
+    try {
+      await api.addBenchmarkItem(id, { requestId: newCase.requestId.trim(), severity: newCase.severity });
+      setNewCase({ requestId: "", severity: "critical" }); loadItems(); load();
+    } catch (e) { setCaseErr(e.message); }
+  };
+  const setSeverity = async (it, severity) => { await api.setEvalItemSeverity(it._id, severity).catch(() => {}); loadItems(); };
+  const removeCase = async (it) => { await api.deleteEvalItem(it._id).catch(() => {}); loadItems(); load(); };
 
   if (!bench) return <Drawer title="Benchmark" onClose={onClose}><Spinner /></Drawer>;
   if (bench._error) return <Drawer title="Benchmark" onClose={onClose}><div className="text-sm text-red-600">{bench._error}</div></Drawer>;
@@ -609,6 +622,40 @@ function BenchmarkDetail({ id, models, onClose }) {
         <div>
           <div className="label mb-2">Leaderboard — ranked by quality per dollar (per 1k requests)</div>
           <Table columns={cols} rows={rows} empty="No models scored yet — run one above." />
+          <div className="mt-1 text-xs text-gray-400">Worse-rate is severity-weighted; re-run a model after changing case severities to update its score.</div>
+        </div>
+
+        <div>
+          <div className="label mb-2">Cases ({items ? fmt.num(items.length) : "…"}) — severity weights the worse-rate (critical ×3, trivial ×0.3)</div>
+          <div className="mb-2 flex flex-wrap items-end gap-2">
+            <div>
+              <div className="label mb-1">Pin a request by ID</div>
+              <input className="input w-64" placeholder="e.g. a request that went wrong"
+                value={newCase.requestId} onChange={(e) => setNewCase((c) => ({ ...c, requestId: e.target.value }))} />
+            </div>
+            <div>
+              <div className="label mb-1">Severity</div>
+              <select className="input" value={newCase.severity} onChange={(e) => setNewCase((c) => ({ ...c, severity: e.target.value }))}>
+                <option value="trivial">trivial</option><option value="normal">normal</option><option value="critical">critical</option>
+              </select>
+            </div>
+            <button className="btn-outline text-sm" disabled={!newCase.requestId.trim()} onClick={addCase}>Add case</button>
+          </div>
+          {caseErr && <div className="mb-2 text-sm text-red-600">{caseErr}</div>}
+          {items === null ? <Spinner /> : items.length === 0 ? <div className="text-sm text-gray-400">No cases yet.</div> : (
+            <div className="max-h-72 divide-y divide-gray-100 overflow-y-auto rounded-lg border border-gray-200">
+              {items.map((it) => (
+                <div key={it._id} className="flex items-center gap-3 px-3 py-2 text-sm">
+                  <select className="input !py-1 text-xs" value={it.severity} onChange={(e) => setSeverity(it, e.target.value)}>
+                    <option value="trivial">trivial</option><option value="normal">normal</option><option value="critical">critical</option>
+                  </select>
+                  <span className="w-32 shrink-0 text-xs text-gray-500">{it.taskType || "—"}{it.pinned ? " · pinned" : ""}</span>
+                  <span className="min-w-0 flex-1 truncate text-gray-600" title={it.preview}>{it.preview}</span>
+                  <button className="btn-outline shrink-0 text-xs text-red-600" onClick={() => removeCase(it)}>Remove</button>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </Drawer>


### PR DESCRIPTION
Good-to-haves **#6 severity-weighted scoring** + **#7 pin problem cases** (the item-level benchmark curation set). DoorDash's headline metric is *weighted* recall — one critical miss should outweigh several trivial ones.

## What's new
- **Severity per case** (`trivial` / `normal` / `critical`) on benchmark items.
- **Severity-weighted worse-rate**: critical ×3, trivial ×0.3. Uniform `normal` → **identical to the raw rate**, so existing/uncurated benchmarks score exactly as before. The summary now carries `worseRate` (weighted, drives the gate), `worseRateRaw`, and a per-severity breakdown.
- **Pin a problem case**: add a specific logged request (e.g. one that went wrong) to a benchmark by request ID, reusing the dataset builder's eligibility + PII projection. `POST /eval-benchmarks/:id/items`, plus list / `PATCH /eval-items/:id` (severity) / `DELETE /eval-items/:id`.
- **Benchmark drawer → "Cases"**: pin a request with a severity, change any case's severity inline, remove cases; leaderboard notes the worse-rate is weighted (re-run a model after editing severities to update its score).

## Testing
`evalSeverityWeighting.test.js` (weighted rate == raw when uniform; a critical miss dominates; trivial barely moves it; breakdown counts). Full unit suite passes; lint + web build clean.

Next in this set: **#5 human-curated verdicts** (override the judge on a result) and **#8 acceptance-rate feedback loop**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)