### PR TITLE
fix(deploy): prune dangling images before pull to prevent disk-full mid-deploy

### DIFF
--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -52,6 +52,16 @@ SEED_BEFORE="$(seed_of || true)"
 PREV_TAG="$(cat "$PREV_FILE" 2>/dev/null || echo main)"
 echo "==> Current tag: ${PREV_TAG}  →  deploying: ${TAG}"
 
+# 1.5 RECLAIM DISK before the pull. The VM root disk is only 20G and orphaned image
+# layers accumulate across image-based deploys until a pull dies with "no space left
+# on device". Dangling-only prune is SAFE: the image in use by the running container
+# and anything still tagged (current :main, the rollback target) are protected; only
+# untagged layers from prior deploys go. Everything is re-pullable from public GHCR.
+echo "==> Reclaiming disk (dangling images) before pull…"
+df -h / | awk 'NR==2{printf "    disk before: %s used, %s free\n",$5,$4}'
+sudo docker image prune -f >/dev/null 2>&1 || echo "!! prune skipped (non-fatal)"
+df -h / | awk 'NR==2{printf "    disk after:  %s used, %s free\n",$5,$4}'
+
 # 2. DEPLOY.
 deploy "$TAG"
 


### PR DESCRIPTION
Adds a dangling-only `docker image prune -f` step to `ops/deploy.sh` **before** the image pull, with before/after disk reporting.

## Why
The arbr.gyde.ai VM root disk is only **20G**. Orphaned image layers accumulate across image-based deploys until a pull dies mid-stream with `no space left on device` (the running app is unaffected — it stays on the prior image, but the deploy fails).

## What
- `sudo docker image prune -f` before the pull, guarded (`|| echo` non-fatal).
- `df -h /` before/after so the reclaim is visible in deploy logs.

## Safety
Dangling-only prune **protects** the image in use by the running container and everything still tagged (current `:main`, the rollback target). Only untagged layers from prior deploys are removed, and all images are re-pullable from the public GHCR.

Validated live on the VM: reclaimed orphaned layers while `:main` and `:sha-*` tags were untouched.

## Known limitation
Pinned `:sha-*` tags are not reclaimed by dangling-only prune (they accumulate slowly). Left as-is intentionally; a broader cleanup or larger disk is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
