### PR TITLE
feat(gateway): POST /v1/embeddings — Gemini + OpenAI, full observability

### DIFF
--- a/clients/js/src/index.js
+++ b/clients/js/src/index.js
@@ -274,7 +274,35 @@ function createClient(options = {}) {
     );
   }
 
-  return { chat, stream, status, models, providers, taskTypes, baseUrl };
+  /**
+   * Generate embeddings — POST /v1/embeddings.
+   *
+   * OpenAI-compatible interface: `model` must be an embedding model whose
+   * provider is connected (e.g. "gemini-embedding-001", "text-embedding-3-small").
+   * `input` is a string or array of strings.
+   * `dimensions` is forwarded to the provider (for Gemini this becomes
+   * `outputDimensionality` — keep it at 768 if your index was built with that size).
+   *
+   * Returns the raw OpenAI-format response:
+   *   `{ object: "list", data: [{ object: "embedding", index, embedding: float[] }], model, usage }`
+   */
+  async function embeddings(opts = {}) {
+    const { model, input, dimensions, signal, timeoutMs: tms, retries: ret } = opts;
+    if (!model)       throw invalid("`model` is required for embeddings");
+    if (input == null) throw invalid("`input` is required for embeddings");
+    return requestWithRetries(
+      fetchImpl,
+      `${baseUrl}/v1/embeddings`,
+      {
+        method:  "POST",
+        headers: baseHeaders,
+        body:    JSON.stringify({ model, input, ...(dimensions != null && { dimensions }) }),
+      },
+      { timeoutMs: tms ?? timeoutMs, retries: ret ?? retries, signal }
+    );
+  }
+
+  return { chat, stream, status, models, providers, taskTypes, embeddings, baseUrl };
 }
 
 // ── LangChain-style adapter (duck-typed; no LangChain dependency) ─────────────

--- a/clients/python/src/arbr_client/__init__.py
+++ b/clients/python/src/arbr_client/__init__.py
@@ -368,6 +368,52 @@ class Client:
         for i in range(0, len(text), _STREAM_CHUNK_CHARS):
             yield text[i : i + _STREAM_CHUNK_CHARS]
 
+    # — embeddings —
+
+    def embeddings(
+        self,
+        input: Any,
+        *,
+        model: str,
+        dimensions: Optional[int] = None,
+        timeout_s: Optional[float] = None,
+        retries: Optional[int] = None,
+    ) -> dict:
+        """Generate embeddings — POST /v1/embeddings.
+
+        OpenAI-compatible interface. ``model`` must be an embedding model whose
+        provider is connected (e.g. ``"gemini-embedding-001"``,
+        ``"text-embedding-3-small"``). ``input`` is a string or list of strings.
+
+        ``dimensions`` is forwarded to the provider. For Gemini this becomes
+        ``outputDimensionality`` — keep it at 768 if your Elasticsearch index
+        was built with that dimensionality.
+
+        Returns the raw OpenAI-format dict::
+
+            {
+              "object": "list",
+              "data": [{"object": "embedding", "index": 0, "embedding": [...]}],
+              "model": "gemini-embedding-001",
+              "usage": {"prompt_tokens": 12, "total_tokens": 12},
+            }
+        """
+        body: dict[str, Any] = {"model": model, "input": input}
+        if dimensions is not None:
+            body["dimensions"] = dimensions
+        return _request_with_retries(
+            f"{self.base_url}/v1/embeddings",
+            method="POST",
+            body=body,
+            timeout_s=timeout_s if timeout_s is not None else self._timeout_s,
+            retries=retries if retries is not None else self._retries,
+            headers=self._headers,
+        )
+
+    async def aembeddings(self, input: Any, *, model: str, dimensions: Optional[int] = None, **kwargs: Any) -> dict:
+        """Async :meth:`embeddings`."""
+        return await asyncio.to_thread(self.embeddings, input, model=model, dimensions=dimensions, **kwargs)
+
     # — status —
 
     def status(self) -> dict:

--- a/server/src/gateway/embeddings.js
+++ b/server/src/gateway/embeddings.js
@@ -1,0 +1,212 @@
+// POST /v1/embeddings — OpenAI-compatible embeddings endpoint.
+//
+// Dispatches to:
+//   - Gemini: REST API directly (batchEmbedContents / embedContent), maps
+//             `dimensions` → `outputDimensionality`
+//   - OpenAI and any OpenAI-compat provider: proxies to ${baseURL}/embeddings
+//
+// No routing engine — caller always pins the model (no "auto" for embeddings).
+// Logs every call to RequestRecord for observability parity with chat.
+
+const { v4: uuidv4 } = require("uuid");
+const connections = require("../providers/connections");
+const { PROVIDERS } = require("../config");
+const logger = require("../logging/logger");
+
+const GEMINI_BASE = "https://generativelanguage.googleapis.com/v1beta/models";
+
+// Map embedding model IDs to their provider.
+// Embedding models are not in the ModelEntry registry (only chat models are synced),
+// so we infer from well-known prefixes.
+const PROVIDER_RE = [
+  [/^(gemini-embedding|text-multilingual-embedding|embedding-\d)/i, "gemini"],
+  [/^(text-embedding-|text-search-|ada-0|text-similarity)/i,       "openai"],
+];
+function inferProvider(modelId) {
+  for (const [re, p] of PROVIDER_RE) if (re.test(modelId)) return p;
+  return null;
+}
+
+// ── Gemini embedding via REST ─────────────────────────────────────────────────
+
+async function embedWithGemini(model, inputs, dims, apiKey) {
+  const makeReq = (text) => ({
+    model:   `models/${model}`,
+    content: { parts: [{ text }] },
+    ...(dims != null && { outputDimensionality: dims }),
+  });
+
+  if (inputs.length === 1) {
+    const res = await fetch(
+      `${GEMINI_BASE}/${model}:embedContent`,
+      {
+        method:  "POST",
+        headers: { "Content-Type": "application/json", "x-goog-api-key": apiKey },
+        body:    JSON.stringify(makeReq(inputs[0])),
+      }
+    );
+    if (!res.ok) {
+      const txt = await res.text().catch(() => res.status);
+      throw new Error(`Gemini embedContent failed ${res.status}: ${txt}`);
+    }
+    const data = await res.json();
+    return {
+      embeddings:   [data.embedding.values],
+      promptTokens: data.embedding?.statistics?.tokenCount || 0,
+    };
+  }
+
+  // Batch
+  const res = await fetch(
+    `${GEMINI_BASE}/${model}:batchEmbedContents`,
+    {
+      method:  "POST",
+      headers: { "Content-Type": "application/json", "x-goog-api-key": apiKey },
+      body:    JSON.stringify({ requests: inputs.map(makeReq) }),
+    }
+  );
+  if (!res.ok) {
+    const txt = await res.text().catch(() => res.status);
+    throw new Error(`Gemini batchEmbedContents failed ${res.status}: ${txt}`);
+  }
+  const data = await res.json();
+  return {
+    embeddings:   data.embeddings.map((e) => e.values),
+    promptTokens: 0, // batch endpoint does not return per-request token counts
+  };
+}
+
+// ── OpenAI / compat embedding via proxy ──────────────────────────────────────
+
+async function embedWithOpenAICompat(model, inputs, dims, baseURL, apiKey) {
+  const input = inputs.length === 1 ? inputs[0] : inputs;
+  const res = await fetch(`${baseURL}/embeddings`, {
+    method:  "POST",
+    headers: {
+      "Content-Type":  "application/json",
+      "Authorization": `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      input,
+      ...(dims != null && { dimensions: dims }),
+    }),
+  });
+  if (!res.ok) {
+    const txt = await res.text().catch(() => res.status);
+    throw new Error(`Embeddings API failed ${res.status}: ${txt}`);
+  }
+  const data = await res.json();
+  return {
+    embeddings:   data.data.map((d) => d.embedding),
+    promptTokens: data.usage?.prompt_tokens || 0,
+  };
+}
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+
+async function handleEmbeddings(req, res) {
+  const _reqStart = Date.now();
+  const requestId = uuidv4();
+  const body = req.body || {};
+
+  // Validate
+  if (!body.model) {
+    return res.status(400).json({ error: { message: "model is required" } });
+  }
+  if (body.input == null) {
+    return res.status(400).json({ error: { message: "input is required" } });
+  }
+
+  const model  = body.model;
+  const inputs = Array.isArray(body.input) ? body.input : [body.input];
+  const dims   = body.dimensions ?? null;
+
+  // Attribution — same field priority as openaiCompat.js
+  const meta = {
+    application: req.apiKey?.application || body.application || "unknown",
+    workflow:    req.headers["x-arbr-workflow"] || body["x-arbr-workflow"] || "embedding",
+    userId:      body.user || req.headers["x-arbr-user-id"] || req.apiKey?.userId || null,
+    department:  body["x-arbr-department"] || req.headers["x-arbr-department"] || req.apiKey?.department || null,
+  };
+
+  // Resolve provider from model ID
+  const provider = inferProvider(model);
+  if (!provider) {
+    return res.status(400).json({
+      error: {
+        message: `Cannot determine provider for model "${model}". ` +
+          `Supported prefixes: gemini-embedding-*, text-embedding-*, ada-*.`,
+      },
+    });
+  }
+
+  const eff = await connections.effective();
+  if (!eff.providers[provider]) {
+    return res.status(503).json({
+      error: {
+        message: `Provider "${provider}" is not connected. ` +
+          `Add a credential in Settings → Connections.`,
+      },
+    });
+  }
+
+  const cred      = eff.providers[provider].credential;
+  const _llmStart = Date.now();
+  let embeddings, promptTokens;
+
+  try {
+    if (provider === "gemini") {
+      ({ embeddings, promptTokens } = await embedWithGemini(model, inputs, dims, cred.apiKey));
+    } else {
+      // OpenAI-compat: get baseURL from static config (known providers) or
+      // from the custom-provider record stored alongside the credential.
+      const baseURL =
+        PROVIDERS[provider]?.baseURL ||
+        eff.providers[provider].baseURL ||
+        "https://api.openai.com/v1";
+      ({ embeddings, promptTokens } = await embedWithOpenAICompat(
+        model, inputs, dims, baseURL, cred.apiKey
+      ));
+    }
+  } catch (err) {
+    setImmediate(() => logger.write({
+      requestId, ...meta,
+      provider, model, modelRequested: model, taskType: "embedding",
+      promptTokens: 0, completionTokens: 0, totalTokens: 0,
+      latencyMs:        Date.now() - _reqStart,
+      gatewayOverheadMs: _llmStart - _reqStart,
+      status: "failure", errorMessage: err.message,
+      routingDecision: "explicit", classifiedBy: "provided", cacheHit: false,
+    }));
+    return res.status(502).json({ error: { message: err.message } });
+  }
+
+  const latencyMs = Date.now() - _reqStart;
+
+  res.set({
+    "X-Arbr-Request-ID": requestId,
+    "X-Arbr-Model":      model,
+    "X-Arbr-Provider":   provider,
+  });
+
+  res.json({
+    object: "list",
+    data:   embeddings.map((embedding, index) => ({ object: "embedding", index, embedding })),
+    model,
+    usage:  { prompt_tokens: promptTokens, total_tokens: promptTokens },
+  });
+
+  // Log non-blocking — same pattern as /v1/chat and /v1/chat/completions
+  setImmediate(() => logger.write({
+    requestId, ...meta,
+    provider, model, modelRequested: model, taskType: "embedding",
+    promptTokens, completionTokens: 0, totalTokens: promptTokens,
+    latencyMs, gatewayOverheadMs: _llmStart - _reqStart,
+    status: "success", routingDecision: "explicit", classifiedBy: "provided", cacheHit: false,
+    messages:     inputs.map((text) => ({ role: "user", content: text })),
+    responseText: null,
+  }));
+}
+
+module.exports = { handleEmbeddings };

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -9,6 +9,7 @@ const registry = require("./pricing/registry");
 const { TASK_CATALOG } = require("./classify/classifier");
 const { handleChat } = require("./gateway/handler");
 const { handleOpenAICompat } = require("./gateway/openaiCompat");
+const { handleEmbeddings } = require("./gateway/embeddings");
 const { purgeOldRecords } = require("./maintenance/purge");
 const errorAlertMonitor = require("./routing/errorAlertMonitor");
 const canaryMonitor = require("./routing/canaryMonitor");
@@ -46,6 +47,10 @@ async function start() {
 
   // OpenAI-compatible endpoint — any client that speaks the OpenAI spec can use Arbr.
   app.post("/v1/chat/completions", auth.middleware, handleOpenAICompat);
+
+  // OpenAI-compatible embeddings endpoint — routes to the appropriate provider
+  // (Gemini or OpenAI-compat) based on the model ID, with full observability.
+  app.post("/v1/embeddings", auth.middleware, handleEmbeddings);
 
   // OpenAI-compatible model discovery — returns only models whose provider is
   // currently connected (live), with a toolCallSupported flag so clients know


### PR DESCRIPTION
## Summary

- Adds `POST /v1/embeddings` (OpenAI-compatible wire format) so embeddings can flow through the Arbr gateway alongside chat calls
- Provider inferred from model ID: `gemini-embedding-*` → Gemini REST API, `text-embedding-*` / `ada-*` → OpenAI proxy
- For Gemini: `dimensions` is mapped to `outputDimensionality` — critical for AI Sales Coach whose Elasticsearch index is pinned to 768 dims
- Batch and single-input both supported
- Full `RequestRecord` logging: taskType, latency, tokens, provider, application/userId/department attribution
- `client.embeddings()` added to both JS and Python SDKs

## Drop-in for AI Sales Coach (existing openai SDK)

```python
from openai import OpenAI
client = OpenAI(base_url="http://arbr-host:4100/v1", api_key="ab_...")
resp = client.embeddings.create(model="gemini-embedding-001", input=texts, dimensions=768)
vectors = [d.embedding for d in resp.data]
```

## Arbr-native usage

**Python:**
```python
resp = arbr.embeddings(texts, model="gemini-embedding-001", dimensions=768)
vectors = [d["embedding"] for d in resp["data"]]
```

**JS:**
```js
const resp = await arbr.embeddings({ model: "gemini-embedding-001", input: texts, dimensions: 768 });
const vectors = resp.data.map(d => d.embedding);
```

## Test plan
- [ ] Single string input with `gemini-embedding-001` + `dimensions: 768` → 768-dim vector
- [ ] Array input → `data` has one entry per input string
- [ ] OpenAI `text-embedding-3-small` works via proxy
- [ ] Missing provider returns 503 with clear message
- [ ] Unknown model prefix returns 400
- [ ] RequestRecord written with `taskType: "embedding"` — visible in dashboard Applications tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)