### PR TITLE
fix(api): /health demoMode reflects effective provider state

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -39,8 +39,16 @@ async function start() {
   }));
   app.use(express.json({ limit: "2mb" }));
 
-  // Liveness.
-  app.get("/health", (_req, res) => res.json({ ok: true, demoMode: config.demoMode }));
+  // Liveness. `demoMode` reflects the EFFECTIVE provider state (env creds +
+  // dashboard-connected creds), matching the console and gateway routing — not
+  // just the boot-time env snapshot. Falls back to the boot flag if the
+  // connection store is momentarily unavailable: liveness must never depend on
+  // the DB being reachable.
+  app.get("/health", async (_req, res) => {
+    let demoMode = config.demoMode;
+    try { demoMode = (await connections.effective()).demoMode; } catch { /* keep boot-time fallback */ }
+    res.json({ ok: true, demoMode });
+  });
 
   // The unified AI gateway — one endpoint for all AI requests.
   // API-key auth (data plane only): validates presented keys, binds attribution,


### PR DESCRIPTION
On arbr.gyde.ai, `/health` reports `demoMode:true` even though 6 providers are connected and the console shows them live.

**Cause:** `/health` returned `config.demoMode` — a **boot-time snapshot of env-var provider keys only** (`config.js:164`). Providers connected via the dashboard are stored in the DB, not env, so the env snapshot stays empty. Meanwhile the console (`/api/status`) and gateway routing use `connections.effective()` (env + DB creds merged), which correctly reports live.

**Fix:** `/health` now reports the effective `demoMode`, matching `/api/status`. Guarded with a fallback to the boot-time flag so liveness never depends on the connection store being reachable.

**Verified locally against Mongo:**
- No providers → `/health` = `{"ok":true,"demoMode":true}`
- After `PUT /api/connections/openai` → `/health` = `{"ok":true,"demoMode":false}` (matches `/api/status`)

Scope: one endpoint, 10 lines. No change to the health-gate contract (`ok:true` on liveness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)