### PR TITLE
chore(sdk): bump JS + Python clients to 0.5.0 — embeddings support

### DIFF
--- a/clients/js/CHANGELOG.md
+++ b/clients/js/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.0 (2026-07-13)
+
+- **`embeddings()`** — generate vector embeddings via `POST /v1/embeddings`. OpenAI-compatible wire format (`{ model, input, dimensions? }`). Dispatches to Gemini (`gemini-embedding-001`) or any OpenAI-compat provider (`text-embedding-3-small`, etc.) with full observability parity to chat.
+- **TypeScript**: added `EmbeddingsRequest`, `EmbeddingObject`, `EmbeddingsResponse` interfaces; `embeddings()` on `Client`.
+
 ## 0.4.0 (2026-06-30)
 
 - **TypeScript**: `Usage` interface gains `cachedReadTokens` and `cacheWriteTokens` — now typed for prompt-cache token breakdown returned by the gateway when Anthropic or OpenAI prompt caching is active.

--- a/clients/js/index.d.ts
+++ b/clients/js/index.d.ts
@@ -169,6 +169,30 @@ export class GatewayError extends Error {
   cause?: unknown;
 }
 
+export interface EmbeddingsRequest {
+  model: string;
+  input: string | string[];
+  /** Truncate output to this many dimensions. Gemini maps this to `outputDimensionality`. */
+  dimensions?: number;
+  /** Per-call overrides. */
+  timeoutMs?: number;
+  retries?: number;
+  signal?: AbortSignal;
+}
+
+export interface EmbeddingObject {
+  object: "embedding";
+  index: number;
+  embedding: number[];
+}
+
+export interface EmbeddingsResponse {
+  object: "list";
+  data: EmbeddingObject[];
+  model: string;
+  usage: { prompt_tokens: number; total_tokens: number };
+}
+
 export interface Client {
   /** One routed completion via POST /v1/chat. */
   chat(opts: ChatRequest): Promise<ChatResponse>;
@@ -186,6 +210,8 @@ export interface Client {
   providers(opts?: { signal?: AbortSignal }): Promise<ProvidersResponse>;
   /** List all supported task types with tier and description — GET /v1/task-types. */
   taskTypes(opts?: { signal?: AbortSignal }): Promise<TaskTypesResponse>;
+  /** Generate embeddings — POST /v1/embeddings. OpenAI-compatible response format. */
+  embeddings(opts: EmbeddingsRequest): Promise<EmbeddingsResponse>;
   baseUrl: string;
 }
 

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arbr-client",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Official JS client for the Arbr AI control-plane gateway — one function to route, observe, and govern every LLM call.",
   "license": "MIT",
   "main": "./src/index.js",

--- a/clients/js/src/index.js
+++ b/clients/js/src/index.js
@@ -274,7 +274,35 @@ function createClient(options = {}) {
     );
   }
 
-  return { chat, stream, status, models, providers, taskTypes, baseUrl };
+  /**
+   * Generate embeddings — POST /v1/embeddings.
+   *
+   * OpenAI-compatible interface: `model` must be an embedding model whose
+   * provider is connected (e.g. "gemini-embedding-001", "text-embedding-3-small").
+   * `input` is a string or array of strings.
+   * `dimensions` is forwarded to the provider (for Gemini this becomes
+   * `outputDimensionality` — keep it at 768 if your index was built with that size).
+   *
+   * Returns the raw OpenAI-format response:
+   *   `{ object: "list", data: [{ object: "embedding", index, embedding: float[] }], model, usage }`
+   */
+  async function embeddings(opts = {}) {
+    const { model, input, dimensions, signal, timeoutMs: tms, retries: ret } = opts;
+    if (!model)       throw invalid("`model` is required for embeddings");
+    if (input == null) throw invalid("`input` is required for embeddings");
+    return requestWithRetries(
+      fetchImpl,
+      `${baseUrl}/v1/embeddings`,
+      {
+        method:  "POST",
+        headers: baseHeaders,
+        body:    JSON.stringify({ model, input, ...(dimensions != null && { dimensions }) }),
+      },
+      { timeoutMs: tms ?? timeoutMs, retries: ret ?? retries, signal }
+    );
+  }
+
+  return { chat, stream, status, models, providers, taskTypes, embeddings, baseUrl };
 }
 
 // ── LangChain-style adapter (duck-typed; no LangChain dependency) ─────────────

--- a/clients/python/CHANGELOG.md
+++ b/clients/python/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0 (2026-07-13)
+
+- **`embeddings()` / `aembeddings()`** — generate vector embeddings via `POST /v1/embeddings`. OpenAI-compatible wire format. Dispatches to Gemini (`gemini-embedding-001`) or any OpenAI-compat provider (`text-embedding-3-small`, etc.) with full observability parity to chat.
+
 ## 0.4.0 (2026-06-30)
 
 - **`Usage` dataclass**: gains `cached_read_tokens` and `cache_write_tokens` — populated from the gateway's prompt-cache token breakdown when Anthropic or OpenAI caching is active (`res.usage.cached_read_tokens`, `res.usage.cache_write_tokens`).

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "arbr-client"
-version = "0.4.0"
+version = "0.5.0"
 description = "Official Python client for the Arbr AI control-plane gateway — one function to route, observe, and govern every LLM call."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/clients/python/src/arbr_client/__init__.py
+++ b/clients/python/src/arbr_client/__init__.py
@@ -368,6 +368,52 @@ class Client:
         for i in range(0, len(text), _STREAM_CHUNK_CHARS):
             yield text[i : i + _STREAM_CHUNK_CHARS]
 
+    # — embeddings —
+
+    def embeddings(
+        self,
+        input: Any,
+        *,
+        model: str,
+        dimensions: Optional[int] = None,
+        timeout_s: Optional[float] = None,
+        retries: Optional[int] = None,
+    ) -> dict:
+        """Generate embeddings — POST /v1/embeddings.
+
+        OpenAI-compatible interface. ``model`` must be an embedding model whose
+        provider is connected (e.g. ``"gemini-embedding-001"``,
+        ``"text-embedding-3-small"``). ``input`` is a string or list of strings.
+
+        ``dimensions`` is forwarded to the provider. For Gemini this becomes
+        ``outputDimensionality`` — keep it at 768 if your Elasticsearch index
+        was built with that dimensionality.
+
+        Returns the raw OpenAI-format dict::
+
+            {
+              "object": "list",
+              "data": [{"object": "embedding", "index": 0, "embedding": [...]}],
+              "model": "gemini-embedding-001",
+              "usage": {"prompt_tokens": 12, "total_tokens": 12},
+            }
+        """
+        body: dict[str, Any] = {"model": model, "input": input}
+        if dimensions is not None:
+            body["dimensions"] = dimensions
+        return _request_with_retries(
+            f"{self.base_url}/v1/embeddings",
+            method="POST",
+            body=body,
+            timeout_s=timeout_s if timeout_s is not None else self._timeout_s,
+            retries=retries if retries is not None else self._retries,
+            headers=self._headers,
+        )
+
+    async def aembeddings(self, input: Any, *, model: str, dimensions: Optional[int] = None, **kwargs: Any) -> dict:
+        """Async :meth:`embeddings`."""
+        return await asyncio.to_thread(self.embeddings, input, model=model, dimensions=dimensions, **kwargs)
+
     # — status —
 
     def status(self) -> dict:

--- a/docs/sdk/js.md
+++ b/docs/sdk/js.md
@@ -165,6 +165,54 @@ const res = await arbr.chat({
 | `mid` | Balanced model | Code generation, support replies, extraction |
 | `premium` | Most capable model | Reasoning, architecture design, security audit |
 
+## `client.embeddings(options) → Promise<EmbeddingsResponse>`
+
+Generate vector embeddings — `POST /v1/embeddings`. OpenAI-compatible wire format, same observability as chat.
+
+```js
+// Single input
+const res = await arbr.embeddings({
+  model: "gemini-embedding-001",
+  input: "Summarise the customer's pain points",
+  dimensions: 768,   // must match your index size
+});
+const vector = res.data[0].embedding;  // float[] of length 768
+
+// Batch
+const res = await arbr.embeddings({
+  model: "gemini-embedding-001",
+  input: ["sentence one", "sentence two", "sentence three"],
+  dimensions: 768,
+});
+const vectors = res.data.map((d) => d.embedding);  // float[][] — one per input
+```
+
+**Options:**
+
+| Option | Required | Description |
+|---|---|---|
+| `model` | yes | Embedding model ID. Gemini: `"gemini-embedding-001"`. OpenAI: `"text-embedding-3-small"`, `"text-embedding-3-large"`, etc. |
+| `input` | yes | String or array of strings to embed. |
+| `dimensions` | no | Truncate output to this many dimensions. For Gemini this becomes `outputDimensionality`. **Must match your vector index size** — changing it after index creation breaks search. |
+| `timeoutMs`, `retries`, `signal` | no | Same per-call overrides as `chat()`. |
+
+**Response:**
+```js
+{
+  object: "list",
+  data: [{ object: "embedding", index: 0, embedding: [0.012, -0.045, …] }],
+  model: "gemini-embedding-001",
+  usage: { prompt_tokens: 8, total_tokens: 8 }
+}
+```
+
+Works as a drop-in for any OpenAI SDK targeting the gateway:
+```js
+import OpenAI from "openai";
+const openai = new OpenAI({ baseURL: "http://localhost:4100/v1", apiKey: "ab_…" });
+const res = await openai.embeddings.create({ model: "gemini-embedding-001", input: texts, dimensions: 768 });
+```
+
 ## `client.status() → Promise<StatusResponse>`
 
 ```js

--- a/docs/sdk/python.md
+++ b/docs/sdk/python.md
@@ -183,6 +183,54 @@ res = arbr.chat("Summarise and extract key clauses from this contract: …", tas
 | `mid` | Balanced model | Code generation, support replies, extraction |
 | `premium` | Most capable model | Reasoning, architecture design, security audit |
 
+## `Client.embeddings(input, *, model, ...) → dict`
+
+Generate vector embeddings — `POST /v1/embeddings`. OpenAI-compatible wire format, same observability as chat.
+
+```python
+# Single input
+res = arbr.embeddings("Summarise the customer's pain points", model="gemini-embedding-001", dimensions=768)
+vector = res["data"][0]["embedding"]  # list[float] of length 768
+
+# Batch
+res = arbr.embeddings(
+    ["sentence one", "sentence two", "sentence three"],
+    model="gemini-embedding-001",
+    dimensions=768,
+)
+vectors = [d["embedding"] for d in res["data"]]  # list[list[float]]
+
+# Async
+res = await arbr.aembeddings(texts, model="gemini-embedding-001", dimensions=768)
+```
+
+**Parameters:**
+
+| Parameter | Required | Description |
+|---|---|---|
+| `input` | yes | String or list of strings to embed (positional). |
+| `model` | yes | Embedding model ID. Gemini: `"gemini-embedding-001"`. OpenAI: `"text-embedding-3-small"`, etc. |
+| `dimensions` | no | Truncate output to this many dimensions. For Gemini this becomes `outputDimensionality`. **Must match your vector index size.** |
+| `timeout_s`, `retries` | no | Same per-call overrides as `chat()`. |
+
+**Response dict:**
+```python
+{
+    "object": "list",
+    "data": [{"object": "embedding", "index": 0, "embedding": [0.012, -0.045, …]}],
+    "model": "gemini-embedding-001",
+    "usage": {"prompt_tokens": 8, "total_tokens": 8},
+}
+```
+
+Works as a drop-in for any OpenAI SDK targeting the gateway:
+```python
+from openai import OpenAI
+client = OpenAI(base_url="http://localhost:4100/v1", api_key="ab_…")
+resp = client.embeddings.create(model="gemini-embedding-001", input=texts, dimensions=768)
+vectors = [d.embedding for d in resp.data]
+```
+
 ## `Client.status() → dict`
 
 ```python

--- a/server/src/gateway/embeddings.js
+++ b/server/src/gateway/embeddings.js
@@ -1,0 +1,212 @@
+// POST /v1/embeddings — OpenAI-compatible embeddings endpoint.
+//
+// Dispatches to:
+//   - Gemini: REST API directly (batchEmbedContents / embedContent), maps
+//             `dimensions` → `outputDimensionality`
+//   - OpenAI and any OpenAI-compat provider: proxies to ${baseURL}/embeddings
+//
+// No routing engine — caller always pins the model (no "auto" for embeddings).
+// Logs every call to RequestRecord for observability parity with chat.
+
+const { v4: uuidv4 } = require("uuid");
+const connections = require("../providers/connections");
+const { PROVIDERS } = require("../config");
+const logger = require("../logging/logger");
+
+const GEMINI_BASE = "https://generativelanguage.googleapis.com/v1beta/models";
+
+// Map embedding model IDs to their provider.
+// Embedding models are not in the ModelEntry registry (only chat models are synced),
+// so we infer from well-known prefixes.
+const PROVIDER_RE = [
+  [/^(gemini-embedding|text-multilingual-embedding|embedding-\d)/i, "gemini"],
+  [/^(text-embedding-|text-search-|ada-0|text-similarity)/i,       "openai"],
+];
+function inferProvider(modelId) {
+  for (const [re, p] of PROVIDER_RE) if (re.test(modelId)) return p;
+  return null;
+}
+
+// ── Gemini embedding via REST ─────────────────────────────────────────────────
+
+async function embedWithGemini(model, inputs, dims, apiKey) {
+  const makeReq = (text) => ({
+    model:   `models/${model}`,
+    content: { parts: [{ text }] },
+    ...(dims != null && { outputDimensionality: dims }),
+  });
+
+  if (inputs.length === 1) {
+    const res = await fetch(
+      `${GEMINI_BASE}/${model}:embedContent`,
+      {
+        method:  "POST",
+        headers: { "Content-Type": "application/json", "x-goog-api-key": apiKey },
+        body:    JSON.stringify(makeReq(inputs[0])),
+      }
+    );
+    if (!res.ok) {
+      const txt = await res.text().catch(() => res.status);
+      throw new Error(`Gemini embedContent failed ${res.status}: ${txt}`);
+    }
+    const data = await res.json();
+    return {
+      embeddings:   [data.embedding.values],
+      promptTokens: data.embedding?.statistics?.tokenCount || 0,
+    };
+  }
+
+  // Batch
+  const res = await fetch(
+    `${GEMINI_BASE}/${model}:batchEmbedContents`,
+    {
+      method:  "POST",
+      headers: { "Content-Type": "application/json", "x-goog-api-key": apiKey },
+      body:    JSON.stringify({ requests: inputs.map(makeReq) }),
+    }
+  );
+  if (!res.ok) {
+    const txt = await res.text().catch(() => res.status);
+    throw new Error(`Gemini batchEmbedContents failed ${res.status}: ${txt}`);
+  }
+  const data = await res.json();
+  return {
+    embeddings:   data.embeddings.map((e) => e.values),
+    promptTokens: 0, // batch endpoint does not return per-request token counts
+  };
+}
+
+// ── OpenAI / compat embedding via proxy ──────────────────────────────────────
+
+async function embedWithOpenAICompat(model, inputs, dims, baseURL, apiKey) {
+  const input = inputs.length === 1 ? inputs[0] : inputs;
+  const res = await fetch(`${baseURL}/embeddings`, {
+    method:  "POST",
+    headers: {
+      "Content-Type":  "application/json",
+      "Authorization": `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      input,
+      ...(dims != null && { dimensions: dims }),
+    }),
+  });
+  if (!res.ok) {
+    const txt = await res.text().catch(() => res.status);
+    throw new Error(`Embeddings API failed ${res.status}: ${txt}`);
+  }
+  const data = await res.json();
+  return {
+    embeddings:   data.data.map((d) => d.embedding),
+    promptTokens: data.usage?.prompt_tokens || 0,
+  };
+}
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+
+async function handleEmbeddings(req, res) {
+  const _reqStart = Date.now();
+  const requestId = uuidv4();
+  const body = req.body || {};
+
+  // Validate
+  if (!body.model) {
+    return res.status(400).json({ error: { message: "model is required" } });
+  }
+  if (body.input == null) {
+    return res.status(400).json({ error: { message: "input is required" } });
+  }
+
+  const model  = body.model;
+  const inputs = Array.isArray(body.input) ? body.input : [body.input];
+  const dims   = body.dimensions ?? null;
+
+  // Attribution — same field priority as openaiCompat.js
+  const meta = {
+    application: req.apiKey?.application || body.application || "unknown",
+    workflow:    req.headers["x-arbr-workflow"] || body["x-arbr-workflow"] || "embedding",
+    userId:      body.user || req.headers["x-arbr-user-id"] || req.apiKey?.userId || null,
+    department:  body["x-arbr-department"] || req.headers["x-arbr-department"] || req.apiKey?.department || null,
+  };
+
+  // Resolve provider from model ID
+  const provider = inferProvider(model);
+  if (!provider) {
+    return res.status(400).json({
+      error: {
+        message: `Cannot determine provider for model "${model}". ` +
+          `Supported prefixes: gemini-embedding-*, text-embedding-*, ada-*.`,
+      },
+    });
+  }
+
+  const eff = await connections.effective();
+  if (!eff.providers[provider]) {
+    return res.status(503).json({
+      error: {
+        message: `Provider "${provider}" is not connected. ` +
+          `Add a credential in Settings → Connections.`,
+      },
+    });
+  }
+
+  const cred      = eff.providers[provider].credential;
+  const _llmStart = Date.now();
+  let embeddings, promptTokens;
+
+  try {
+    if (provider === "gemini") {
+      ({ embeddings, promptTokens } = await embedWithGemini(model, inputs, dims, cred.apiKey));
+    } else {
+      // OpenAI-compat: get baseURL from static config (known providers) or
+      // from the custom-provider record stored alongside the credential.
+      const baseURL =
+        PROVIDERS[provider]?.baseURL ||
+        eff.providers[provider].baseURL ||
+        "https://api.openai.com/v1";
+      ({ embeddings, promptTokens } = await embedWithOpenAICompat(
+        model, inputs, dims, baseURL, cred.apiKey
+      ));
+    }
+  } catch (err) {
+    setImmediate(() => logger.write({
+      requestId, ...meta,
+      provider, model, modelRequested: model, taskType: "embedding",
+      promptTokens: 0, completionTokens: 0, totalTokens: 0,
+      latencyMs:        Date.now() - _reqStart,
+      gatewayOverheadMs: _llmStart - _reqStart,
+      status: "failure", errorMessage: err.message,
+      routingDecision: "explicit", classifiedBy: "provided", cacheHit: false,
+    }));
+    return res.status(502).json({ error: { message: err.message } });
+  }
+
+  const latencyMs = Date.now() - _reqStart;
+
+  res.set({
+    "X-Arbr-Request-ID": requestId,
+    "X-Arbr-Model":      model,
+    "X-Arbr-Provider":   provider,
+  });
+
+  res.json({
+    object: "list",
+    data:   embeddings.map((embedding, index) => ({ object: "embedding", index, embedding })),
+    model,
+    usage:  { prompt_tokens: promptTokens, total_tokens: promptTokens },
+  });
+
+  // Log non-blocking — same pattern as /v1/chat and /v1/chat/completions
+  setImmediate(() => logger.write({
+    requestId, ...meta,
+    provider, model, modelRequested: model, taskType: "embedding",
+    promptTokens, completionTokens: 0, totalTokens: promptTokens,
+    latencyMs, gatewayOverheadMs: _llmStart - _reqStart,
+    status: "success", routingDecision: "explicit", classifiedBy: "provided", cacheHit: false,
+    messages:     inputs.map((text) => ({ role: "user", content: text })),
+    responseText: null,
+  }));
+}
+
+module.exports = { handleEmbeddings };

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -9,6 +9,7 @@ const registry = require("./pricing/registry");
 const { TASK_CATALOG } = require("./classify/classifier");
 const { handleChat } = require("./gateway/handler");
 const { handleOpenAICompat } = require("./gateway/openaiCompat");
+const { handleEmbeddings } = require("./gateway/embeddings");
 const { purgeOldRecords } = require("./maintenance/purge");
 const errorAlertMonitor = require("./routing/errorAlertMonitor");
 const canaryMonitor = require("./routing/canaryMonitor");
@@ -46,6 +47,10 @@ async function start() {
 
   // OpenAI-compatible endpoint — any client that speaks the OpenAI spec can use Arbr.
   app.post("/v1/chat/completions", auth.middleware, handleOpenAICompat);
+
+  // OpenAI-compatible embeddings endpoint — routes to the appropriate provider
+  // (Gemini or OpenAI-compat) based on the model ID, with full observability.
+  app.post("/v1/embeddings", auth.middleware, handleEmbeddings);
 
   // OpenAI-compatible model discovery — returns only models whose provider is
   // currently connected (live), with a toolCallSupported flag so clients know


### PR DESCRIPTION
## Summary

- `embeddings()` / `aembeddings()` added to both JS and Python SDKs (`POST /v1/embeddings`, OpenAI-compatible wire format) — dispatches to Gemini or any OpenAI-compat provider with full observability
- TypeScript interfaces added: `EmbeddingsRequest`, `EmbeddingObject`, `EmbeddingsResponse`; `embeddings()` on `Client`
- Docs updated in `docs/sdk/js.md` and `docs/sdk/python.md` with single + batch examples, `dimensions` caveats, and OpenAI SDK drop-in snippet
- Both SDKs bumped `0.4.0 → 0.5.0`; CHANGELOGs updated

## Test plan

- [ ] `npm publish` in `clients/js/` — verify `arbr-client@0.5.0` on npm with `embeddings()` in the type definitions
- [ ] `pip publish` in `clients/python/` — verify `arbr-client==0.5.0` on PyPI
- [ ] Smoke test: call `arbr.embeddings({ model: "gemini-embedding-001", input: "test", dimensions: 768 })` against a running gateway with Gemini connected
- [ ] Confirm TypeScript autocomplete shows `EmbeddingsRequest` params and `EmbeddingsResponse.data[].embedding`

🤖 Generated with [Claude Code](https://claude.com/claude-code)