### PR TITLE
ci(security): add gitleaks, npm audit gates, CodeQL, and Trivy image scan

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,29 @@
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "17 6 * * 1" # weekly, catches newly published queries against unchanged code
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (JavaScript/TypeScript)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        with:
+          languages: javascript-typescript
+
+      - uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        with:
+          category: "/language:javascript-typescript"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,62 @@
+name: Security
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0 # scan full history, not just the tip commit
+
+      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  dependency-audit:
+    name: npm audit (prod deps, high+)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: 20
+
+      - name: Audit server
+        run: npm audit --omit=dev --audit-level=high
+
+      - name: Audit web
+        run: npm audit --omit=dev --audit-level=high
+        working-directory: web
+
+      - name: Audit JS SDK
+        # the SDK ships without a lockfile; generate one transiently so audit can resolve the tree
+        run: npm i --package-lock-only --ignore-scripts && npm audit --omit=dev --audit-level=high
+        working-directory: clients/js
+
+  image-scan:
+    name: Image scan (Trivy)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Build image
+        run: docker build -t arbr-control-plane:scan .
+
+      - name: Scan image for HIGH/CRITICAL vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: arbr-control-plane:scan
+          format: table
+          exit-code: "1"
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true # only fail on vulnerabilities that have a fix available

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,9 +17,18 @@ jobs:
         with:
           fetch-depth: 0 # scan full history, not just the tip commit
 
-      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+      # The gitleaks-action wrapper requires a paid license for org repos; the
+      # MIT-licensed CLI does not. Pinned by version + sha256.
+      - name: Run gitleaks (full history)
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_VERSION: 8.30.1
+          GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+        run: |
+          curl -sSfL -o gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf gitleaks.tar.gz gitleaks
+          ./gitleaks git --redact --no-banner --exit-code 1 .
 
   dependency-audit:
     name: npm audit (prod deps, high+)

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,14 @@
+# Gitleaks config — extends the default ruleset with a repo-specific allowlist.
+# Add entries here only for confirmed false positives, and keep them as narrow
+# as possible (exact match strings, not path or rule exclusions).
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Confirmed false positives"
+regexTarget = "match"
+regexes = [
+  # React table column props in the dashboard; entropy-flagged by generic-api-key
+  '''key: "p50LatencyMs"''',
+]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,32 @@
-# Single image: builds the dashboard, then runs the server which serves both the
-# API/gateway and the built dashboard on one port.
-FROM node:20-alpine
+# Multi-stage: build the dashboard with the full toolchain, then run the server
+# from a minimal layer that serves both the API/gateway and the built dashboard
+# on one port. The runtime layer carries only production deps and no npm/yarn
+# (npm's bundled dependencies are a recurring CVE source flagged by image scans).
+FROM node:20-alpine AS webbuild
 
 WORKDIR /app
 
-# Server deps
-COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
-
-# Web deps + build
 COPY web/package.json web/package-lock.json ./web/
 RUN npm --prefix web ci
 COPY web ./web
 RUN npm --prefix web run build
 
-# Server source
+FROM node:20-alpine
+
+# Pick up base-image security fixes (e.g. openssl) without waiting on a new node tag.
+RUN apk --no-cache upgrade
+
+WORKDIR /app
+
+# Server deps, then drop the package managers from the runtime layer.
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev && npm cache clean --force \
+  && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx \
+            /opt/yarn* /usr/local/bin/yarn /usr/local/bin/yarnpkg
+
+# Server source + built dashboard (server resolves web/dist relative to its own tree)
 COPY server ./server
+COPY --from=webbuild /app/web/dist ./web/dist
 
 ENV PORT=4100
 EXPOSE 4100


### PR DESCRIPTION
## Why

A gateway that stores provider credentials shipped with zero security scanning in CI.

## What

- `security.yml`: full-history gitleaks secret scan; `npm audit --omit=dev --audit-level=high` across the three npm roots (the JS SDK generates a transient lockfile since it ships without one); Trivy image scan failing on fixable HIGH/CRITICAL
- `codeql.yml`: javascript-typescript analysis on PR, main, and a weekly schedule
- All actions SHA-pinned, matching the existing convention in `ci.yml`

## Verification

- All three npm audits pass locally today (0 high+ prod vulnerabilities)
- Workflow YAML validated; the PR itself will exercise gitleaks, audit, Trivy, and CodeQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)