### PR TITLE
Auto-benchmark: suggest cheaper unscored candidates (#9, cost-safe)

### DIFF
--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -892,7 +892,26 @@ router.get("/eval-benchmarks/:id", async (req, res, next) => {
       return { ...r, efficiency: efficiencyOf(r.summary, r.actualCostUsd), judge: judgeReliability(verdicts) };
     }));
     leaderboard.sort((a, b) => (b.efficiency.qualityPerDollar ?? -1) - (a.efficiency.qualityPerDollar ?? -1));
-    res.json({ ...bench, leaderboard });
+
+    // "Auto-benchmark" (cost-safe): connected, chat-capable models CHEAPER than the baseline that
+    // haven't been scored yet — the candidates most worth trying. Suggestions only; scoring (which
+    // spends tokens) stays a human click. Ranked by biggest saving vs the baseline.
+    const avgPrice = (m) => ((m?.inputPer1M || 0) + (m?.outputPer1M || 0)) / 2;
+    const basePrice = avgPrice(pricing.getModel(bench.baselineModel));
+    const scored = new Set(runs.map((r) => r.candidateModel));
+    let suggestedCandidates = [];
+    if (basePrice > 0) {
+      const { eff } = await getRouter().catch(() => ({}));
+      const liveIds = new Set(eff?.liveIds || []);
+      suggestedCandidates = pricing.listModels()
+        .filter((m) => liveIds.has(m.provider) && m.chatCapable !== false && m.id !== bench.baselineModel
+          && !scored.has(m.id) && avgPrice(m) > 0 && avgPrice(m) < basePrice)
+        .map((m) => ({ model: m.id, provider: m.provider, label: m.label || m.id, tier: m.tier,
+          savingVsBaselinePct: (basePrice - avgPrice(m)) / basePrice }))
+        .sort((a, b) => b.savingVsBaselinePct - a.savingVsBaselinePct)
+        .slice(0, 6);
+    }
+    res.json({ ...bench, leaderboard, suggestedCandidates });
   } catch (e) { next(e); }
 });
 

--- a/web/src/pages/ModelEvals.jsx
+++ b/web/src/pages/ModelEvals.jsx
@@ -633,6 +633,19 @@ function BenchmarkDetail({ id, models, onClose }) {
           </div>
           {err && <div className="mt-2 text-sm text-red-600">{err}</div>}
           {notice && <div className="mt-2 text-sm text-arbr-green-700">{notice}</div>}
+          {bench.suggestedCandidates?.length > 0 && (
+            <div className="mt-3 border-t border-gray-100 pt-3">
+              <div className="text-xs text-gray-500">Suggested — connected models cheaper than the baseline, not scored yet. Click to load one, then Run:</div>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {bench.suggestedCandidates.map((s) => (
+                  <button key={s.model} className="btn-outline text-xs" onClick={() => setCand(s.model)}
+                    title={`~${pct(s.savingVsBaselinePct)} cheaper than ${bench.baselineModel}`}>
+                    {s.label} · −{pct(s.savingVsBaselinePct)}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
 
         <div>


### PR DESCRIPTION
Nice-to-have **#9**, in its **cost-safe** form. **Stacked on #125** (→124→123→main).

DoorDash's lesson is "adopt the winner the moment it wins" — but auto-running every new model against every benchmark spends real tokens. So this **surfaces** the candidates most worth trying instead of auto-spending:

- `GET /eval-benchmarks/:id` returns **`suggestedCandidates`**: connected, chat-capable models **cheaper than the baseline** that **haven't been scored yet**, ranked by saving vs the baseline (top 6).
- The benchmark drawer shows them as chips (`model · −45%`); clicking one **pre-fills** the "Score a model" candidate select — the human still picks a judge and hits Run. No auto-spend.

Lint + web build pass.

## Plan status
✅ Must-haves · ✅ Good-to-haves (4–8) · ✅ #9, #12. **Remaining: #10 cascade routing, #11 combo evals** (the big hot-path build; #11 depends on #10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)