### PR TITLE
feat(web): restyle console to the ARBR monochrome brand

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -6,11 +6,11 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
     <title>Arbr · Control Plane</title>
-    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23262626'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='central' text-anchor='middle' font-family='Inter%2C system-ui%2C sans-serif' font-weight='700' font-size='20' fill='%23a3e635' letter-spacing='-0.5'%3EA%3C/text%3E%3C/svg%3E" />
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='17.57 8.235 112 112'%3E%3Crect x='17.57' y='8.235' width='112' height='112' rx='24' fill='%23171817'/%3E%3Cpolygon points='24.71 104.9 38.4 104.9 74.29 36.71 109.93 104.67 122.43 104.67 80.33 23.57 68.34 23.57 24.71 104.9' fill='%23f3f2ed'/%3E%3C/svg%3E" />
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/components/Layout.jsx
+++ b/web/src/components/Layout.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { NavLink } from "react-router-dom";
 import { getAdminToken } from "../api.js";
+import { Logo } from "./Logo.jsx";
 
 // ── Inline icons (16×16 stroke, no external dep) ──────────────────────────────
 const Icon = ({ children }) => (
@@ -108,18 +109,13 @@ const FOOTER_LINK = { to: "/docs", label: "Docs", icon: icons.docs };
 function navClass({ isActive }) {
   return `mx-1 my-0.5 flex items-center gap-2.5 rounded-lg px-3 py-2 text-[13px] font-medium transition-colors ${
     isActive
-      ? "bg-arbr-green-50 text-arbr-green-700"
+      ? "bg-arbr-accent-50 text-arbr-charcoal font-semibold"
       : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
   }`;
 }
 
 function Wordmark() {
-  return (
-    <div className="flex items-baseline gap-0.5">
-      <span className="text-xl font-bold tracking-tight text-arbr-charcoal">ARBR</span>
-      <span className="text-xl font-bold text-arbr-green-600">.</span>
-    </div>
-  );
+  return <Logo className="h-5 w-auto text-arbr-charcoal" />;
 }
 
 export default function Layout({ status, onSignOut, children }) {
@@ -213,8 +209,8 @@ export default function Layout({ status, onSignOut, children }) {
               Demo — no provider keys
             </span>
           ) : (
-            <span className="inline-flex items-center gap-1.5 rounded-md border border-arbr-green-200 bg-arbr-green-50 px-2 py-0.5 text-xs font-medium text-arbr-green-700">
-              <span className="h-1.5 w-1.5 rounded-full bg-arbr-green-500" />
+            <span className="inline-flex items-center gap-1.5 rounded-md border border-green-200 bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700">
+              <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
               {(status?.liveProviders || []).join(", ") || "Live"}
             </span>
           )}
@@ -224,7 +220,7 @@ export default function Layout({ status, onSignOut, children }) {
             </span>
           )}
           {status?.routingMode && status.routingMode !== "off" && (
-            <span className="inline-flex items-center rounded-md border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-700">
+            <span className="inline-flex items-center rounded-md border border-gray-200 bg-gray-100 px-2 py-0.5 text-xs font-medium text-arbr-charcoal">
               {status.routingMode === "ai" ? "AI routing" : "Cost guardrail"}
             </span>
           )}

--- a/web/src/components/Logo.jsx
+++ b/web/src/components/Logo.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+// ARBR wordmark — the geometric, crossbar-less-"A" brand lockup
+// (source: assets/brand/arbr-wordmark.svg). Inlined so it inherits color via
+// `currentColor` (set a text-* class on this element or a parent) and needs no
+// external asset, keeping it CSP-safe. `className` controls size/color.
+export function Logo({ className = "h-5 w-auto text-arbr-charcoal" }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 554.65 131.4"
+      fill="currentColor"
+      role="img"
+      aria-label="ARBR"
+    >
+      <title>ARBR</title>
+      <polygon points="24.71 104.9 38.4 104.9 74.29 36.71 109.93 104.67 122.43 104.67 80.33 23.57 68.34 23.57 24.71 104.9" />
+      <path d="M177.89,104.94h11.37V33.67h36.36c8.97,0,16.25,7.27,16.25,16.25h0c0,8.97-7.27,16.25-16.25,16.25h-21.26l38.48,38.48h15.23l-28.26-29.23c13.38-2.58,23.7-11.71,23.42-27.24-.85-14.54-9.33-25.2-23.25-25.96h-51.84s-.25,82.73-.25,82.73Z" />
+      <path d="M380.49,61.21c12.4-9.94,10.89-26.07,2.88-33.09,0,0-4.07-5.09-13.91-5.85l-54.22-.21v82.69h54.22s23.59-.85,23.42-22.66c.37-10.31-3.91-17.15-12.39-20.88ZM326.42,33.79h39.53c6.38,0,11.54,5.17,11.54,11.54,0,3.19-1.29,6.07-3.38,8.16-2.09,2.09-4.98,3.38-8.16,3.38h-39.53v-23.08ZM378.35,89.62c-2.3,2.31-5.48,3.73-8.99,3.73h-42.93v-25.46h42.93c7.03,0,12.72,5.7,12.72,12.73,0,3.51-1.42,6.7-3.73,8.99Z" />
+      <path d="M449.76,104.94h11.37V33.67h36.36c8.97,0,16.25,7.27,16.25,16.25h0c0,8.97-7.27,16.25-16.25,16.25h-21.26l38.48,38.48h15.23l-28.26-29.23c13.38-2.58,23.7-11.71,23.42-27.24-.85-14.54-9.33-25.2-23.25-25.96h-51.84s-.25,82.73-.25,82.73Z" />
+    </svg>
+  );
+}

--- a/web/src/components/RequestsTable.jsx
+++ b/web/src/components/RequestsTable.jsx
@@ -83,7 +83,7 @@ function explainRouting(r) {
 function RoutingExplanation({ r }) {
   const lines = explainRouting(r);
   return (
-    <div className="rounded-lg border border-arbr-green-200 bg-arbr-green-50 p-4">
+    <div className="rounded-lg border border-arbr-accent-200 bg-arbr-accent-50 p-4">
       <div className="mb-1 flex items-center gap-2">
         <span className="label">Why this routing</span>
         <Badge tone={ROUTING_TONE[r.routingDecision]}>{r.routingDecision}</Badge>

--- a/web/src/components/TrendChart.jsx
+++ b/web/src/components/TrendChart.jsx
@@ -55,7 +55,7 @@ export default function TrendChart({ appName }) {
       ) : (
         <ResponsiveContainer width="100%" height={220}>
           <ComposedChart data={rows} margin={{ top: 4, right: 16, left: 0, bottom: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+            <CartesianGrid strokeDasharray="3 3" stroke="#e7e5df" />
             <XAxis dataKey="date" tick={{ fontSize: 11 }} tickFormatter={(d) => d.slice(5)} />
             <YAxis yAxisId="cost" orientation="left" tick={{ fontSize: 11 }}
               tickFormatter={(v) => `$${v.toFixed(2)}`} width={58} />
@@ -65,9 +65,9 @@ export default function TrendChart({ appName }) {
               labelFormatter={(d) => `Date: ${d}`}
             />
             <Legend wrapperStyle={{ fontSize: 12 }} />
-            <Bar yAxisId="cost" dataKey="cost" name="cost" fill="#4ade80" opacity={0.8} radius={[2, 2, 0, 0]} />
+            <Bar yAxisId="cost" dataKey="cost" name="cost" fill="#171817" opacity={0.85} radius={[2, 2, 0, 0]} />
             <Line yAxisId="reqs" dataKey="requests" name="requests" type="monotone"
-              stroke="#6366f1" strokeWidth={2} dot={false} />
+              stroke="#9ca3af" strokeWidth={2} dot={false} />
           </ComposedChart>
         </ResponsiveContainer>
       )}

--- a/web/src/components/ui.jsx
+++ b/web/src/components/ui.jsx
@@ -11,7 +11,7 @@ export function Tabs({ tabs, active, onChange }) {
           onClick={() => onChange(k)}
           className={`-mb-px border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
             active === k
-              ? "border-arbr-green-600 text-arbr-charcoal"
+              ? "border-arbr-accent-600 text-arbr-charcoal"
               : "border-transparent text-gray-500 hover:text-arbr-charcoal"
           }`}
         >
@@ -64,12 +64,9 @@ export function Stat({ label, value, sub }) {
 }
 
 const BADGE_TONES = {
-  green:    "bg-arbr-green-50 text-arbr-green-700 border-arbr-green-200",
+  green:    "bg-green-50 text-green-700 border-green-200",   // semantic: live / healthy / good-vs-bad verdicts
   charcoal: "bg-gray-100 text-arbr-charcoal border-gray-200",
   amber:    "bg-amber-50 text-amber-700 border-amber-200",
-  indigo:   "bg-indigo-50 text-indigo-700 border-indigo-200",
-  violet:   "bg-violet-50 text-violet-700 border-violet-200",
-  teal:     "bg-teal-50 text-teal-700 border-teal-200",
   red:      "bg-red-50 text-red-700 border-red-200",
   gray:     "bg-gray-50 text-gray-500 border-gray-200",
 };
@@ -122,7 +119,7 @@ export function Toggle({ checked, onChange, label }) {
     <button
       type="button"
       onClick={() => onChange(!checked)}
-      className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${checked ? "bg-arbr-green-600" : "bg-gray-300"}`}
+      className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${checked ? "bg-arbr-accent-600" : "bg-gray-300"}`}
       aria-pressed={checked}
       aria-label={label}
     >
@@ -184,7 +181,7 @@ export function CodeBlock({ code, lang }) {
       {lang && <span className="absolute left-3 top-2 font-mono text-[10px] uppercase tracking-wide text-gray-400">{lang}</span>}
       <button
         onClick={copy}
-        className="absolute right-2 top-2 rounded border border-gray-200 bg-white px-2 py-0.5 font-mono text-xs text-gray-500 hover:border-arbr-green-600 hover:text-arbr-charcoal"
+        className="absolute right-2 top-2 rounded border border-gray-200 bg-white px-2 py-0.5 font-mono text-xs text-gray-500 hover:border-arbr-accent-600 hover:text-arbr-charcoal"
       >
         {copied ? "Copied" : "Copy"}
       </button>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -6,7 +6,7 @@
     height: 100%;
   }
   body {
-    @apply bg-gray-50 text-arbr-charcoal font-sans antialiased;
+    @apply bg-arbr-paper text-arbr-charcoal font-sans antialiased;
   }
 }
 
@@ -34,7 +34,7 @@
     @apply text-xs font-medium uppercase tracking-wide text-gray-500;
   }
   .input {
-    @apply rounded-md border border-gray-200 px-3 py-2 text-sm focus:border-arbr-green-600 focus:outline-none focus:ring-2 focus:ring-arbr-green-600/15;
+    @apply rounded-md border border-gray-200 px-3 py-2 text-sm focus:border-arbr-accent-600 focus:outline-none focus:ring-2 focus:ring-arbr-accent-600/15;
   }
   .mono {
     @apply font-mono text-[13px] tracking-tight;

--- a/web/src/pages/Applications.jsx
+++ b/web/src/pages/Applications.jsx
@@ -45,8 +45,8 @@ function statusBadge(isKilled, neverUsed) {
     );
   }
   return (
-    <span className="inline-flex items-center gap-1 text-xs font-medium text-arbr-green-700">
-      <span className="h-1.5 w-1.5 rounded-full bg-arbr-green-600 inline-block" />
+    <span className="inline-flex items-center gap-1 text-xs font-medium text-green-700">
+      <span className="h-1.5 w-1.5 rounded-full bg-green-600 inline-block" />
       Active
     </span>
   );
@@ -64,7 +64,7 @@ function healthLevel(isKilled, neverUsed, successPct, avgLatency) {
 }
 
 const HEALTH_DOT = {
-  green: "bg-arbr-green-500",
+  green: "bg-green-500",
   amber: "bg-amber-400",
   red:   "bg-red-400",
   none:  "bg-gray-300",
@@ -124,7 +124,7 @@ function AppCard({ app, stats, config, onToggleKill }) {
         <div className="flex items-start gap-2 min-w-0">
           <span className={`h-2 w-2 rounded-full shrink-0 mt-[5px] ${HEALTH_DOT[health]}`} />
           {/* Two-line wrap instead of truncate so names stay readable */}
-          <span className="text-[15px] font-bold text-arbr-charcoal group-hover:text-arbr-green-700 leading-snug break-words min-w-0">
+          <span className="text-[15px] font-bold text-arbr-charcoal group-hover:text-arbr-accent-700 leading-snug break-words min-w-0">
             {app}
           </span>
         </div>
@@ -190,7 +190,7 @@ function AppRow({ app, stats, config, onToggleKill }) {
   return (
     <tr className={`border-b border-gray-100 last:border-0 transition-colors hover:bg-gray-50/60 ${isKilled ? "bg-red-50/20" : neverUsed ? "bg-gray-50/30" : ""}`}>
       <td className="py-3 pl-4 pr-3">
-        <Link to={`/applications/${encodeURIComponent(app)}`} className="font-medium text-arbr-charcoal hover:text-arbr-green-700 hover:underline">
+        <Link to={`/applications/${encodeURIComponent(app)}`} className="font-medium text-arbr-charcoal hover:text-arbr-accent-700 hover:underline">
           {app}
         </Link>
       </td>
@@ -201,7 +201,7 @@ function AppRow({ app, stats, config, onToggleKill }) {
       <td className="py-3 px-3 text-sm text-arbr-charcoal tabular-nums">{stats ? fmt.ms(stats.avgLatency) : "—"}</td>
       <td className="py-3 pl-3 pr-4">
         <div className="flex items-center justify-end gap-3">
-          <Link to={`/applications/${encodeURIComponent(app)}`} className="text-xs text-arbr-green-600 hover:underline whitespace-nowrap">
+          <Link to={`/applications/${encodeURIComponent(app)}`} className="text-xs text-arbr-accent-600 hover:underline whitespace-nowrap">
             View →
           </Link>
           <Toggle checked={isActive} onChange={() => onToggleKill(app, !isKilled)} label="connected" />

--- a/web/src/pages/Budgets.jsx
+++ b/web/src/pages/Budgets.jsx
@@ -19,7 +19,7 @@ function actionLabel(action) {
 // Inline progress bar: green → amber (>80%) → red (breached).
 function SpendBar({ cap }) {
   const pct = Math.min(cap.pct ?? 0, 100);
-  const color = cap.breached ? "bg-red-500" : pct > 80 ? "bg-amber-400" : "bg-arbr-green-600";
+  const color = cap.breached ? "bg-red-500" : pct > 80 ? "bg-amber-400" : "bg-green-600";
   return (
     <div className="flex items-center gap-2">
       <div className="relative h-1.5 w-20 overflow-hidden rounded-full bg-gray-200">
@@ -65,7 +65,7 @@ function CapRow({ cap, onRefresh }) {
 
   return (
     <>
-      <tr className={`border-b border-gray-100 ${cap.breached && cap.enabled ? "bg-red-50/40" : "hover:bg-arbr-green-50"}`}>
+      <tr className={`border-b border-gray-100 ${cap.breached && cap.enabled ? "bg-red-50/40" : "hover:bg-arbr-accent-50"}`}>
         <td className="px-3 py-2.5">
           <Toggle checked={cap.enabled} onChange={toggle} label="enabled" />
         </td>

--- a/web/src/pages/Docs.jsx
+++ b/web/src/pages/Docs.jsx
@@ -142,10 +142,10 @@ res = arbr.chat("Summarise this ticket: ...", model="auto", max_tokens=300)   # 
       <Card title="Learn more">
         <p className="text-sm text-gray-600">
           Full guides live in the repo's <code>docs/</code> (VitePress): integration walkthroughs for
-          <a className="mx-1 text-arbr-green-700 underline" href="https://github.com/project-arbr/arbr-control-plane/tree/main/docs/integrations" target="_blank" rel="noreferrer">OpenCode / LibreChat / NVIDIA</a>,
-          plus <a className="mx-1 text-arbr-green-700 underline" href="https://github.com/project-arbr/arbr-control-plane/blob/main/docs/routing.md" target="_blank" rel="noreferrer">routing</a>,
-          <a className="mx-1 text-arbr-green-700 underline" href="https://github.com/project-arbr/arbr-control-plane/blob/main/docs/budgets.md" target="_blank" rel="noreferrer">budgets</a>, and the
-          <a className="mx-1 text-arbr-green-700 underline" href="https://github.com/project-arbr/arbr-control-plane/blob/main/docs/api-reference.md" target="_blank" rel="noreferrer">API reference</a>.
+          <a className="mx-1 text-arbr-accent-700 underline" href="https://github.com/project-arbr/arbr-control-plane/tree/main/docs/integrations" target="_blank" rel="noreferrer">OpenCode / LibreChat / NVIDIA</a>,
+          plus <a className="mx-1 text-arbr-accent-700 underline" href="https://github.com/project-arbr/arbr-control-plane/blob/main/docs/routing.md" target="_blank" rel="noreferrer">routing</a>,
+          <a className="mx-1 text-arbr-accent-700 underline" href="https://github.com/project-arbr/arbr-control-plane/blob/main/docs/budgets.md" target="_blank" rel="noreferrer">budgets</a>, and the
+          <a className="mx-1 text-arbr-accent-700 underline" href="https://github.com/project-arbr/arbr-control-plane/blob/main/docs/api-reference.md" target="_blank" rel="noreferrer">API reference</a>.
         </p>
       </Card>
     </div>

--- a/web/src/pages/Governance.jsx
+++ b/web/src/pages/Governance.jsx
@@ -17,7 +17,7 @@ function SaveRow({ saving, ok, err }) {
       <button className="btn-secondary text-sm" type="submit" disabled={saving}>
         {saving ? "Saving…" : "Save"}
       </button>
-      {ok  && <span className="text-sm text-arbr-green-600">Saved.</span>}
+      {ok  && <span className="text-sm text-arbr-accent-600">Saved.</span>}
       {err && <span className="text-sm text-red-600">{err}</span>}
     </div>
   );
@@ -199,7 +199,7 @@ function GuardrailsTab({ gov, setGov, save, saving, ok, err }) {
       <Card>
         <div className={`-mx-6 -mt-6 mb-4 rounded-t-lg px-6 py-3 ${isKilled ? "bg-red-50 border-b border-red-200" : "bg-gray-50 border-b border-gray-100"}`}>
           <div className="flex items-center gap-3">
-            <span className={`inline-flex h-2 w-2 rounded-full ${isKilled ? "bg-red-500 animate-pulse" : "bg-arbr-green-500"}`} />
+            <span className={`inline-flex h-2 w-2 rounded-full ${isKilled ? "bg-red-500 animate-pulse" : "bg-green-500"}`} />
             <span className={`text-sm font-semibold ${isKilled ? "text-red-700" : "text-arbr-charcoal"}`}>
               {isKilled ? "Gateway halted — all /v1/* requests returning 503" : "Gateway active"}
             </span>
@@ -514,7 +514,7 @@ function RecentEventsCard() {
         </div>
       )}
       <div className="mt-3 border-t border-gray-100 pt-3 text-right">
-        <Link to="/audit" className="text-xs text-arbr-green-600 hover:underline">View full audit log →</Link>
+        <Link to="/audit" className="text-xs text-arbr-accent-600 hover:underline">View full audit log →</Link>
       </div>
     </Card>
   );
@@ -636,7 +636,7 @@ function SystemInfoCard() {
     { label: "Active providers", value: status?.liveProviders?.length != null ? fmt.num(status.liveProviders.length) : "—" },
     { label: "Default model",    value: status?.defaultModel || "—" },
     { label: "Routing mode",     value: status?.routingMode || "—",
-      extra: <Link to="/routing" className="ml-2 text-xs text-arbr-green-600 hover:underline">Configure →</Link> },
+      extra: <Link to="/routing" className="ml-2 text-xs text-arbr-accent-600 hover:underline">Configure →</Link> },
   ];
 
   return (

--- a/web/src/pages/Login.jsx
+++ b/web/src/pages/Login.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { api, setAdminToken, clearAdminToken } from "../api.js";
+import { Logo } from "../components/Logo.jsx";
 
 // Shown when the instance has admin auth enabled (ARBR_ADMIN_KEY) and the
 // browser has no valid key stored. Sessionless: the key IS the credential.
@@ -25,12 +26,9 @@ export default function Login({ onAuthed }) {
   };
 
   return (
-    <div className="flex min-h-full items-center justify-center bg-gray-50 px-4">
+    <div className="flex min-h-full items-center justify-center bg-arbr-paper px-4">
       <form onSubmit={submit} className="card w-full max-w-sm p-8">
-        <div className="flex items-baseline gap-0.5">
-          <span className="text-xl font-bold tracking-tight text-arbr-charcoal">ARBR</span>
-          <span className="text-xl font-bold text-arbr-green-600">.</span>
-        </div>
+        <Logo className="h-6 w-auto text-arbr-charcoal" />
         <p className="mt-1 text-sm text-gray-500">This instance requires the admin key.</p>
 
         <div className="mt-6">

--- a/web/src/pages/ModelEvals.jsx
+++ b/web/src/pages/ModelEvals.jsx
@@ -157,7 +157,7 @@ function CampaignDetail({ id, onClose }) {
         <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
           App <b>{detail.application}</b> · candidate <b>{detail.candidateModel}</b> · judge {detail.judgeModel || "none"} ·
           sample {pct(detail.sampleRate)} · notify at {detail.thresholds?.minPairs} pairs, loss ≤ {pct(detail.thresholds?.maxLossRate)}
-          {detail.notifiedAt && <span className="ml-1 text-arbr-green-700">· healthy-notification sent</span>}
+          {detail.notifiedAt && <span className="ml-1 text-arbr-accent-700">· healthy-notification sent</span>}
         </div>
         <div>
           <div className="label mb-1">Recent pairs</div>
@@ -260,7 +260,7 @@ function RunDetail({ id, onClose }) {
         <div className="flex justify-end"><RefreshButton onClick={load} /></div>
         {(() => {
           const o = runOutcome(run);
-          const bg = o.tone === "green" ? "bg-green-50 text-arbr-green-700"
+          const bg = o.tone === "green" ? "bg-green-50 text-green-700"
             : o.tone === "red" ? "bg-red-50 text-red-700"
             : o.tone === "amber" ? "bg-amber-50 text-amber-800"
             : "bg-gray-50 text-gray-600";
@@ -298,7 +298,7 @@ function RunDetail({ id, onClose }) {
               <button className="btn-secondary text-sm" disabled={busy} onClick={startShadow}>Start shadow →</button>
               <button className="btn-secondary text-sm" disabled={busy} onClick={startCanary}>Start canary →</button>
             </div>
-            {notice && <div className={`mt-2 text-sm ${notice.startsWith("Error") ? "text-red-600" : "text-arbr-green-700"}`}>{notice}</div>}
+            {notice && <div className={`mt-2 text-sm ${notice.startsWith("Error") ? "text-red-600" : "text-arbr-accent-700"}`}>{notice}</div>}
           </div>
         )}
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
@@ -310,7 +310,7 @@ function RunDetail({ id, onClose }) {
         <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-xs text-gray-600">
           {run.baselineModel} → {run.candidateModel} · judge {run.judgeModel || "none"} · {run.riskTier} risk · est. cost {fmt.usd(run.estimatedCostUsd)} · actual {fmt.usd(run.actualCostUsd)}
           {run.fidelity === "masked" && <span className="ml-1 text-amber-600">· masked dataset (lower-fidelity: candidate saw redacted prompts vs the original baseline)</span>}
-          {s.disprovedWorse > 0 && <span className="ml-1 text-arbr-green-700">· disprove pass overturned {fmt.num(s.disprovedWorse)} false “worse” verdict{s.disprovedWorse === 1 ? "" : "s"}</span>}
+          {s.disprovedWorse > 0 && <span className="ml-1 text-arbr-accent-700">· disprove pass overturned {fmt.num(s.disprovedWorse)} false “worse” verdict{s.disprovedWorse === 1 ? "" : "s"}</span>}
         </div>
         <div className="flex items-center justify-between">
           <div className="label">Worst candidate examples</div>
@@ -439,7 +439,7 @@ function NewEval({ models, apps, onCreated }) {
       )}
       <SameFamilyWarning candidate={form.candidateModel} judge={form.judgeModel} />
       {err && <div className="mt-3 text-sm text-red-600">{err}</div>}
-      {notice && <div className="mt-3 text-sm text-arbr-green-700">{notice}</div>}
+      {notice && <div className="mt-3 text-sm text-arbr-accent-700">{notice}</div>}
       <div className="mt-3">
         <button className="btn-secondary text-sm" disabled={busy || !valid} onClick={submit}>
           {busy ? "Starting…" : "Run eval"}
@@ -661,7 +661,7 @@ function BenchmarkDetail({ id, models, onClose }) {
           </div>
           <SameFamilyWarning candidate={cand} judge={judge} />
           {err && <div className="mt-2 text-sm text-red-600">{err}</div>}
-          {notice && <div className="mt-2 text-sm text-arbr-green-700">{notice}</div>}
+          {notice && <div className="mt-2 text-sm text-arbr-accent-700">{notice}</div>}
           {bench.suggestedCandidates?.length > 0 && (
             <div className="mt-3 border-t border-gray-100 pt-3">
               <div className="text-xs text-gray-500">Suggested — connected models cheaper than the baseline, not scored yet. Click to load one, then Run:</div>
@@ -825,7 +825,7 @@ function StageHeading({ n, title, desc }) {
   return (
     <div className="border-b border-gray-100 pb-1 pt-2">
       <div className="flex items-baseline gap-2">
-        <span className="font-mono text-[11px] font-semibold uppercase tracking-wider text-arbr-green-600">Stage {n}</span>
+        <span className="font-mono text-[11px] font-semibold uppercase tracking-wider text-arbr-accent-600">Stage {n}</span>
         <span className="text-base font-semibold text-arbr-charcoal">{title}</span>
       </div>
       <p className="mt-0.5 text-xs text-gray-500">{desc}</p>

--- a/web/src/pages/Models.jsx
+++ b/web/src/pages/Models.jsx
@@ -68,7 +68,7 @@ const isChatLikely = (id) => !NON_CHAT_MODEL_RE.test(String(id || ""));
 
 function StatusDot({ live }) {
   return (
-    <span className={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${live ? "bg-arbr-green-600" : "bg-gray-300"}`} />
+    <span className={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${live ? "bg-green-600" : "bg-gray-300"}`} />
   );
 }
 
@@ -81,7 +81,7 @@ function Field({ label, children }) {
   );
 }
 
-const INPUT = "w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-arbr-green-600 focus:outline-none focus:ring-1 focus:ring-arbr-green-600";
+const INPUT = "w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-arbr-accent-600 focus:outline-none focus:ring-1 focus:ring-arbr-accent-600";
 const BTN   = "rounded-md px-3 py-1.5 text-sm font-medium transition-colors";
 const BTN_PRIMARY = `${BTN} bg-arbr-charcoal text-white hover:bg-arbr-ink`;
 const BTN_GHOST   = `${BTN} border border-gray-300 text-gray-700 hover:bg-gray-50`;
@@ -98,7 +98,7 @@ function BenchmarkBar({ dim, value }) {
       <span className="w-16 text-right text-gray-500 capitalize flex-shrink-0">{dim}</span>
       <div className="flex-1 h-1.5 rounded-full bg-gray-200 overflow-hidden">
         {pct != null && (
-          <div className="h-1.5 rounded-full bg-arbr-green-600 transition-all" style={{ width: `${pct}%` }} />
+          <div className="h-1.5 rounded-full bg-arbr-accent-600 transition-all" style={{ width: `${pct}%` }} />
         )}
       </div>
       <span className="w-8 font-mono text-gray-600 flex-shrink-0">{pct != null ? pct : "—"}</span>
@@ -175,7 +175,7 @@ function ModelMetaPanel({ model }) {
         <div className="flex items-center gap-2">
           <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">Capabilities</span>
           {chips.map((c) => (
-            <span key={c} className="rounded-full bg-arbr-green-50 border border-arbr-green-200 px-2 py-0.5 text-xs font-medium text-arbr-green-700">{c}</span>
+            <span key={c} className="rounded-full bg-arbr-accent-50 border border-arbr-accent-200 px-2 py-0.5 text-xs font-medium text-arbr-accent-700">{c}</span>
           ))}
         </div>
       )}
@@ -361,7 +361,7 @@ function ModelRow({ model, onRefresh }) {
           <div className="px-4 py-2.5 bg-gray-50 border-t border-gray-100 flex items-center gap-2">
             <button
               onClick={(e) => { e.stopPropagation(); setShowTest((v) => !v); setDeleting(false); }}
-              className={`${BTN} text-xs ${showTest ? "bg-arbr-green-50 text-arbr-green-700 border border-arbr-green-200" : "text-gray-600 hover:bg-gray-100"}`}
+              className={`${BTN} text-xs ${showTest ? "bg-arbr-accent-50 text-arbr-accent-700 border border-arbr-accent-200" : "text-gray-600 hover:bg-gray-100"}`}
             >
               Test
             </button>
@@ -462,7 +462,7 @@ function AddModelForm({ providerId, models, onSave, onClose }) {
               required
             />
             {autoFilled && (
-              <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-arbr-green-600 font-medium">
+              <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-arbr-accent-600 font-medium">
                 auto-filled
               </span>
             )}
@@ -541,7 +541,7 @@ function ModelList({ providerId, models, onRefresh }) {
       {summary && (
         summary.error
           ? <p className="text-sm text-red-600">{summary.error}</p>
-          : <p className="text-sm text-arbr-green-700">Imported: {summary.created} new, {summary.adopted} adopted, {summary.skipped} already present{summary.conflicts?.length ? `, ${summary.conflicts.length} skipped (owned by another provider)` : ""}.</p>
+          : <p className="text-sm text-arbr-accent-700">Imported: {summary.created} new, {summary.adopted} adopted, {summary.skipped} already present{summary.conflicts?.length ? `, ${summary.conflicts.length} skipped (owned by another provider)` : ""}.</p>
       )}
 
       {disc && disc.error && <p className="text-sm text-red-600">Discovery failed: {disc.error}</p>}
@@ -560,7 +560,7 @@ function ModelList({ providerId, models, onRefresh }) {
                 <input type="checkbox" checked={!!sel[m.id]} disabled={m.registered}
                   onChange={(e) => setSel((s) => ({ ...s, [m.id]: e.target.checked }))} />
                 <span className="font-mono text-gray-700">{m.id}</span>
-                {m.registered ? <Badge tone="green">registered</Badge> : m.known && <Badge tone="gray">known pricing</Badge>}
+                {m.registered ? <Badge tone="charcoal">registered</Badge> : m.known && <Badge tone="gray">known pricing</Badge>}
                 {m.chatLikely === false && <Badge tone="amber">non-chat</Badge>}
               </label>
             ))}
@@ -695,7 +695,7 @@ function BuiltinProviderDetail({ provider, models, onRefresh }) {
       </div>
 
       {testResult && (
-        <div className={`text-sm rounded-lg px-4 py-3 ${testResult.ok ? "bg-arbr-green-50 text-arbr-green-800 border border-arbr-green-200" : "bg-red-50 text-red-700 border border-red-200"}`}>
+        <div className={`text-sm rounded-lg px-4 py-3 ${testResult.ok ? "bg-arbr-accent-50 text-arbr-accent-800 border border-arbr-accent-200" : "bg-red-50 text-red-700 border border-red-200"}`}>
           {testResult.ok ? `✓ Connected · model: ${testResult.model}${testResult.sample ? ` · "${testResult.sample}"` : ""}` : `✗ ${testResult.message}`}
         </div>
       )}
@@ -788,7 +788,7 @@ function CustomProviderDetail({ provider, models, onRefresh, onDeleted }) {
       </div>
 
       {testResult && (
-        <div className={`text-sm rounded-lg px-4 py-3 ${testResult.ok ? "bg-arbr-green-50 text-arbr-green-800 border border-arbr-green-200" : "bg-red-50 text-red-700 border border-red-200"}`}>
+        <div className={`text-sm rounded-lg px-4 py-3 ${testResult.ok ? "bg-arbr-accent-50 text-arbr-accent-800 border border-arbr-accent-200" : "bg-red-50 text-red-700 border border-red-200"}`}>
           {testResult.ok
             ? `✓ Connected · model: ${testResult.model}${testResult.sample ? ` · "${testResult.sample}"` : ""}`
             : `✗ ${testResult.message}`}
@@ -915,7 +915,7 @@ function CatalogProviderDetail({ provider, models, onRefresh }) {
           <div className="flex flex-col gap-1 text-sm">
             <label className="font-medium text-gray-700">
               Base URL
-              {info.url && <span className="ml-2 text-xs font-normal text-arbr-green-700">· pre-filled with official endpoint</span>}
+              {info.url && <span className="ml-2 text-xs font-normal text-arbr-accent-700">· pre-filled with official endpoint</span>}
               {!info.url && <span className="ml-2 text-xs font-normal text-amber-600">· account-specific, see hint below</span>}
             </label>
             <input
@@ -1006,7 +1006,7 @@ function AddProviderForm({ onSaved, onClose }) {
         </select>
         <span className="text-[11px] text-gray-400">Pick to prefill the base URL, or leave as Custom and enter it manually.</span>
       </Field>
-      {pickedInfo?.hint && <p className="text-[11px] text-arbr-green-700">{pickedInfo.hint}</p>}
+      {pickedInfo?.hint && <p className="text-[11px] text-arbr-accent-700">{pickedInfo.hint}</p>}
       <Field label="Provider ID (slug)">
         <input className={INPUT} placeholder="my-provider" value={form.id} onChange={s("id")} required />
         <span className="text-[11px] text-gray-400">Lowercase, no spaces. Used internally to match models.</span>
@@ -1057,7 +1057,7 @@ function ProviderSidebar({ allProviders, selected, onSelect, onRefresh }) {
             onClick={() => onSelect(p)}
             className={`w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-left transition-colors ${
               selected?.provider === p.provider && selected?.type === p.type
-                ? "bg-arbr-green-50 text-arbr-charcoal font-medium"
+                ? "bg-arbr-accent-50 text-arbr-charcoal font-medium"
                 : "text-gray-600 hover:bg-gray-50"
             }`}
           >

--- a/web/src/pages/Recommendations.jsx
+++ b/web/src/pages/Recommendations.jsx
@@ -27,14 +27,14 @@ function stepsFromEvalStatus(evalStatus) {
 }
 
 const DOT_CLASS = {
-  done:    "w-6 h-6 rounded-full bg-arbr-green-600 text-white flex items-center justify-center text-xs font-medium",
-  active:  "w-6 h-6 rounded-full border-2 border-arbr-green-600 text-arbr-green-600 flex items-center justify-center text-xs font-medium",
+  done:    "w-6 h-6 rounded-full bg-arbr-accent-600 text-white flex items-center justify-center text-xs font-medium",
+  active:  "w-6 h-6 rounded-full border-2 border-arbr-accent-600 text-arbr-accent-600 flex items-center justify-center text-xs font-medium",
   running: "w-6 h-6 rounded-full border-2 border-amber-400 text-amber-500 flex items-center justify-center text-xs font-medium animate-pulse",
   failed:  "w-6 h-6 rounded-full border-2 border-red-400 text-red-500 flex items-center justify-center text-xs font-medium",
   idle:    "w-6 h-6 rounded-full border-2 border-gray-200 text-gray-300 flex items-center justify-center text-xs font-medium",
 };
 const DOT_TEXT = {
-  done: "text-arbr-green-700 font-medium", active: "text-arbr-green-600 font-medium",
+  done: "text-arbr-accent-700 font-medium", active: "text-arbr-accent-600 font-medium",
   running: "text-amber-600", failed: "text-red-600", idle: "text-gray-300",
 };
 
@@ -50,7 +50,7 @@ function StepTracker({ steps }) {
             <span className={`text-xs ${DOT_TEXT[step.status]}`}>{step.label}</span>
           </div>
           {i < steps.length - 1 && (
-            <div className={`flex-1 h-px mx-3 min-w-8 ${step.status === "done" ? "bg-arbr-green-200" : "bg-gray-100"}`} />
+            <div className={`flex-1 h-px mx-3 min-w-8 ${step.status === "done" ? "bg-arbr-accent-200" : "bg-gray-100"}`} />
           )}
         </React.Fragment>
       ))}
@@ -66,7 +66,7 @@ function QualitySummary({ s }) {
       <Badge tone={s.worseRate > 0.05 ? "red" : "green"}>worse {pct(s.worseRate)}</Badge>
       {s.criticalFailRate != null && <Badge tone={s.criticalFailRate > 0 ? "red" : "gray"}>critical {pct(s.criticalFailRate)}</Badge>}
       <Badge tone="gray">format {pct(s.formatPassRate)}</Badge>
-      <Badge tone="green">cost -{pct(s.costSavingPct)}</Badge>
+      <Badge tone="charcoal">cost -{pct(s.costSavingPct)}</Badge>
       {s.avgLatencyDeltaPct != null && <Badge tone="gray">latency {s.avgLatencyDeltaPct > 0 ? "+" : ""}{pct(s.avgLatencyDeltaPct)}</Badge>}
     </div>
   );
@@ -115,7 +115,7 @@ function RecCard({ rec, models, onChange }) {
             {rec.taskType && <span className="text-xs text-gray-400 truncate hidden sm:block">· {rec.taskType}</span>}
             {rec.application && <span className="text-xs text-gray-400 truncate hidden sm:block">· {rec.application}</span>}
           </div>
-          <span className="shrink-0 text-sm font-semibold text-arbr-green-600">{fmt.usd(rec.projectedSavings)} saved</span>
+          <span className="shrink-0 text-sm font-semibold text-arbr-accent-600">{fmt.usd(rec.projectedSavings)} saved</span>
         </div>
       </Card>
     );
@@ -157,15 +157,15 @@ function RecCard({ rec, models, onChange }) {
             <span className="inline-block bg-gray-100 text-arbr-charcoal rounded px-2 py-1 text-xs font-mono">
               {rec.currentModel}
             </span>
-            <span className="text-xs text-arbr-green-600 pl-2 leading-none select-none">↓</span>
-            <span className="inline-block bg-arbr-green-50 text-arbr-green-700 border border-arbr-green-200 rounded px-2 py-1 text-xs font-mono">
+            <span className="text-xs text-arbr-accent-600 pl-2 leading-none select-none">↓</span>
+            <span className="inline-block bg-arbr-accent-50 text-arbr-accent-700 border border-arbr-accent-200 rounded px-2 py-1 text-xs font-mono">
               {rec.suggestedModel}
             </span>
           </div>
         </div>
         <div className="border-l border-gray-100 pl-6 shrink-0 text-right">
           <div className="label mb-1">Projected saving</div>
-          <div className="text-3xl font-bold text-arbr-green-600">{fmt.usd(rec.projectedSavings)}</div>
+          <div className="text-3xl font-bold text-arbr-accent-600">{fmt.usd(rec.projectedSavings)}</div>
           <div className="mt-0.5 text-xs text-gray-500">{fmt.usd(rec.currentCost)} → {fmt.usd(rec.projectedCost)}</div>
           <div className="mt-0.5 text-xs text-gray-400">{fmt.num(rec.requestCount)} requests</div>
         </div>
@@ -214,7 +214,7 @@ function RecCard({ rec, models, onChange }) {
               </button>
             </div>
           )}
-          {notice && <p className="mt-2 text-sm text-arbr-green-700">{notice}</p>}
+          {notice && <p className="mt-2 text-sm text-arbr-accent-700">{notice}</p>}
           {err    && <p className="mt-2 text-sm text-red-600">{err}</p>}
         </div>
         {rec.qualitySummary && (
@@ -289,7 +289,7 @@ function EmptyState({ analysis, busy, onMarkCheap }) {
                 </div>
               </div>
               <div className="flex items-center gap-3 shrink-0">
-                <span className="text-sm font-semibold text-arbr-green-600">~{fmt.usd(o.projectedSavings)}</span>
+                <span className="text-sm font-semibold text-arbr-accent-600">~{fmt.usd(o.projectedSavings)}</span>
                 <button className="btn-outline text-xs" disabled={busy} onClick={() => onMarkCheap([o.taskType])}>
                   Mark cheap
                 </button>

--- a/web/src/pages/Routing.jsx
+++ b/web/src/pages/Routing.jsx
@@ -548,7 +548,7 @@ export default function Routing({ onChange }) {
             </p>
             <div className="space-y-2">
               {MODE_OPTIONS.map(([k, label, desc]) => (
-                <label key={k} className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 ${mode === k ? "border-arbr-green-600 bg-arbr-green-50" : "border-gray-200 hover:border-gray-300"}`}>
+                <label key={k} className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 ${mode === k ? "border-arbr-accent-600 bg-arbr-accent-50" : "border-gray-200 hover:border-gray-300"}`}>
                   <input type="radio" name="routingMode" className="mt-1" checked={mode === k} onChange={() => changeMode(k)} />
                   <div>
                     <div className="text-sm font-medium text-arbr-charcoal">{label}</div>

--- a/web/src/pages/Settings.jsx
+++ b/web/src/pages/Settings.jsx
@@ -136,7 +136,7 @@ function ApiKeys({ onChange }) {
       </p>
 
       {created && (
-        <div className="rounded-lg border border-arbr-green-200 bg-arbr-green-50 p-4">
+        <div className="rounded-lg border border-arbr-accent-200 bg-arbr-accent-50 p-4">
           <div className="text-sm font-medium text-arbr-charcoal">Key created: {created.name}</div>
           <div className="mt-1 text-xs text-gray-600">
             Copy it now — <strong>this is the only time it will be shown.</strong>
@@ -146,7 +146,7 @@ function ApiKeys({ onChange }) {
             <button className="btn-secondary" onClick={copyKey}>{copied ? "Copied" : "Copy"}</button>
             <button className="btn-ghost" onClick={() => setCreated(null)}>Dismiss</button>
           </div>
-          <div className="mt-4 border-t border-arbr-green-200 pt-4">
+          <div className="mt-4 border-t border-arbr-accent-200 pt-4">
             <div className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-2">Share with your developer</div>
             <pre className="rounded bg-white p-3 text-xs leading-relaxed text-gray-700 overflow-x-auto whitespace-pre">{[
               `# .env`,
@@ -302,7 +302,7 @@ export default function Settings({ onChange }) {
             <p className="mb-4 text-sm text-gray-600">
               Used when a request sends <code className="rounded bg-gray-100 px-1">model: "auto"</code> or
               names no model. Configure providers and models in the{" "}
-              <a href="/models" className="text-arbr-green-600 hover:underline">Models</a> page.
+              <a href="/models" className="text-arbr-accent-600 hover:underline">Models</a> page.
             </p>
             <div className="flex flex-wrap items-end gap-4">
               <div>

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,24 +1,28 @@
 /** @type {import('tailwindcss').Config} */
-// Arbr design system — developer-tool aesthetic.
+// Arbr design system — monochrome charcoal-on-paper brand (projectarbr.org).
+// Chrome is charcoal/paper only. `arbr.accent` is the interactive/emphasis ramp
+// (all charcoal tints); color is reserved for semantic status, using Tailwind's
+// stock green/amber/red at call sites. Source letterforms/colors: assets/brand/.
 export default {
   content: ["./index.html", "./src/**/*.{js,jsx}"],
   theme: {
     extend: {
       colors: {
         arbr: {
-          green: {
-            50:  "#f0fdf4",
-            100: "#dcfce7",
-            200: "#bbf7d0",
-            300: "#86efac",
-            400: "#4ade80",
-            500: "#22c55e",
-            600: "#16a34a",
-            700: "#15803d",
-            800: "#166534",
+          charcoal: "#171817",  // brand ink: text, primary buttons, active/interactive states
+          ink:      "#0b0b0b",  // hover / near-black
+          paper:    "#f3f2ed",  // app background (warm off-white)
+          surface:  "#ffffff",  // cards
+          // Interactive + emphasis ramp — monochrome. Formerly the brand green;
+          // now charcoal tints so nav/tabs/toggles/links/bars read as quiet chrome.
+          accent: {
+            50:  "#f4f3f0",  // subtle active/panel fill on white
+            200: "#dddbd4",  // hairline borders
+            500: "#57564f",  // muted
+            600: "#171817",  // charcoal — primary interactive
+            700: "#141413",  // text / links
+            800: "#0b0b0b",  // deep
           },
-          charcoal: "#0f172a",
-          ink:      "#020617",
         },
         gray: {
           50:  "#f9fafb",
@@ -34,7 +38,7 @@ export default {
         },
       },
       fontFamily: {
-        sans: ['Inter', 'system-ui', 'sans-serif'],
+        sans: ['"Space Grotesk"', 'system-ui', 'sans-serif'],
         mono: ['"JetBrains Mono"', '"Fira Code"', 'Consolas', 'monospace'],
       },
       borderRadius: {


### PR DESCRIPTION
Aligns the dashboard with projectarbr.org — a minimal, geometric, charcoal-on-paper identity.

**Changes**
- Tokens: charcoal `#171817`, warm paper `#f3f2ed`, white surface; the brand-green ramp becomes a monochrome `arbr.accent` ramp.
- Type: Inter → Space Grotesk (JetBrains Mono kept for numerals).
- New shared `<Logo/>` inlines the real crossbar-less-"A" wordmark (deduped from Layout + Login); off-token lime-A favicon replaced with the charcoal/off-white mark.
- Interactive accent (nav, tabs, toggles, focus, links, bars) → charcoal.
- Color reserved for status only: green for live/health + good-vs-bad verdicts; amber/red for warn/error.

**Scope**: re-skin only (17 files + Logo.jsx), no layout or logic changes, light-only (no dark mode).

**Verification**: production build clean; grep sweep shows no `arbr-green`/old hexes/Inter left; compiled CSS confirms new tokens resolved and old palette gone; Login + Overview render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)