### PR TITLE
docs(attribution): team usage guide + header attribution on compat path

### DIFF
--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -97,6 +97,42 @@ Run a prompt in OpenCode, then open the Arbr dashboard:
 If nothing shows up, check that `baseURL` ends in `/v1`, that `ARBR_API_KEY` is exported in the same
 shell OpenCode runs in, and that the key is valid in **Settings → API keys**.
 
+## Team usage — per-developer attribution
+
+When a team shares one Arbr key, send a `X-Arbr-User-Id` header to attribute each developer's
+requests separately in the dashboard. The `@ai-sdk/openai-compatible` provider supports default
+headers via `options.headers`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "arbr": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Arbr",
+      "options": {
+        "baseURL": "https://your-arbr-host/v1",
+        "apiKey": "{env:ARBR_API_KEY}",
+        "headers": {
+          "X-Arbr-User-Id": "{env:ARBR_USER_ID}"
+        }
+      }
+    }
+  }
+}
+```
+
+Each developer exports their own identifier before launching OpenCode:
+
+```sh
+export ARBR_API_KEY="ab_…"        # shared team key
+export ARBR_USER_ID="alice@company.com"   # each dev sets their own
+```
+
+After that, **Overview → Applications → opencode** shows a per-developer cost and request
+breakdown with no additional key management. You can also set `X-Arbr-Department` the same
+way to group by team (e.g. `"engineering"` or `"product"`).
+
 ## Related
 
 - [OpenAI-compatible endpoint](/gateway/openai-compat) — the API OpenCode talks to

--- a/docs/sdk/js.md
+++ b/docs/sdk/js.md
@@ -35,6 +35,33 @@ console.log(res.model, res.routingDecision);  // "gpt-4o-mini", "ai"
 | `retries` | `2` | Retries on network errors, timeouts, 429, 5xx. Exponential backoff + jitter. |
 | `fetch` | global `fetch` | Injectable for tests or custom agents. |
 
+## Team attribution — identifying developers
+
+When a team shares one gateway key, pass `userId` to attribute each developer's requests
+separately. Set it at the client level so every call is attributed automatically:
+
+```js
+const arbr = createClient({
+  baseUrl: process.env.ARBR_GATEWAY_URL,
+  apiKey: process.env.ARBR_API_KEY,
+  application: "opencode",
+  userId: process.env.ARBR_USER_ID,     // e.g. "alice@company.com"
+  department: "engineering",            // optional team grouping
+});
+```
+
+Or override per-call when a single client instance serves multiple users:
+
+```js
+await arbr.chat({
+  messages: "…",
+  userId: session.user.email,
+});
+```
+
+Each developer's spend and requests appear separately in **Overview → Applications → opencode**
+with no additional key management needed.
+
 ## `client.chat(messages, options?) → Promise<ChatResponse>`
 
 ```js

--- a/docs/sdk/python.md
+++ b/docs/sdk/python.md
@@ -45,6 +45,31 @@ arbr = create_client(
 
 `base_url` and `api_key` fall back to `$ARBR_GATEWAY_URL` and `$ARBR_API_KEY`.
 
+## Team attribution — identifying developers
+
+When a team shares one gateway key, pass `user_id` to attribute each developer's requests
+separately. Set it at the client level so every call is attributed automatically:
+
+```python
+import os
+from arbr_client import create_client
+
+arbr = create_client(
+    application="opencode",
+    user_id=os.environ.get("ARBR_USER_ID"),   # e.g. "alice@company.com"
+    department="engineering",                  # optional team grouping
+)
+```
+
+Or override per-call when a single client instance serves multiple users:
+
+```python
+res = arbr.chat("…", user_id=current_user.email)
+```
+
+Each developer's spend and requests appear separately in **Overview → Applications → opencode**
+with no additional key management needed.
+
 ## `Client.chat(messages, *, ...) → ChatResponse`
 
 ```python

--- a/server/src/gateway/openaiCompat.js
+++ b/server/src/gateway/openaiCompat.js
@@ -338,9 +338,9 @@ async function handleOpenAICompat(req, res) {
   const timestamp = new Date();
   const meta = {
     application: appName,
-    workflow: body["x-arbr-workflow"] || "completion",
-    userId: body.user || null,
-    department: body["x-arbr-department"] || null,
+    workflow: body["x-arbr-workflow"] || req.headers["x-arbr-workflow"] || "completion",
+    userId: body.user || req.headers["x-arbr-user-id"] || null,
+    department: body["x-arbr-department"] || req.headers["x-arbr-department"] || null,
   };
 
   // Normalize max_tokens → maxTokens for the routing layer.

--- a/web/src/pages/Docs.jsx
+++ b/web/src/pages/Docs.jsx
@@ -38,8 +38,11 @@ export default function Docs() {
 curl -X POST ${base}/v1/chat/completions \\
   -H 'Content-Type: application/json' \\
   -H 'Authorization: Bearer ab_…' \\
+  -H 'X-Arbr-User-Id: alice@company.com' \\
   -d '{ "model": "auto", "messages": [{ "role": "user", "content": "Hello" }], "max_tokens": 300 }'
-# model: "auto" lets Arbr route; pin a model id (e.g. "gpt-4o") to bypass policy.`;
+# model: "auto" lets Arbr route; pin a model id (e.g. "gpt-4o") to bypass policy.
+# X-Arbr-User-Id: optional — attributes this request to a team member in the dashboard.
+# X-Arbr-Department: optional — groups requests by team (e.g. "engineering").`;
 
   const nativeCurl = `# Native endpoint — richer attribution (application/workflow/department/taskType).
 curl -X POST ${base}/v1/chat \\


### PR DESCRIPTION
## Summary

- **Server**: `openaiCompat.js` now reads `X-Arbr-User-Id` and `X-Arbr-Department` request headers (in addition to `body.user` from PR #126) so any HTTP client that supports default headers — including OpenCode via `@ai-sdk/openai-compatible` — can attribute team members without per-user keys
- **`docs/integrations/opencode.md`**: new "Team usage" section showing the `X-Arbr-User-Id` header pattern with `{env:ARBR_USER_ID}` in the OpenCode provider config
- **`docs/sdk/js.md`**: new "Team attribution" section with shared-key + `userId` example (constructor default and per-call override)
- **`docs/sdk/python.md`**: same for Python (`user_id` snake_case)
- **`web/src/pages/Docs.jsx`**: compat `curl` example now shows `X-Arbr-User-Id` and `X-Arbr-Department` headers with inline comments

## No SDK version bump needed

The Node and Python SDK code didn't change — `userId`/`user_id` have been supported since v0.1. This only documents the pattern and fills the header gap for non-SDK clients.

## How the OpenCode team flow works after this

```sh
# Each developer exports once (e.g. in .zshrc / .bashrc):
export ARBR_API_KEY="ab_…"             # shared team key
export ARBR_USER_ID="alice@company.com"
```

```json
// ~/.config/opencode/opencode.json (each dev's own copy)
{
  "provider": {
    "arbr": {
      "npm": "@ai-sdk/openai-compatible",
      "options": {
        "baseURL": "https://your-arbr-host/v1",
        "apiKey": "{env:ARBR_API_KEY}",
        "headers": { "X-Arbr-User-Id": "{env:ARBR_USER_ID}" }
      }
    }
  }
}
```

→ **Overview → Applications → opencode** immediately shows per-developer spend breakdown.

> Depends on #126 for `body.user` support; both can merge independently in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)