### PR TITLE
fix(deploy): make production profile fail closed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,8 +49,9 @@ MONGO_URI=mongodb://localhost:27017/arbr-control-plane
 # ARBR_ENCRYPTION_KEY=
 
 # --- Production ---
-# NODE_ENV=production forces fail-closed boot (admin + encryption keys required)
-# and turns on Settings.requireApiKey so anonymous /v1 calls are rejected.
+# docker-compose.prod.yml sets NODE_ENV=production automatically. If running the
+# server without that Compose profile, set it yourself to force fail-closed boot
+# (admin + encryption keys required) and reject anonymous /v1 calls.
 # NODE_ENV=production
 
 # --- Fallback scope (provider errors) ---

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Build dashboard
         run: npm run web:build
 
+      - name: Validate production Compose profile
+        run: npm run test:compose:prod
+
       - name: JS SDK unit tests
         run: npm --prefix clients/js test
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -41,7 +41,7 @@ node -e "console.log('admin:', require('crypto').randomBytes(32).toString('hex')
 
 ## Single-VM deployment (recommended)
 
-One small VM (EC2 t3.small class), Docker Compose, nginx or an ALB in front.
+One small VM (EC2 t3.small class), Docker Compose 2.24.4 or newer, nginx or an ALB in front.
 
 ```sh
 git clone <repo> && cd control-plane
@@ -51,12 +51,14 @@ cp .env.example .env
 #   ARBR_ENCRYPTION_KEY=...     (required — encrypts dashboard-stored provider keys)
 #   SEED_ON_BOOT=false           (REQUIRED — seeding wipes request records; demo only)
 #   provider keys as needed
-docker compose up -d
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 curl -s localhost:4100/health    # → {"ok":true,...}
 ```
 
-After boot: sign in with the admin key → Settings → API keys → create a key per application →
-flip **Require API keys** on. From then on the data plane rejects anonymous calls.
+The production profile sets `NODE_ENV=production`, disables demo seeding, binds port 4100
+to loopback, and refuses to start unless both required keys are set. It also forces gateway
+API-key authentication on. After boot: sign in with the admin key → Settings → API keys →
+create a key per application.
 
 ### Option A — nginx on the same VM (TLS via certbot)
 
@@ -116,7 +118,8 @@ need the public hostname.
 - [ ] `ARBR_ADMIN_KEY` set (dashboard/admin API locked)
 - [ ] `ARBR_ENCRYPTION_KEY` set (dashboard-stored provider keys encrypted with your secret)
 - [ ] `SEED_ON_BOOT=false` (seeding **wipes request records** — demo only)
-- [ ] Gateway API keys issued per application; **Require API keys** flipped ON (Settings → API keys)
+- [ ] Started with `docker-compose.prod.yml` (fail-closed mode; gateway keys forced on)
+- [ ] Gateway API keys issued per application
 - [ ] TLS at the proxy (Option A/B); 4100 not directly internet-reachable
 - [ ] MongoDB not publicly bound (compose default is fine — no host port); backups scheduled
   (`mongodump` cron or a managed Mongo/Atlas)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,6 +3,9 @@
 #   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 #
 # Changes from the base:
+#   - NODE_ENV forced to production, activating fail-closed startup checks and
+#     requiring gateway API keys. The app refuses to start without both
+#     ARBR_ADMIN_KEY and ARBR_ENCRYPTION_KEY.
 #   - Port bound to loopback (127.0.0.1) so 4100 is only reachable from a
 #     same-host reverse proxy (nginx/Caddy). Never directly internet-reachable.
 #   - SEED_ON_BOOT forced to false (seeding WIPES request records).
@@ -12,7 +15,10 @@
 #   ARBR_ENCRYPTION_KEY=<random 32-byte hex> — encrypts stored provider keys
 services:
   app:
-    ports:
+    # Compose normally appends ports from override files. !override is required
+    # to remove the base profile's public 0.0.0.0:4100 binding.
+    ports: !override
       - "127.0.0.1:4100:4100"
     environment:
+      NODE_ENV: production
       SEED_ON_BOOT: "false"

--- a/docs/deployment-gcp.md
+++ b/docs/deployment-gcp.md
@@ -27,7 +27,7 @@ gcloud compute ssh YOUR_INSTANCE_NAME --zone YOUR_ZONE
 curl -fsSL https://get.docker.com | sh
 sudo usermod -aG docker $USER
 newgrp docker
-docker compose version   # should show v2.x
+docker compose version   # must be v2.24.4 or newer
 ```
 
 ## Step 4 — Install nginx + certbot
@@ -45,7 +45,7 @@ cp .env.example .env
 nano .env
 ```
 
-Set these four values — everything else has safe defaults:
+Set these values before starting the production profile:
 
 ```sh
 # Generate each key by running this command twice (use a different value for each):
@@ -71,6 +71,8 @@ curl http://localhost:4100/health   # → {"ok":true,"demoMode":false}
 ```
 
 `docker-compose.prod.yml` binds port 4100 to loopback (`127.0.0.1`) so it is never directly internet-reachable.
+It also sets `NODE_ENV=production`, which makes ARBR refuse to start without the admin and
+encryption keys and forces gateway API-key authentication on.
 
 ## Step 7 — Configure nginx
 
@@ -181,6 +183,7 @@ intact) → posts a success/rollback note to the governance webhook.
 - [ ] Port 4100 not in any public GCP firewall rule
 - [ ] TLS certificate issued by certbot
 - [ ] At least one provider key configured
-- [ ] Gateway API keys created per app; **Require API Keys** toggled ON
+- [ ] Started with `docker-compose.prod.yml` (fail-closed mode; gateway keys forced on)
+- [ ] Gateway API keys created per app
 - [ ] MongoDB volume is on a persistent disk (default in Docker Compose)
 - [ ] `docker compose logs` checked for any boot errors

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,6 @@
 # Deployment
 
-One standalone instance per organisation — the same model as a LiteLLM proxy or shared MLflow tracking server. A single VM with Docker Compose; TLS terminated by nginx or an ALB.
+One standalone instance per organisation — the same model as a LiteLLM proxy or shared MLflow tracking server. A single VM with Docker Compose 2.24.4 or newer; TLS terminated by nginx or an ALB.
 
 ## Architecture
 
@@ -40,7 +40,7 @@ cp .env.example .env
 #   ARBR_ENCRYPTION_KEY=<generate>
 #   SEED_ON_BOOT=false          ← REQUIRED in production
 #   OPENAI_API_KEY=sk-...       ← at least one provider key
-docker compose up -d
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 curl -s localhost:4100/health   # → {"ok":true}
 ```
 
@@ -49,7 +49,10 @@ Generate strong keys:
 node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 ```
 
-After boot: sign in → Settings → API keys → create a key per app → flip **Require API keys** on.
+The production profile activates fail-closed startup checks, disables demo seeding, binds
+port 4100 to loopback, and forces gateway API-key authentication on. If either required key
+is missing, ARBR refuses to start. After boot: sign in → Settings → API keys → create a key
+per app.
 
 ## nginx (TLS via certbot)
 
@@ -101,7 +104,8 @@ Point apps at the **internal** address (`http://10.x.x.x:4100`) — gateway traf
 - [ ] `ARBR_ADMIN_KEY` set (dashboard/admin API locked)
 - [ ] `ARBR_ENCRYPTION_KEY` set (dashboard-stored provider keys encrypted)
 - [ ] `SEED_ON_BOOT=false` (seeding **wipes request records** — demo only)
-- [ ] Gateway API keys issued per application; **Require API keys** flipped ON
+- [ ] Started with `docker-compose.prod.yml` (fail-closed mode; gateway keys forced on)
+- [ ] Gateway API keys issued per application
 - [ ] TLS at the proxy; port 4100 not internet-reachable directly
 - [ ] MongoDB not publicly bound; backups scheduled (`mongodump` cron or Atlas)
 - [ ] Provider keys via environment / secret manager (env takes precedence over dashboard-stored)

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:server:unit": "node --test server/test/unit/*.test.js",
     "test:server:integration": "node --test server/test/integration/*.test.js",
     "test:server": "node --test server/test/unit/*.test.js server/test/integration/*.test.js",
+    "test:compose:prod": "node server/scripts/production-compose-smoke.js",
     "bench:latency": "node server/scripts/latency-bench.js",
     "bench:latency:stream": "node server/scripts/latency-bench.js --stream"
   },

--- a/server/scripts/production-compose-smoke.js
+++ b/server/scripts/production-compose-smoke.js
@@ -1,0 +1,25 @@
+// Validate the fully merged self-hosted production Compose profile. This catches
+// security regressions that are invisible when reviewing an override file alone
+// (notably Compose appending rather than replacing the base profile's ports).
+const assert = require("assert").strict;
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "../..");
+
+const output = execFileSync(
+  "docker",
+  ["compose", "-f", "docker-compose.yml", "-f", "docker-compose.prod.yml", "config", "--format", "json"],
+  { cwd: repoRoot, encoding: "utf8" }
+);
+const app = JSON.parse(output).services.app;
+
+assert.equal(app.environment.NODE_ENV, "production", "production profile must set NODE_ENV=production");
+assert.equal(app.environment.SEED_ON_BOOT, "false", "production profile must disable demo seeding");
+assert.deepEqual(
+  app.ports.map(({ host_ip: hostIp, published, target }) => ({ hostIp, published, target })),
+  [{ hostIp: "127.0.0.1", published: "4100", target: 4100 }],
+  "production profile must expose port 4100 on loopback only"
+);
+
+console.log("Production Compose profile is fail-closed and loopback-only.");


### PR DESCRIPTION
## Summary
- force `NODE_ENV=production` and disable demo seeding in the public production Compose profile
- replace the base public port mapping so production binds only to `127.0.0.1:4100`
- add a CI smoke test for the fully merged Compose configuration
- update cloud-neutral and GCP self-hosting docs to use the secure production profile

## Verification
- production Compose smoke test passes
- merged Compose config contains production mode, seeding disabled, and one loopback-only port
- production container build succeeds
- container refuses to start without `ARBR_ADMIN_KEY` and `ARBR_ENCRYPTION_KEY`
- 162 server unit tests pass
- dashboard production build succeeds
- new smoke-test script passes ESLint

Integration tests were attempted locally but the sandbox blocks MongoMemoryServer from binding a port; GitHub CI will run the full integration suite.