### PR TITLE
Land #5/#8/#9 on main (stacked merges landed in branches, not main)

### DIFF
--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -558,6 +558,26 @@ router.get("/analytics/overview", async (req, res, next) => {
   try { res.json(await analytics.overview(req.query)); } catch (e) { next(e); }
 });
 
+// Adoption / acceptance-rate — the "production truth" beside benchmark scores: what humans actually
+// did with Arbr's suggestions (accepted vs dismissed) and its canaries (promoted vs rolled back).
+router.get("/analytics/acceptance", async (_req, res, next) => {
+  try {
+    const rc = Object.fromEntries((await Recommendation.aggregate([{ $group: { _id: "$status", n: { $sum: 1 } } }])).map((r) => [r._id, r.n]));
+    const accepted = rc.accepted || 0, dismissed = rc.dismissed || 0, pending = rc.pending || 0;
+    const decided = accepted + dismissed;
+    const overridden = await Recommendation.countDocuments({ evalStatus: "overridden" });
+    const ec = Object.fromEntries((await RoutingExperiment.aggregate([{ $group: { _id: "$status", n: { $sum: 1 } } }])).map((r) => [r._id, r.n]));
+    const promoted = ec.promoted || 0, rolledBack = ec.rolled_back || 0;
+    const canaryDecided = promoted + rolledBack;
+    res.json({
+      recommendations: { total: accepted + dismissed + pending, accepted, dismissed, pending, overridden,
+        acceptanceRate: decided ? accepted / decided : null },
+      canaries: { promoted, rolledBack, active: ec.active || 0, paused: ec.paused || 0,
+        promotionRate: canaryDecided ? promoted / canaryDecided : null },
+    });
+  } catch (e) { next(e); }
+});
+
 const VIEWS = {
   application: analytics.byApplication,
   team: analytics.byTeam,

--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -1055,6 +1055,21 @@ router.get("/evals/runs/:id/results", async (req, res, next) => {
   } catch (e) { next(e); }
 });
 
+// Human-curated verdict: override (or clear) the judge on one result, then re-score the run.
+router.patch("/evals/results/:id", async (req, res, next) => {
+  try {
+    const { verdict } = req.body || {};
+    if (verdict != null && !["better", "equal", "worse"].includes(verdict)) {
+      return res.status(400).json({ error: "verdict must be better | equal | worse (or null to clear)" });
+    }
+    const result = await EvalResult.findByIdAndUpdate(req.params.id, { $set: { humanVerdict: verdict ?? null } }, { new: true }).lean().catch(() => null);
+    if (!result) return res.status(404).json({ error: "not found" });
+    const run = await evalReplay.recomputeRun(result.evalRunId); // re-score with the override
+    setImmediate(() => logAction("eval.verdict.override", "evalResult", String(result._id), { verdict: verdict ?? null }));
+    res.json({ result, run });
+  } catch (e) { next(e); }
+});
+
 // Clamp/normalize canary guardrail inputs to sane numbers (falls back to defaults).
 function sanitizeGuardrails(g) {
   const d = { maxErrorRateIncrease: 0.02, maxLatencyRegressionPct: 0.25, maxWorseRate: 0.10, minCostSavingPct: 0.10 };

--- a/server/src/api/routes.js
+++ b/server/src/api/routes.js
@@ -892,7 +892,26 @@ router.get("/eval-benchmarks/:id", async (req, res, next) => {
       return { ...r, efficiency: efficiencyOf(r.summary, r.actualCostUsd), judge: judgeReliability(verdicts) };
     }));
     leaderboard.sort((a, b) => (b.efficiency.qualityPerDollar ?? -1) - (a.efficiency.qualityPerDollar ?? -1));
-    res.json({ ...bench, leaderboard });
+
+    // "Auto-benchmark" (cost-safe): connected, chat-capable models CHEAPER than the baseline that
+    // haven't been scored yet — the candidates most worth trying. Suggestions only; scoring (which
+    // spends tokens) stays a human click. Ranked by biggest saving vs the baseline.
+    const avgPrice = (m) => ((m?.inputPer1M || 0) + (m?.outputPer1M || 0)) / 2;
+    const basePrice = avgPrice(pricing.getModel(bench.baselineModel));
+    const scored = new Set(runs.map((r) => r.candidateModel));
+    let suggestedCandidates = [];
+    if (basePrice > 0) {
+      const { eff } = await getRouter().catch(() => ({}));
+      const liveIds = new Set(eff?.liveIds || []);
+      suggestedCandidates = pricing.listModels()
+        .filter((m) => liveIds.has(m.provider) && m.chatCapable !== false && m.id !== bench.baselineModel
+          && !scored.has(m.id) && avgPrice(m) > 0 && avgPrice(m) < basePrice)
+        .map((m) => ({ model: m.id, provider: m.provider, label: m.label || m.id, tier: m.tier,
+          savingVsBaselinePct: (basePrice - avgPrice(m)) / basePrice }))
+        .sort((a, b) => b.savingVsBaselinePct - a.savingVsBaselinePct)
+        .slice(0, 6);
+    }
+    res.json({ ...bench, leaderboard, suggestedCandidates });
   } catch (e) { next(e); }
 });
 

--- a/server/src/eval/replay.js
+++ b/server/src/eval/replay.js
@@ -278,4 +278,39 @@ async function finish(run, entries, hardError, actualCost = 0) {
   return run;
 }
 
-module.exports = { startRun, executeRun, aggregate, estimateRunCost };
+// Re-score a finished run from its stored results, applying human verdict overrides
+// (effective verdict = humanVerdict ?? judgeVerdict) and current per-item severities. Rebuilds the
+// summary via aggregate() and re-evaluates pass/fail, so a human correcting the judge can flip the
+// outcome. Cost/latency are unchanged by an override; they're recomputed from the same stored data.
+async function recomputeRun(runId) {
+  const run = await EvalRun.findById(runId);
+  if (!run || !["passed", "failed"].includes(run.status)) return run || null;
+  const results = await EvalResult.find({ evalRunId: run._id }).lean();
+  const itemIds = results.map((r) => r.evalItemId).filter(Boolean);
+  const items = await EvalItem.find({ _id: { $in: itemIds } }, { severity: 1, productionCost: 1, productionLatencyMs: 1 }).lean();
+  const byItem = new Map(items.map((it) => [String(it._id), it]));
+
+  const entries = results.map((r) => {
+    if (r.error) return { errored: true };
+    const it = byItem.get(String(r.evalItemId)) || {};
+    return {
+      verdict: r.humanVerdict || r.judgeVerdict || null,
+      severity: it.severity || "normal",
+      criticalFailure: !!r.criticalFailure,
+      formatPass: r.formatPass !== false,
+      candidateCost: r.candidateCost || 0, candidateLatencyMs: r.candidateLatencyMs || 0,
+      productionCost: it.productionCost || 0, productionLatencyMs: it.productionLatencyMs || 0,
+      errored: false, disproved: !!r.disproved,
+    };
+  });
+  const summary = aggregate(entries);
+  summary.humanOverrides = results.filter((r) => r.humanVerdict).length;
+  run.summary = summary;
+  const { passed, failures } = evaluateRun(summary, run.thresholds || {});
+  run.status = passed ? "passed" : "failed";
+  run.failures = failures;
+  await run.save();
+  return run;
+}
+
+module.exports = { startRun, executeRun, aggregate, estimateRunCost, recomputeRun };

--- a/server/src/models/EvalResult.js
+++ b/server/src/models/EvalResult.js
@@ -15,6 +15,9 @@ const evalResultSchema = new mongoose.Schema(
     candidateLatencyMs: { type: Number, default: 0 },
 
     judgeVerdict: { type: String, enum: ["better", "equal", "worse", null], default: null },
+    // A human's overriding verdict for this item (ground truth). When set, it beats the judge in
+    // scoring: the effective verdict = humanVerdict ?? judgeVerdict, and the run is re-scored.
+    humanVerdict: { type: String, enum: ["better", "equal", "worse", null], default: null },
     // The judge's FIRST-pass verdict, kept when the "disprove it" pass overturned a "worse" call.
     preDisproveVerdict: { type: String, enum: ["better", "equal", "worse", null], default: null },
     disproved: { type: Boolean, default: false }, // a "worse" verdict was overturned on falsification

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -83,6 +83,7 @@ export const api = {
   evalRuns: (recommendationId) => req(`/evals/runs${qs({ recommendationId })}`),
 
   // Reusable benchmarks ("DashBench"): a named frozen set, scored against many candidates.
+  acceptanceStats: () => req("/analytics/acceptance"),
   benchmarks: () => req("/eval-benchmarks"),
   benchmark: (id) => req(`/eval-benchmarks/${id}`),
   createBenchmark: (body) => req("/eval-benchmarks", { method: "POST", body: JSON.stringify(body) }),

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -96,6 +96,7 @@ export const api = {
   evalRun: (id) => req(`/evals/runs/${id}`),
   deleteEvalRun: (id) => req(`/evals/runs/${id}`, { method: "DELETE" }),
   evalRunResults: (id) => req(`/evals/runs/${id}/results`),
+  setResultVerdict: (resultId, verdict) => req(`/evals/results/${resultId}`, { method: "PATCH", body: JSON.stringify({ verdict }) }),
 
   // Routing experiments (canary rollout).
   routingExperiments: (status) => req(`/routing-experiments${qs({ status })}`),

--- a/web/src/pages/ModelEvals.jsx
+++ b/web/src/pages/ModelEvals.jsx
@@ -221,6 +221,12 @@ function RunDetail({ id, onClose }) {
   }, [id]);
   useEffect(() => { load(); }, [load]);
 
+  // Human-curated verdict: override the judge on an item; the run is re-scored server-side.
+  const overrideVerdict = async (resultId, verdict) => {
+    await api.setResultVerdict(resultId, verdict).catch(() => {});
+    load();
+  };
+
   // A passed eval seeds the next pipeline stages directly — no recommendation, no override
   // (the passed run itself is the gate, linked via requiredEvalRunId).
   const promote = async (fn, ok) => {
@@ -315,10 +321,20 @@ function RunDetail({ id, onClose }) {
             {results.slice(0, 20).map((r) => (
               <div key={r._id} className="rounded-lg border border-gray-200 p-3">
                 <div className="flex items-center gap-2">
-                  {r.judgeVerdict ? <Badge tone={VERDICT_TONE[r.judgeVerdict]}>{r.judgeVerdict}</Badge> : <Badge tone="gray">unjudged</Badge>}
+                  {(() => {
+                    const v = r.humanVerdict || r.judgeVerdict;
+                    return v ? <Badge tone={VERDICT_TONE[v]}>{v}{r.humanVerdict ? " · human" : ""}</Badge> : <Badge tone="gray">unjudged</Badge>;
+                  })()}
                   {r.criticalFailure && <Badge tone="red">critical</Badge>}
                   {!r.formatPass && <Badge tone="amber">format fail</Badge>}
                   {r.error && <span className="text-xs text-red-600">{r.error}</span>}
+                  <select className="input ml-auto !py-0.5 text-xs" title="Override the judge (re-scores the run)"
+                    value={r.humanVerdict || ""} onChange={(e) => overrideVerdict(r._id, e.target.value || null)}>
+                    <option value="">judge: {r.judgeVerdict || "—"}</option>
+                    <option value="better">mark better</option>
+                    <option value="equal">mark equal</option>
+                    <option value="worse">mark worse</option>
+                  </select>
                 </div>
                 {r.judgeRationale && <p className="mt-2 text-sm text-gray-600">{r.judgeRationale}</p>}
                 {r.candidateResponse && <CodeBlock code={r.candidateResponse} />}

--- a/web/src/pages/ModelEvals.jsx
+++ b/web/src/pages/ModelEvals.jsx
@@ -827,6 +827,7 @@ export default function ModelEvals() {
   const [openId, setOpenId] = useState(null);
   const [confirmDel, setConfirmDel] = useState(null);
   const [override, setOverride] = useState(null); // { campaign, message } when the gate blocks resume
+  const [adoption, setAdoption] = useState(null);
   const [err, setErr] = useState(null);
 
   const load = useCallback(() => {
@@ -838,6 +839,7 @@ export default function ModelEvals() {
     // Candidate + judge get CALLED during a run, so only offer connected, chat-capable models.
     api.models({ live: true, routable: true }).then((m) => setModels(m || [])).catch(() => {});
     api.facets().then((f) => setApps([...new Set(f?.applications || [])])).catch(() => {});
+    api.acceptanceStats().then(setAdoption).catch(() => {});
   }, [load]);
 
   // Activating a shadow campaign is gated on a passed offline eval (or an override). If the gate
@@ -890,6 +892,19 @@ export default function ModelEvals() {
         <h1 className="text-2xl font-bold text-arbr-charcoal">Model Evals</h1>
         <p className="mt-1 text-sm text-gray-500">Prove a cheaper model is no worse than the current one before it becomes a rule. The stages below follow that flow — offline eval → shadow → canary → promote.</p>
       </div>
+
+      {adoption && (adoption.recommendations.acceptanceRate != null || adoption.canaries.promotionRate != null) && (
+        <Card title="Adoption — the production-truth signal beside benchmark scores">
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <Stat label="Recommendations accepted" value={adoption.recommendations.acceptanceRate == null ? "—" : pct(adoption.recommendations.acceptanceRate)}
+              sub={`${fmt.num(adoption.recommendations.accepted)} of ${fmt.num(adoption.recommendations.accepted + adoption.recommendations.dismissed)} decided`} />
+            <Stat label="Dismissed" value={fmt.num(adoption.recommendations.dismissed)} sub={`${fmt.num(adoption.recommendations.pending)} pending`} />
+            <Stat label="Canaries promoted" value={adoption.canaries.promotionRate == null ? "—" : pct(adoption.canaries.promotionRate)}
+              sub={`${fmt.num(adoption.canaries.promoted)} promoted · ${fmt.num(adoption.canaries.rolledBack)} rolled back`} />
+            <Stat label="Overrides" value={fmt.num(adoption.recommendations.overridden)} sub="accepted without a passed eval" />
+          </div>
+        </Card>
+      )}
 
       <StageHeading n="1" title="Offline eval" desc="Replay past traffic through a candidate and judge it against the baseline. No production impact." />
       <BenchmarksSection models={models} apps={apps} />

--- a/web/src/pages/ModelEvals.jsx
+++ b/web/src/pages/ModelEvals.jsx
@@ -662,6 +662,19 @@ function BenchmarkDetail({ id, models, onClose }) {
           <SameFamilyWarning candidate={cand} judge={judge} />
           {err && <div className="mt-2 text-sm text-red-600">{err}</div>}
           {notice && <div className="mt-2 text-sm text-arbr-green-700">{notice}</div>}
+          {bench.suggestedCandidates?.length > 0 && (
+            <div className="mt-3 border-t border-gray-100 pt-3">
+              <div className="text-xs text-gray-500">Suggested — connected models cheaper than the baseline, not scored yet. Click to load one, then Run:</div>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {bench.suggestedCandidates.map((s) => (
+                  <button key={s.model} className="btn-outline text-xs" onClick={() => setCand(s.model)}
+                    title={`~${pct(s.savingVsBaselinePct)} cheaper than ${bench.baselineModel}`}>
+                    {s.label} · −{pct(s.savingVsBaselinePct)}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
 
         <div>


### PR DESCRIPTION
**Recovery PR.** #124/#125/#127 show as "merged" but they merged **into their parent branches, not `main`** (stacked out of order). So `main` is missing three shipped features:
- **#5** human-curated verdicts (`humanVerdict` + `recomputeRun`)
- **#8** acceptance-rate loop (`GET /analytics/acceptance` + Adoption card)
- **#9** auto-benchmark suggestions (`suggestedCandidates`)

`#123` (severity + pin) *is* on main via its squash, so this branch **cherry-picks only the three missing feature commits** onto current `main` (no #123 duplication, no squash-vs-branch merge conflict). All three applied cleanly.

Verified: features present on the branch; full unit suite + lint + web build pass.

Merge this to land the three on main; then deploy. (Lesson logged: don't ladder-stack PRs across a squash-merge — land the base first, then rebase the next.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)