### PR TITLE
Acceptance-rate feedback loop — production truth beside benchmarks (#8)

### DIFF
--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -558,6 +558,26 @@ router.get("/analytics/overview", async (req, res, next) => {
   try { res.json(await analytics.overview(req.query)); } catch (e) { next(e); }
 });
 
+// Adoption / acceptance-rate — the "production truth" beside benchmark scores: what humans actually
+// did with Arbr's suggestions (accepted vs dismissed) and its canaries (promoted vs rolled back).
+router.get("/analytics/acceptance", async (_req, res, next) => {
+  try {
+    const rc = Object.fromEntries((await Recommendation.aggregate([{ $group: { _id: "$status", n: { $sum: 1 } } }])).map((r) => [r._id, r.n]));
+    const accepted = rc.accepted || 0, dismissed = rc.dismissed || 0, pending = rc.pending || 0;
+    const decided = accepted + dismissed;
+    const overridden = await Recommendation.countDocuments({ evalStatus: "overridden" });
+    const ec = Object.fromEntries((await RoutingExperiment.aggregate([{ $group: { _id: "$status", n: { $sum: 1 } } }])).map((r) => [r._id, r.n]));
+    const promoted = ec.promoted || 0, rolledBack = ec.rolled_back || 0;
+    const canaryDecided = promoted + rolledBack;
+    res.json({
+      recommendations: { total: accepted + dismissed + pending, accepted, dismissed, pending, overridden,
+        acceptanceRate: decided ? accepted / decided : null },
+      canaries: { promoted, rolledBack, active: ec.active || 0, paused: ec.paused || 0,
+        promotionRate: canaryDecided ? promoted / canaryDecided : null },
+    });
+  } catch (e) { next(e); }
+});
+
 const VIEWS = {
   application: analytics.byApplication,
   team: analytics.byTeam,

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -83,6 +83,7 @@ export const api = {
   evalRuns: (recommendationId) => req(`/evals/runs${qs({ recommendationId })}`),
 
   // Reusable benchmarks ("DashBench"): a named frozen set, scored against many candidates.
+  acceptanceStats: () => req("/analytics/acceptance"),
   benchmarks: () => req("/eval-benchmarks"),
   benchmark: (id) => req(`/eval-benchmarks/${id}`),
   createBenchmark: (body) => req("/eval-benchmarks", { method: "POST", body: JSON.stringify(body) }),

--- a/web/src/pages/ModelEvals.jsx
+++ b/web/src/pages/ModelEvals.jsx
@@ -798,6 +798,7 @@ export default function ModelEvals() {
   const [openId, setOpenId] = useState(null);
   const [confirmDel, setConfirmDel] = useState(null);
   const [override, setOverride] = useState(null); // { campaign, message } when the gate blocks resume
+  const [adoption, setAdoption] = useState(null);
   const [err, setErr] = useState(null);
 
   const load = useCallback(() => {
@@ -809,6 +810,7 @@ export default function ModelEvals() {
     // Candidate + judge get CALLED during a run, so only offer connected, chat-capable models.
     api.models({ live: true, routable: true }).then((m) => setModels(m || [])).catch(() => {});
     api.facets().then((f) => setApps([...new Set(f?.applications || [])])).catch(() => {});
+    api.acceptanceStats().then(setAdoption).catch(() => {});
   }, [load]);
 
   // Activating a shadow campaign is gated on a passed offline eval (or an override). If the gate
@@ -861,6 +863,19 @@ export default function ModelEvals() {
         <h1 className="text-2xl font-bold text-arbr-charcoal">Model Evals</h1>
         <p className="mt-1 text-sm text-gray-500">Prove a cheaper model is no worse than the current one before it becomes a rule. The stages below follow that flow — offline eval → shadow → canary → promote.</p>
       </div>
+
+      {adoption && (adoption.recommendations.acceptanceRate != null || adoption.canaries.promotionRate != null) && (
+        <Card title="Adoption — the production-truth signal beside benchmark scores">
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <Stat label="Recommendations accepted" value={adoption.recommendations.acceptanceRate == null ? "—" : pct(adoption.recommendations.acceptanceRate)}
+              sub={`${fmt.num(adoption.recommendations.accepted)} of ${fmt.num(adoption.recommendations.accepted + adoption.recommendations.dismissed)} decided`} />
+            <Stat label="Dismissed" value={fmt.num(adoption.recommendations.dismissed)} sub={`${fmt.num(adoption.recommendations.pending)} pending`} />
+            <Stat label="Canaries promoted" value={adoption.canaries.promotionRate == null ? "—" : pct(adoption.canaries.promotionRate)}
+              sub={`${fmt.num(adoption.canaries.promoted)} promoted · ${fmt.num(adoption.canaries.rolledBack)} rolled back`} />
+            <Stat label="Overrides" value={fmt.num(adoption.recommendations.overridden)} sub="accepted without a passed eval" />
+          </div>
+        </Card>
+      )}
 
       <StageHeading n="1" title="Offline eval" desc="Replay past traffic through a candidate and judge it against the baseline. No production impact." />
       <BenchmarksSection models={models} apps={apps} />


### PR DESCRIPTION
Good-to-have **#8**, the last of the set — DoorDash's *two-tier* evaluation: benchmark scores **plus** real-world acceptance as the ultimate signal. **Stacked on #124** (→ #123 → main); merge in order.

## What it does
Surfaces what humans actually did with Arbr's suggestions:
- **`GET /api/analytics/acceptance`** — recommendations accepted / dismissed / pending / overridden + **acceptanceRate**, and canaries promoted / rolled_back + **promotionRate**, aggregated from the `Recommendation` and `RoutingExperiment` collections.
- **Model Evals → "Adoption" card**: acceptance rate, dismissed/pending, canary promotion rate, and override count — framed as the production-truth signal beside benchmark scores. Hidden until there's ≥1 decided recommendation or canary.

## Testing
Lint + web build pass. (Endpoint verifies on prod after deploy — it's read-only aggregation.)

## Plan status after this
✅ Must-haves (1–3) · ✅ Good-to-haves (4–8) · ✅ #12. **Remaining: nice-to-haves #9 auto-benchmark, #10 cascade routing, #11 combo evals.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)