### PR TITLE
fix(api): repair two regressions from the routes-split landing (merge before deploy)

### DIFF
--- a/server/src/api/routes/keys.js
+++ b/server/src/api/routes/keys.js
@@ -12,6 +12,7 @@ function keyView(d) {
   return {
     _id: d._id, name: d.name, application: d.application, prefix: d.prefix,
     enabled: d.enabled, rpm: d.rpm, createdAt: d.createdAt, lastUsedAt: d.lastUsedAt,
+    userId: d.userId || null, department: d.department || null,
     allowedModels: d.allowedModels || [], defaultModel: d.defaultModel || null,
   };
 }
@@ -25,7 +26,7 @@ router.get("/keys", async (_req, res, next) => {
 
 router.post("/keys", async (req, res, next) => {
   try {
-    const { name, application, rpm, allowedModels, defaultModel } = req.body || {};
+    const { name, application, rpm, allowedModels, defaultModel, userId, department } = req.body || {};
     if (!name || !String(name).trim()) return res.status(400).json({ error: "name is required" });
     if (!application || !String(application).trim()) return res.status(400).json({ error: "application is required" });
     const secret = "ab_" + crypto.randomBytes(16).toString("hex");
@@ -35,11 +36,13 @@ router.post("/keys", async (req, res, next) => {
       keyHash: auth.hashKey(secret),
       prefix: `ab_…${secret.slice(-4)}`,
       rpm: Number(rpm) > 0 ? Number(rpm) : null,
+      userId: userId ? String(userId).trim() || null : null,
+      department: department ? String(department).trim() || null : null,
       allowedModels: Array.isArray(allowedModels) ? allowedModels.filter(Boolean) : [],
       defaultModel: defaultModel ? String(defaultModel).trim() || null : null,
     });
     auth.invalidate();
-    setImmediate(() => logAction("key.create", "key", doc._id, { name: doc.name, application: doc.application }));
+    setImmediate(() => logAction("key.create", "key", doc._id, { name: doc.name, application: doc.application, userId: doc.userId }));
     // The ONLY time the full secret is ever returned.
     res.json({ ...keyView(doc.toObject()), key: secret });
   } catch (e) { next(e); }
@@ -54,6 +57,8 @@ router.patch("/keys/:id", async (req, res, next) => {
     if (req.body.rpm === null || Number(req.body.rpm) > 0) update.rpm = req.body.rpm === null ? null : Number(req.body.rpm);
     if (Array.isArray(req.body.allowedModels)) update.allowedModels = req.body.allowedModels.filter(Boolean);
     if ("defaultModel" in req.body) update.defaultModel = req.body.defaultModel ? String(req.body.defaultModel).trim() || null : null;
+    if ("userId" in req.body) update.userId = req.body.userId ? String(req.body.userId).trim() || null : null;
+    if ("department" in req.body) update.department = req.body.department ? String(req.body.department).trim() || null : null;
     const doc = await ApiKey.findByIdAndUpdate(req.params.id, update, { new: true }).lean();
     auth.invalidate();
     res.json(doc ? keyView(doc) : { error: "not found" });

--- a/server/src/gateway/auth.js
+++ b/server/src/gateway/auth.js
@@ -71,7 +71,7 @@ async function resolveKey(authHeader) {
     err.statusCode = 401;
     throw err;
   }
-  if (overRpmLimit(doc.keyHash, doc.rpm)) {
+  if (await overRpmLimit(`key:${doc.keyHash}`, doc.rpm)) {
     const err = new Error(`API key "${doc.name}" is over its ${doc.rpm} requests/minute limit.`);
     err.statusCode = 429;
     throw err;

--- a/server/test/integration/keysAttribution.test.js
+++ b/server/test/integration/keysAttribution.test.js
@@ -1,0 +1,52 @@
+"use strict";
+// Regression coverage for two breakages introduced by the routes-split landing:
+// 1. userId/department attribution dropped from the key routes (PR #131 content).
+// 2. resolveKey (WS auth path) called async overRpmLimit without await — the
+//    pending Promise is always truthy, so every keyed WS request threw 429.
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+const mongoose = require("mongoose");
+const express = require("express");
+const supertest = require("supertest");
+
+process.env.ARBR_ADMIN_KEY = "";
+
+const ApiKey = require("../../src/models/ApiKey");
+const auth = require("../../src/gateway/auth");
+const apiRoutes = require("../../src/api/routes");
+
+let mongod, agent;
+const buildApp = () => { const a = express(); a.use(express.json()); a.use("/api", apiRoutes); return a; };
+
+before(async () => { mongod = await MongoMemoryServer.create(); await mongoose.connect(mongod.getUri()); agent = supertest(buildApp()); });
+after(async () => { await mongoose.disconnect(); await mongod.stop(); });
+beforeEach(async () => { await ApiKey.deleteMany({}); auth.invalidate(); });
+
+test("create accepts and returns userId/department; list keeps them", async () => {
+  const res = await agent.post("/api/keys").send({ name: "k", application: "app-a", userId: "u-42", department: "support" });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.userId, "u-42");
+  assert.equal(res.body.department, "support");
+  const list = await agent.get("/api/keys");
+  assert.equal(list.body[0].userId, "u-42");
+  assert.equal(list.body[0].department, "support");
+});
+
+test("PATCH can set and clear userId/department", async () => {
+  const res = await agent.post("/api/keys").send({ name: "k", application: "app-a" });
+  const set = await agent.patch(`/api/keys/${res.body._id}`).send({ userId: "u-9", department: "eng" });
+  assert.equal(set.body.userId, "u-9");
+  assert.equal(set.body.department, "eng");
+  const clear = await agent.patch(`/api/keys/${res.body._id}`).send({ userId: null, department: null });
+  assert.equal(clear.body.userId, null);
+  assert.equal(clear.body.department, null);
+});
+
+test("resolveKey passes a valid key instead of always throwing 429", async () => {
+  const res = await agent.post("/api/keys").send({ name: "ws", application: "app-a" });
+  auth.invalidate();
+  const doc = await auth.resolveKey(`Bearer ${res.body.key}`);
+  assert.equal(doc.name, "ws");
+  assert.equal(doc.application, "app-a");
+});


### PR DESCRIPTION
## Why

While re-landing the p1 branches I audited the routes split (#149) against the pre-split monolith and found two regressions now live on main. **Recommend merging this before the next deploy.**

## What

1. **Key attribution dropped (PR #131 content).** The split was authored from a pre-#131 `routes.js`, so `userId`/`department` vanished from `keyView` and the create/patch key routes while the model fields remained. The dashboard silently loses per-user attribution on new keys.
2. **Every keyed WebSocket request 429s.** `resolveKey` (WS auth for `/v1/realtime`, #137) calls the now-async `overRpmLimit` without `await`; the pending Promise is always truthy. Awaited, and switched to the same `key:`-prefixed bucket as the HTTP middleware.

A route-inventory audit of all 113 pre-split endpoints found nothing else missing.

## Verification

- New `keysAttribution.test.js`: attribution create/patch/list + a resolveKey regression test, verified to fail against unfixed main and pass with the fix.
- Full server suite green (170/170).

🤖 Generated with [Claude Code](https://claude.com/claude-code)