### PR TITLE
Human-curated verdicts: override the judge, re-score the run (#5)

### DIFF
--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -1055,6 +1055,21 @@ router.get("/evals/runs/:id/results", async (req, res, next) => {
   } catch (e) { next(e); }
 });
 
+// Human-curated verdict: override (or clear) the judge on one result, then re-score the run.
+router.patch("/evals/results/:id", async (req, res, next) => {
+  try {
+    const { verdict } = req.body || {};
+    if (verdict != null && !["better", "equal", "worse"].includes(verdict)) {
+      return res.status(400).json({ error: "verdict must be better | equal | worse (or null to clear)" });
+    }
+    const result = await EvalResult.findByIdAndUpdate(req.params.id, { $set: { humanVerdict: verdict ?? null } }, { new: true }).lean().catch(() => null);
+    if (!result) return res.status(404).json({ error: "not found" });
+    const run = await evalReplay.recomputeRun(result.evalRunId); // re-score with the override
+    setImmediate(() => logAction("eval.verdict.override", "evalResult", String(result._id), { verdict: verdict ?? null }));
+    res.json({ result, run });
+  } catch (e) { next(e); }
+});
+
 // Clamp/normalize canary guardrail inputs to sane numbers (falls back to defaults).
 function sanitizeGuardrails(g) {
   const d = { maxErrorRateIncrease: 0.02, maxLatencyRegressionPct: 0.25, maxWorseRate: 0.10, minCostSavingPct: 0.10 };

--- a/server/src/eval/replay.js
+++ b/server/src/eval/replay.js
@@ -278,4 +278,39 @@ async function finish(run, entries, hardError, actualCost = 0) {
   return run;
 }
 
-module.exports = { startRun, executeRun, aggregate, estimateRunCost };
+// Re-score a finished run from its stored results, applying human verdict overrides
+// (effective verdict = humanVerdict ?? judgeVerdict) and current per-item severities. Rebuilds the
+// summary via aggregate() and re-evaluates pass/fail, so a human correcting the judge can flip the
+// outcome. Cost/latency are unchanged by an override; they're recomputed from the same stored data.
+async function recomputeRun(runId) {
+  const run = await EvalRun.findById(runId);
+  if (!run || !["passed", "failed"].includes(run.status)) return run || null;
+  const results = await EvalResult.find({ evalRunId: run._id }).lean();
+  const itemIds = results.map((r) => r.evalItemId).filter(Boolean);
+  const items = await EvalItem.find({ _id: { $in: itemIds } }, { severity: 1, productionCost: 1, productionLatencyMs: 1 }).lean();
+  const byItem = new Map(items.map((it) => [String(it._id), it]));
+
+  const entries = results.map((r) => {
+    if (r.error) return { errored: true };
+    const it = byItem.get(String(r.evalItemId)) || {};
+    return {
+      verdict: r.humanVerdict || r.judgeVerdict || null,
+      severity: it.severity || "normal",
+      criticalFailure: !!r.criticalFailure,
+      formatPass: r.formatPass !== false,
+      candidateCost: r.candidateCost || 0, candidateLatencyMs: r.candidateLatencyMs || 0,
+      productionCost: it.productionCost || 0, productionLatencyMs: it.productionLatencyMs || 0,
+      errored: false, disproved: !!r.disproved,
+    };
+  });
+  const summary = aggregate(entries);
+  summary.humanOverrides = results.filter((r) => r.humanVerdict).length;
+  run.summary = summary;
+  const { passed, failures } = evaluateRun(summary, run.thresholds || {});
+  run.status = passed ? "passed" : "failed";
+  run.failures = failures;
+  await run.save();
+  return run;
+}
+
+module.exports = { startRun, executeRun, aggregate, estimateRunCost, recomputeRun };

--- a/server/src/models/EvalResult.js
+++ b/server/src/models/EvalResult.js
@@ -15,6 +15,9 @@ const evalResultSchema = new mongoose.Schema(
     candidateLatencyMs: { type: Number, default: 0 },
 
     judgeVerdict: { type: String, enum: ["better", "equal", "worse", null], default: null },
+    // A human's overriding verdict for this item (ground truth). When set, it beats the judge in
+    // scoring: the effective verdict = humanVerdict ?? judgeVerdict, and the run is re-scored.
+    humanVerdict: { type: String, enum: ["better", "equal", "worse", null], default: null },
     // The judge's FIRST-pass verdict, kept when the "disprove it" pass overturned a "worse" call.
     preDisproveVerdict: { type: String, enum: ["better", "equal", "worse", null], default: null },
     disproved: { type: Boolean, default: false }, // a "worse" verdict was overturned on falsification

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -96,6 +96,7 @@ export const api = {
   evalRun: (id) => req(`/evals/runs/${id}`),
   deleteEvalRun: (id) => req(`/evals/runs/${id}`, { method: "DELETE" }),
   evalRunResults: (id) => req(`/evals/runs/${id}/results`),
+  setResultVerdict: (resultId, verdict) => req(`/evals/results/${resultId}`, { method: "PATCH", body: JSON.stringify({ verdict }) }),
 
   // Routing experiments (canary rollout).
   routingExperiments: (status) => req(`/routing-experiments${qs({ status })}`),

--- a/web/src/pages/ModelEvals.jsx
+++ b/web/src/pages/ModelEvals.jsx
@@ -194,6 +194,12 @@ function RunDetail({ id, onClose }) {
   }, [id]);
   useEffect(() => { load(); }, [load]);
 
+  // Human-curated verdict: override the judge on an item; the run is re-scored server-side.
+  const overrideVerdict = async (resultId, verdict) => {
+    await api.setResultVerdict(resultId, verdict).catch(() => {});
+    load();
+  };
+
   // A passed eval seeds the next pipeline stages directly — no recommendation, no override
   // (the passed run itself is the gate, linked via requiredEvalRunId).
   const promote = async (fn, ok) => {
@@ -288,10 +294,20 @@ function RunDetail({ id, onClose }) {
             {results.slice(0, 20).map((r) => (
               <div key={r._id} className="rounded-lg border border-gray-200 p-3">
                 <div className="flex items-center gap-2">
-                  {r.judgeVerdict ? <Badge tone={VERDICT_TONE[r.judgeVerdict]}>{r.judgeVerdict}</Badge> : <Badge tone="gray">unjudged</Badge>}
+                  {(() => {
+                    const v = r.humanVerdict || r.judgeVerdict;
+                    return v ? <Badge tone={VERDICT_TONE[v]}>{v}{r.humanVerdict ? " · human" : ""}</Badge> : <Badge tone="gray">unjudged</Badge>;
+                  })()}
                   {r.criticalFailure && <Badge tone="red">critical</Badge>}
                   {!r.formatPass && <Badge tone="amber">format fail</Badge>}
                   {r.error && <span className="text-xs text-red-600">{r.error}</span>}
+                  <select className="input ml-auto !py-0.5 text-xs" title="Override the judge (re-scores the run)"
+                    value={r.humanVerdict || ""} onChange={(e) => overrideVerdict(r._id, e.target.value || null)}>
+                    <option value="">judge: {r.judgeVerdict || "—"}</option>
+                    <option value="better">mark better</option>
+                    <option value="equal">mark equal</option>
+                    <option value="worse">mark worse</option>
+                  </select>
                 </div>
                 {r.judgeRationale && <p className="mt-2 text-sm text-gray-600">{r.judgeRationale}</p>}
                 {r.candidateResponse && <CodeBlock code={r.candidateResponse} />}


### PR DESCRIPTION
Good-to-have **#5** — the "human decides" ethos applied to eval verdicts. **Stacked on #123** (shared `replay.js`/`ModelEvals.jsx`); merge #123 first.

## What it does
A person can override the judge on any result. The human verdict beats the judge in scoring (effective = `humanVerdict ?? judgeVerdict`), and the run is **re-scored server-side** — so correcting a wrong "worse" can flip the outcome to pass (or vice-versa).

- `EvalResult.humanVerdict`.
- `replay.recomputeRun()` rebuilds the summary from stored results + current item severities (reuses `aggregate`, so severity weighting from #123 applies) and re-evaluates thresholds. Cost/latency are recomputed from the same stored data (unchanged by a verdict flip); `summary.humanOverrides` counts overrides.
- `PATCH /api/evals/results/:id { verdict }` → set/clear, recompute, return the updated run.
- RunDetail "worst examples": a per-result override dropdown; the badge shows the effective verdict tagged **· human** when overridden.

## Testing
Lint + eval unit suites + web build pass. (Live re-score verification after merge/deploy.)

That completes the good-to-haves (#4–#8). Remaining in the plan: nice-to-haves **#9 auto-benchmark**, **#10 cascade routing**, **#11 combo evals**. #8 (acceptance-rate loop) — next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)