### PR TITLE
feat(gateway): OpenAI Realtime WebSocket proxy — wss://arbr-host/v1/realtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "mongoose": "^9.7.4",
-        "uuid": "^14.0.1"
+        "uuid": "^14.0.1",
+        "ws": "^8.21.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1560,9 +1561,9 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.2.tgz",
-      "integrity": "sha512-KfjEOT6sCg0vvItagfEtGpmrGoLMGfma4Affb5BGEqPmS2YR3AxW54pABSkhQlzCehTB+0BnLquAe1lGF4J9zQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.3.tgz",
+      "integrity": "sha512-F+L5SsciykwDl7eDxacnhDTcWe1IF6jetzfkvI5PPfq6ogWHO7xcjU90SGh/3lqbbS0tgun+qF01KIqxawrCsA==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
@@ -6346,6 +6347,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xml-naming": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "mongoose": "^9.7.4",
-    "uuid": "^14.0.1"
+    "uuid": "^14.0.1",
+    "ws": "^8.21.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/server/src/gateway/auth.js
+++ b/server/src/gateway/auth.js
@@ -67,6 +67,30 @@ async function setRequireApiKey(on) {
   return s.requireApiKey;
 }
 
+// Shared key validator — used by both HTTP middleware and the WS upgrade handler.
+// Returns the keyDoc if valid, null if no key was presented (anonymous request).
+// Throws an Error with .statusCode on invalid/revoked/rate-limited keys.
+async function resolveKey(authHeader) {
+  const raw = authHeader && authHeader.startsWith("Bearer ")
+    ? authHeader.slice(7).trim()
+    : null;
+  if (!raw) return null;
+  const keys = await _keysByHash();
+  const doc = keys.get(hashKey(raw));
+  if (!doc) {
+    const err = new Error("Unknown, disabled, or revoked API key.");
+    err.statusCode = 401;
+    throw err;
+  }
+  if (overRpmLimit(doc.keyHash, doc.rpm)) {
+    const err = new Error(`API key "${doc.name}" is over its ${doc.rpm} requests/minute limit.`);
+    err.statusCode = 429;
+    throw err;
+  }
+  stampLastUsed(doc);
+  return doc;
+}
+
 // Express middleware for the data plane.
 async function middleware(req, res, next) {
   try {
@@ -115,4 +139,4 @@ async function middleware(req, res, next) {
   }
 }
 
-module.exports = { middleware, hashKey, invalidate, requireApiKeyOn, setRequireApiKey };
+module.exports = { middleware, resolveKey, hashKey, invalidate, requireApiKeyOn, setRequireApiKey };

--- a/server/src/gateway/realtimeProxy.js
+++ b/server/src/gateway/realtimeProxy.js
@@ -1,0 +1,154 @@
+// Realtime WebSocket proxy — transparent bidirectional relay for OpenAI Realtime API.
+//
+// Client connects to wss://arbr-host/v1/realtime?model=gpt-realtime-2.1-mini
+// with Authorization: Bearer ab_…  The proxy:
+//   1. Resolves the real OpenAI key from connections.effective()
+//   2. Opens an upstream WS to OpenAI with the real key
+//   3. Relays all frames both ways without modification
+//   4. Inspects response.done events to accumulate audio token counts
+//   5. Writes a RequestRecord on session close (same observability as chat)
+
+const WebSocket = require("ws");
+const { v4: uuidv4 } = require("uuid");
+const connections = require("../providers/connections");
+const logger = require("../logging/logger");
+
+const OPENAI_REALTIME_BASE = "wss://api.openai.com/v1/realtime";
+
+// Models handled by this proxy — all OpenAI realtime variants.
+const REALTIME_MODEL_RE = /^(gpt-.*realtime|o\d.*realtime)/i;
+
+function inferProvider(model) {
+  if (REALTIME_MODEL_RE.test(model)) return "openai";
+  return null;
+}
+
+async function handleRealtimeSession(req, clientWs) {
+  const requestId = uuidv4();
+  const sessionStart = Date.now();
+  const url = new URL(req.url, "http://localhost");
+  const model = url.searchParams.get("model") || "";
+
+  const provider = inferProvider(model);
+  if (!provider) {
+    clientWs.close(1008, `Unsupported realtime model "${model}". Supported: gpt-*-realtime-*, o[n]-*-realtime-*.`);
+    return;
+  }
+
+  // Resolve provider credential.
+  let cred;
+  try {
+    const eff = await connections.effective();
+    cred = eff.providers[provider]?.credential;
+  } catch (err) {
+    clientWs.close(1013, "Gateway error resolving provider credentials.");
+    return;
+  }
+
+  if (!cred?.apiKey) {
+    clientWs.close(1013, `Provider "${provider}" is not connected. Add a credential in Settings → Connections.`);
+    return;
+  }
+
+  // Open upstream WebSocket to OpenAI.
+  const upstreamUrl = `${OPENAI_REALTIME_BASE}?model=${encodeURIComponent(model)}`;
+  const upstream = new WebSocket(upstreamUrl, {
+    headers: {
+      "Authorization": `Bearer ${cred.apiKey}`,
+      "OpenAI-Beta":   "realtime=v1",
+    },
+  });
+
+  // Token accumulators — extracted from response.done events.
+  let audioInputTokens  = 0;
+  let audioOutputTokens = 0;
+  let textInputTokens   = 0;
+  let textOutputTokens  = 0;
+  let sessionStatus     = "success";
+  let torn              = false;
+
+  const meta = {
+    application: req.apiKey?.application || "unknown",
+    workflow:    req.headers["x-arbr-workflow"] || "realtime-voice",
+    userId:      req.apiKey?.userId     || req.headers["x-arbr-user-id"] || null,
+    department:  req.apiKey?.department || req.headers["x-arbr-department"] || null,
+  };
+
+  function teardown(status) {
+    if (torn) return;
+    torn = true;
+    if (status) sessionStatus = status;
+    if (upstream.readyState === WebSocket.OPEN || upstream.readyState === WebSocket.CONNECTING) {
+      upstream.close();
+    }
+    if (clientWs.readyState === WebSocket.OPEN) clientWs.close();
+
+    const totalInputTokens  = audioInputTokens  + textInputTokens;
+    const totalOutputTokens = audioOutputTokens + textOutputTokens;
+
+    setImmediate(() => logger.write({
+      requestId, ...meta,
+      provider, model, modelRequested: model,
+      taskType: "realtime-voice",
+      promptTokens:     totalInputTokens,
+      completionTokens: totalOutputTokens,
+      totalTokens:      totalInputTokens + totalOutputTokens,
+      audioInputTokens,
+      audioOutputTokens,
+      sessionDurationMs: Date.now() - sessionStart,
+      latencyMs:         Date.now() - sessionStart,
+      status: sessionStatus,
+      routingDecision: "explicit", classifiedBy: "provided", cacheHit: false,
+    }));
+  }
+
+  // ── Upstream → client relay ────────────────────────────────────────────────
+  upstream.on("message", (data, isBinary) => {
+    // Inspect text frames for response.done to extract token counts.
+    if (!isBinary) {
+      try {
+        const evt = JSON.parse(data);
+        if (evt.type === "response.done" && evt.response?.usage) {
+          const u = evt.response.usage;
+          audioInputTokens  += u.input_token_details?.audio_tokens  ?? 0;
+          textInputTokens   += u.input_token_details?.text_tokens   ?? 0;
+          audioOutputTokens += u.output_token_details?.audio_tokens ?? 0;
+          textOutputTokens  += u.output_token_details?.text_tokens  ?? 0;
+        }
+      } catch { /* non-JSON frame — ignore */ }
+    }
+    if (clientWs.readyState === WebSocket.OPEN) {
+      clientWs.send(data, { binary: isBinary });
+    }
+  });
+
+  upstream.on("close", (code, reason) => {
+    if (!torn && clientWs.readyState === WebSocket.OPEN) {
+      clientWs.close(code, reason);
+    }
+    teardown();
+  });
+
+  upstream.on("error", (err) => {
+    console.error("[realtimeProxy] upstream error:", err.message);
+    teardown("failure");
+  });
+
+  // ── Client → upstream relay ────────────────────────────────────────────────
+  clientWs.on("message", (data, isBinary) => {
+    if (upstream.readyState === WebSocket.OPEN) {
+      upstream.send(data, { binary: isBinary });
+    }
+  });
+
+  clientWs.on("close", () => {
+    teardown();
+  });
+
+  clientWs.on("error", (err) => {
+    console.error("[realtimeProxy] client error:", err.message);
+    teardown("failure");
+  });
+}
+
+module.exports = { handleRealtimeSession };

--- a/server/src/gateway/wsAuth.js
+++ b/server/src/gateway/wsAuth.js
@@ -1,0 +1,43 @@
+// WebSocket upgrade handler — intercepts HTTP upgrades on /v1/realtime before
+// Express sees them, validates the Arbr API key (same logic as HTTP middleware),
+// and hands off to the realtime proxy.
+const { WebSocketServer } = require("ws");
+const { resolveKey } = require("./auth");
+const { handleRealtimeSession } = require("./realtimeProxy");
+const Settings = require("../models/Settings");
+
+const wss = new WebSocketServer({ noServer: true });
+
+async function handleUpgrade(req, socket, head) {
+  const url = new URL(req.url, "http://localhost");
+  if (!url.pathname.startsWith("/v1/realtime")) {
+    socket.destroy();
+    return;
+  }
+
+  let keyDoc = null;
+  try {
+    keyDoc = await resolveKey(req.headers.authorization || "");
+  } catch (err) {
+    socket.write(`HTTP/1.1 ${err.statusCode || 401} Unauthorized\r\n\r\n`);
+    socket.destroy();
+    return;
+  }
+
+  // If anonymous, reject when requireApiKey is on.
+  if (!keyDoc) {
+    const s = await Settings.get().catch(() => ({ requireApiKey: false }));
+    if (s.requireApiKey) {
+      socket.write("HTTP/1.1 401 Unauthorized\r\n\r\nAn API key is required.");
+      socket.destroy();
+      return;
+    }
+  }
+
+  req.apiKey = keyDoc;
+  wss.handleUpgrade(req, socket, head, (ws) => {
+    handleRealtimeSession(req, ws);
+  });
+}
+
+module.exports = { handleUpgrade };

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,4 +1,5 @@
 // App bootstrap: connect Mongo, mount the gateway + admin API, start listening.
+const http = require("http");
 const path = require("path");
 const fs = require("fs");
 const express = require("express");
@@ -10,6 +11,7 @@ const { TASK_CATALOG } = require("./classify/classifier");
 const { handleChat } = require("./gateway/handler");
 const { handleOpenAICompat } = require("./gateway/openaiCompat");
 const { handleEmbeddings } = require("./gateway/embeddings");
+const { handleUpgrade } = require("./gateway/wsAuth");
 const { purgeOldRecords } = require("./maintenance/purge");
 const errorAlertMonitor = require("./routing/errorAlertMonitor");
 const canaryMonitor = require("./routing/canaryMonitor");
@@ -140,7 +142,9 @@ async function start() {
   // Eval replay worker: picks up queued eval runs (survives restarts; setImmediate did not).
   evalWorker.start();
 
-  app.listen(config.port, config.host, () => {
+  const server = http.createServer(app);
+  server.on("upgrade", handleUpgrade);
+  server.listen(config.port, config.host, () => {
     console.log("\n" + describe() + "\n");
     console.log(`  ready:       http://localhost:${config.port}`);
     console.log(`  gateway:     POST http://localhost:${config.port}/v1/chat`);

--- a/server/src/models/RequestRecord.js
+++ b/server/src/models/RequestRecord.js
@@ -72,6 +72,12 @@ const requestRecordSchema = new mongoose.Schema(
     // Shape: { basis, classificationUsed, rule?, policy?, defaultScope?, override? }
     routingExplain: { type: mongoose.Schema.Types.Mixed, default: null },
 
+    // Realtime voice sessions — audio token breakdown and total session wall-clock time.
+    // Populated only for taskType:"realtime-voice"; zero/null on all other records.
+    audioInputTokens:  { type: Number, default: 0 },
+    audioOutputTokens: { type: Number, default: 0 },
+    sessionDurationMs: { type: Number, default: null },
+
     // Captured context (full prompt + response). PII-masked at write time when
     // Settings.piiMaskingEnabled is on, and size-capped. Headers are intentionally NOT
     // stored (they carry Authorization/API keys). Governed by retentionDays auto-purge.


### PR DESCRIPTION
## Summary

Adds a transparent WebSocket proxy for the OpenAI Realtime API. Any client connecting to `wss://arbr-host/v1/realtime?model=gpt-realtime-*` with an Arbr key gets proxied through to OpenAI with the real key injected — full observability, zero protocol changes.

## What Changed

- **`server/src/index.js`** — switched from `app.listen()` to `http.createServer(app)` so WS upgrades can be intercepted before Express; wires `server.on("upgrade", handleUpgrade)`
- **`package.json`** — added `ws@^8` dependency
- **`server/src/gateway/auth.js`** — extracted `resolveKey(authHeader)` shared helper, reused by both HTTP middleware and WS upgrade path
- **`server/src/gateway/wsAuth.js`** _(new)_ — WS upgrade handler: validates `ab_` key, enforces `requireApiKey` setting, hands off to proxy
- **`server/src/gateway/realtimeProxy.js`** _(new)_ — bidirectional frame relay; all frames pass through unchanged; inspects `response.done` events to accumulate audio token counts; writes `RequestRecord` on session close
- **`server/src/models/RequestRecord.js`** — adds `audioInputTokens`, `audioOutputTokens`, `sessionDurationMs` fields

## How to Test

**1. Auth rejection (no key):**
```sh
npx wscat -c "ws://localhost:4100/v1/realtime?model=gpt-4o-mini-realtime-preview"
# → connection closed (401)
```

**2. Valid connection:**
```sh
npx wscat -c "ws://localhost:4100/v1/realtime?model=gpt-4o-mini-realtime-preview" \
  -H "Authorization: Bearer ab_..."
# → receives {"type":"session.created",...} from OpenAI
```

**3. Full voice round-trip (app side):**
Set in `sis/ai-sales-coach/backend/.env`:
```
ARBR_REALTIME_URL=ws://localhost:4100
ARBR_API_KEY=ab_...
```
Update `openaiRealtimeService.js` WS URL + auth header, start a voice session — confirm speech-to-speech works.

**4. Observability:**
After session ends:
```js
db.request_records.findOne({ taskType: "realtime-voice" })
// → audioInputTokens, audioOutputTokens, sessionDurationMs populated
```

## Risk & Notes

- `http.createServer(app)` is a drop-in replacement for `app.listen()` — Express behaviour is unchanged
- Only `/v1/realtime` upgrades are handled; all other upgrade requests are destroyed immediately
- Session reconnect (OpenAI ~15 min limit) is handled by the app: upstream close propagates to the client, client reconnects to the gateway, gateway opens a fresh upstream session — no proxy-side state needed
- Gemini Live is deferred (SDK doesn't expose raw WS endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)