### PR TITLE
fix(privacy): re-land metadata-only production logging (#160)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -125,6 +125,8 @@ need the public hostname.
   (`mongodump` cron or a managed Mongo/Atlas)
 - [ ] Provider keys via environment/secret manager (env takes precedence over dashboard-stored)
 - [ ] Budgets configured with **Block/Downgrade** actions for cost protection
+- [ ] Payload capture remains off unless partner consent and retention requirements are documented
+- [ ] MongoDB volume/disk and backups are encrypted; backup retention matches the agreed policy
 
 ## Operational notes & limits
 

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -75,6 +75,7 @@ export default defineConfig({
         items: [
           { text: 'API reference', link: '/api-reference' },
           { text: 'Configuration', link: '/configuration' },
+          { text: 'Data privacy & retention', link: '/privacy' },
           { text: 'Deployment', link: '/deployment' },
           { text: 'Deploy on GCP', link: '/deployment-gcp' },
         ]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,3 +71,6 @@ These are **not** environment variables — they're managed in the dashboard and
 - Gateway API keys
 - Routing rules
 - AI routing policy
+
+Production instances start with payload capture disabled, PII masking enabled, and 30-day
+retention. See [Data privacy and retention](./privacy.md) before enabling prompt/response capture.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,37 @@
+# Data privacy and retention
+
+ARBR records cost, latency, model, routing, application, and token metadata for every gateway
+request. In production, prompt and response payload capture is **off by default**, PII masking
+is on, and request retention defaults to 30 days. Local demo/development mode keeps the
+historical demo-friendly defaults.
+
+## Opting in to payload capture
+
+Enable **Governance → Privacy & Content → Store request & response payloads** only after your
+data owner confirms that prompts and model outputs may be retained. The dashboard requires an
+explicit confirmation and shows a persistent warning while capture is enabled. PII masking is
+pattern-based and reduces risk; it is not a guarantee that all sensitive data will be detected.
+
+Metadata-only mode applies to native chat, OpenAI-compatible chat (including streaming),
+embeddings, request-derived evaluation datasets, replay results, and shadow-evaluation pairs.
+Costs, token counts, latency, attribution, routing decisions, and evaluation verdicts remain
+available without storing prompt or response text.
+
+## Retention, deletion, and export
+
+Configure retention under **Governance → Observability → Log Retention**. ARBR purges request
+records and text-bearing evaluation items/results/datasets older than the configured window at
+startup and every 24 hours. Reducing the window is therefore not an immediate synchronous
+deletion; restart ARBR to run the purge immediately, or wait for the next scheduled run.
+
+The Requests CSV export contains operational metadata and does not export prompt or response
+payloads. Deleting a benchmark through the API/dashboard also deletes its items, runs, and
+results. ARBR does not delete copies already present in external backups or exports.
+
+## Storage responsibilities
+
+`ARBR_ENCRYPTION_KEY` encrypts provider credentials stored through the dashboard. It does **not**
+encrypt MongoDB request records or Docker volumes. The operator is responsible for disk/volume
+encryption, MongoDB access controls, backup encryption, backup retention, restore testing, and
+secure deletion of expired backups. On cloud VMs, use encrypted persistent disks and restrict
+MongoDB to the private Compose network or an authenticated managed service.

--- a/server/src/api/routes/evalBenchmarks.js
+++ b/server/src/api/routes/evalBenchmarks.js
@@ -138,7 +138,15 @@ router.post("/eval-benchmarks/:id/items", async (req, res, next) => {
     if (await EvalItem.findOne({ datasetId: bench._id, requestId })) return res.status(409).json({ error: "already_in_benchmark", message: "That request is already a case in this benchmark." });
 
     const settings = await Settings.get().catch(() => ({}));
-    const { messages, productionResponse } = evalDatasetBuilder.projectText(rec, bench.piiMode, !!settings.piiMaskingEnabled, settings.customPiiPatterns || []);
+    if (settings.captureRequestPayloads === false) {
+      return res.status(409).json({
+        error: "payload_capture_disabled",
+        message: "Enable payload capture before copying request content into an evaluation benchmark.",
+      });
+    }
+    const { messages, productionResponse } = evalDatasetBuilder.projectText(
+      rec, bench.piiMode, !!settings.piiMaskingEnabled, settings.customPiiPatterns || [], true
+    );
     const sev = ["trivial", "normal", "critical"].includes(severity) ? severity : "normal";
     const item = await EvalItem.create({
       datasetId: bench._id, requestId: rec.requestId, application: rec.application || null,

--- a/server/src/api/routes/governance.js
+++ b/server/src/api/routes/governance.js
@@ -2,21 +2,23 @@
 const express = require("express");
 const { logAction } = require("../auditLogger");
 const Settings = require("../../models/Settings");
+const { config } = require("../../config");
 
 const router = express.Router();
 
 // ── Governance settings (maintenance mode, max-tokens, webhook, retention, PII) ──
 function governanceView(s) {
+  const defaults = Settings.privacyDefaults(config.isProduction);
   return {
     maintenanceMode:         s.maintenanceMode || { enabled: false, message: "" },
     maxTokensGuardrail:      s.maxTokensGuardrail || null,
     globalRpmGuardrail:      s.globalRpmGuardrail || null,
-    captureRequestPayloads:  s.captureRequestPayloads !== false,  // default true
-    piiMaskingEnabled:       s.piiMaskingEnabled ?? false,
+    captureRequestPayloads:  s.captureRequestPayloads ?? defaults.captureRequestPayloads,
+    piiMaskingEnabled:       s.piiMaskingEnabled ?? defaults.piiMaskingEnabled,
     customPiiPatterns:       s.customPiiPatterns || [],
     requireApiKey:           s.requireApiKey ?? false,
     webhookUrl:              s.webhookUrl || null,
-    retentionDays:           s.retentionDays ?? 90,
+    retentionDays:           s.retentionDays ?? defaults.retentionDays,
     alertErrorRateEnabled:   s.alertErrorRateEnabled ?? false,
     alertErrorRateThreshold: s.alertErrorRateThreshold ?? 5,
     outputGuardrailsEnabled: s.outputGuardrailsEnabled ?? false,

--- a/server/src/eval/dataset.js
+++ b/server/src/eval/dataset.js
@@ -96,8 +96,8 @@ function inferValidators(responses) {
 }
 
 // Store the item text according to piiMode + global masking. Returns { messages, productionResponse }.
-function projectText(record, piiMode, maskEnabled, customPatterns) {
-  if (piiMode === "metadata_only") return { messages: null, productionResponse: null };
+function projectText(record, piiMode, maskEnabled, customPatterns, captureEnabled = true) {
+  if (!captureEnabled || piiMode === "metadata_only") return { messages: null, productionResponse: null };
   const raw = piiMode === "raw_allowed" && !maskEnabled;
   const msgs = Array.isArray(record.messages)
     ? record.messages
@@ -114,9 +114,12 @@ async function createFromTraffic({ rec, targetCount, piiMode = "masked", windowD
   const target = targetCount || targetCountForRisk(risk);
   const settings = await Settings.get().catch(() => ({}));
   const maskEnabled = !!settings.piiMaskingEnabled;
+  const captureEnabled = settings.captureRequestPayloads !== false;
   const customPatterns = settings.customPiiPatterns || [];
   // Global masking wins: never store raw when masking is on.
-  const effectivePiiMode = piiMode === "raw_allowed" && maskEnabled ? "masked" : piiMode;
+  const effectivePiiMode = !captureEnabled
+    ? "metadata_only"
+    : (piiMode === "raw_allowed" && maskEnabled ? "masked" : piiMode);
 
   const since = new Date(Date.now() - windowDays * 86400000);
   const dataset = await EvalDataset.create({
@@ -137,6 +140,13 @@ async function createFromTraffic({ rec, targetCount, piiMode = "masked", windowD
     status: "creating",
     createdBy,
   });
+
+  if (!captureEnabled) {
+    dataset.status = "failed";
+    dataset.error = "Payload capture is disabled. Enable it explicitly before creating replay datasets from traffic.";
+    await dataset.save();
+    return dataset;
+  }
 
   try {
     const raw = await RequestRecord.find(buildScopeQuery(rec, since))
@@ -164,7 +174,7 @@ async function createFromTraffic({ rec, targetCount, piiMode = "masked", windowD
     // Attach validators inferred from the baseline outputs, so formatPassRate is a real gate.
     const validators = inferValidators(sampled.map((r) => r.responseText));
     const items = sampled.map((r) => {
-      const { messages, productionResponse } = projectText(r, effectivePiiMode, maskEnabled, customPatterns);
+      const { messages, productionResponse } = projectText(r, effectivePiiMode, maskEnabled, customPatterns, captureEnabled);
       return {
         datasetId: dataset._id, requestId: r.requestId, application: r.application || null,
         workflow: r.workflow || null, taskType: r.taskType || null, currentModel: r.model || null,

--- a/server/src/eval/replay.js
+++ b/server/src/eval/replay.js
@@ -150,6 +150,7 @@ async function executeRun(runId) {
 
   const settings = await require("../models/Settings").get().catch(() => ({}));
   const maskEnabled = !!settings.piiMaskingEnabled;
+  const captureEnabled = settings.captureRequestPayloads !== false;
   const customPatterns = settings.customPiiPatterns || [];
   const cm = pricing.getModel(run.candidateModel);
   if (!cm || !eff.liveIds.includes(cm.provider)) {
@@ -201,7 +202,15 @@ async function executeRun(runId) {
         if (dp.overturned) { finalVerdict = "equal"; disproved = true; disproveReason = dp.reason; }
       }
 
-      const storedResp = clampText(maskEnabled ? maskPii(candidate.text || "", customPatterns) : (candidate.text || ""));
+      const storedResp = captureEnabled
+        ? clampText(maskEnabled ? maskPii(candidate.text || "", customPatterns) : (candidate.text || ""))
+        : null;
+      const rawRationale = disproved
+        ? `[disprove pass overturned "worse"] ${disproveReason || ""}`.trim()
+        : (scored ? scored.judgeRationale : judgeError);
+      const storedRationale = captureEnabled && rawRationale
+        ? clampText(maskEnabled ? maskPii(rawRationale, customPatterns) : rawRationale)
+        : null;
       await EvalResult.create({
         evalRunId: run._id, evalItemId: item._id, requestId: item.requestId,
         baselineModel: dataset.baselineModel, candidateModel: run.candidateModel,
@@ -213,7 +222,7 @@ async function executeRun(runId) {
         criticalFailure: scored ? !!scored.criticalFailure : false,
         validatorResults: results, formatPass,
         abFlipped: scored ? !!scored.abFlipped : false,
-        judgeRationale: disproved ? `[disprove pass overturned "worse"] ${disproveReason || ""}`.trim() : (scored ? scored.judgeRationale : judgeError),
+        judgeRationale: storedRationale,
       });
       entries.push({
         verdict: finalVerdict,

--- a/server/src/eval/shadow.js
+++ b/server/src/eval/shadow.js
@@ -10,6 +10,20 @@ const { maskMessages, maskPii, clampText } = require("../logging/piiFilter");
 const { judge } = require("./judge");
 const { isSingleShot, shouldSample, withinWindow, campaignMatches } = require("./logic");
 
+function shadowPayload({ messages, prodText, candidateText }, settings) {
+  if (settings?.captureRequestPayloads === false) {
+    return { messages: null, prodResponse: null, candidateResponse: null };
+  }
+  const mask = !!settings?.piiMaskingEnabled;
+  const patterns = settings?.customPiiPatterns || [];
+  const msgArr = Array.isArray(messages) ? messages : [{ role: "user", content: String(messages ?? "") }];
+  return {
+    messages: mask ? maskMessages(msgArr, patterns) : msgArr,
+    prodResponse: clampText(mask ? maskPii(prodText || "", patterns) : (prodText || "")),
+    candidateResponse: clampText(mask ? maskPii(candidateText || "", patterns) : (candidateText || "")),
+  };
+}
+
 // Short-lived active-campaign cache per application (mirrors getAppConfig in handler.js).
 const _campaignCache = new Map(); // application -> { campaign, expiresAt }
 async function getActiveCampaign(application) {
@@ -98,27 +112,31 @@ async function maybeShadowEval({ application, workflow, taskType, messages, hasT
     if (!candidate) { await recordCandidateError(campaign); return; }
 
     const s = await Settings.get().catch(() => null);
-    const mask = !!s?.piiMaskingEnabled;
-    const msgArr = Array.isArray(messages) ? messages : [{ role: "user", content: String(messages ?? "") }];
+    const stored = shadowPayload({ messages, prodText: prod.text, candidateText: candidate.text }, s);
     const pair = new EvalPair({
       campaignId: campaign._id, requestId, application, taskType, timestamp: new Date(),
       prodModel: prod.model, prodProvider: prod.provider, prodCost: costOf(prod.model, prod.usage),
-      prodLatencyMs: prod.latencyMs, prodResponse: clampText(mask ? maskPii(prod.text || "") : (prod.text || "")),
+      prodLatencyMs: prod.latencyMs, prodResponse: stored.prodResponse,
       candidateModel: campaign.candidateModel, candidateProvider: cm.provider,
       candidateCost: costOf(campaign.candidateModel, candidate.usage), candidateLatencyMs: candidate.latencyMs,
-      candidateResponse: clampText(mask ? maskPii(candidate.text || "") : (candidate.text || "")),
+      candidateResponse: stored.candidateResponse,
       judgeModel: campaign.judgeModel || null,
-      messages: mask ? maskMessages(msgArr) : msgArr,
+      messages: stored.messages,
     });
 
     const v = await judge({
       router, eff, judgeModel: campaign.judgeModel, messages, prodText: prod.text, candidateText: candidate.text,
     });
-    if (v) { pair.verdict = v.verdict; pair.rationale = v.rationale; }
+    if (v) {
+      pair.verdict = v.verdict;
+      pair.rationale = s?.captureRequestPayloads === false
+        ? null
+        : clampText(s?.piiMaskingEnabled ? maskPii(v.rationale || "", s.customPiiPatterns || []) : v.rationale);
+    }
     await pair.save();
 
     if (pair.verdict) await checkThresholdAndNotify(campaign);
   } catch { /* never affect the served request */ }
 }
 
-module.exports = { maybeShadowEval, getActiveCampaign, invalidateCampaignCache, isSingleShot };
+module.exports = { maybeShadowEval, getActiveCampaign, invalidateCampaignCache, isSingleShot, shadowPayload };

--- a/server/src/logging/logger.js
+++ b/server/src/logging/logger.js
@@ -6,6 +6,20 @@ const { maskMessages, maskPii, clampText } = require("./piiFilter");
 const Settings = require("../models/Settings");
 const capEngine = require("../routing/capEngine");
 
+function payloadFields(record, settings) {
+  if (settings?.captureRequestPayloads === false) {
+    return { messages: undefined, responseText: null };
+  }
+  let messages = record.messages;
+  let responseText = typeof record.responseText === "string" ? record.responseText : null;
+  if ((messages || responseText) && settings?.piiMaskingEnabled) {
+    if (messages) messages = maskMessages(messages, settings.customPiiPatterns);
+    if (responseText) responseText = maskPii(responseText, settings.customPiiPatterns);
+  }
+  if (responseText) responseText = clampText(responseText);
+  return { messages, responseText };
+}
+
 // record: {
 //   requestId, timestamp, application, workflow, userId, department,
 //   provider, model, modelRequested, taskType,
@@ -35,18 +49,7 @@ async function write(record) {
     // PII-mask when enabled, then size-cap. Only the logged copy is masked — the model
     // already received the original text. Settings are read lazily (singleton pattern).
     const s = await Settings.get().catch(() => null);
-    let messages = record.messages;
-    let responseText = typeof record.responseText === "string" ? record.responseText : null;
-    if (s?.captureRequestPayloads === false) {
-      messages = undefined;
-      responseText = null;
-    } else if (messages || responseText) {
-      if (s?.piiMaskingEnabled) {
-        if (messages) messages = maskMessages(messages, s.customPiiPatterns);
-        if (responseText) responseText = maskPii(responseText, s.customPiiPatterns);
-      }
-    }
-    if (responseText) responseText = clampText(responseText);
+    const { messages, responseText } = payloadFields(record, s);
 
     await RequestRecord.create({
       ...record,
@@ -79,4 +82,4 @@ async function write(record) {
   }
 }
 
-module.exports = { write };
+module.exports = { write, payloadFields };

--- a/server/src/models/Settings.js
+++ b/server/src/models/Settings.js
@@ -4,6 +4,14 @@
 const mongoose = require("mongoose");
 const { config } = require("../config");
 
+function privacyDefaults(isProduction = config.isProduction) {
+  return isProduction
+    ? { retentionDays: 30, piiMaskingEnabled: true, captureRequestPayloads: false }
+    : { retentionDays: 90, piiMaskingEnabled: false, captureRequestPayloads: true };
+}
+
+const PRIVACY_DEFAULTS = privacyDefaults();
+
 const settingsSchema = new mongoose.Schema(
   {
     key: { type: String, default: "global", unique: true },
@@ -54,16 +62,16 @@ const settingsSchema = new mongoose.Schema(
     // Webhook URL for real-time alerts (cap breach, provider errors, new unknown applications).
     webhookUrl: { type: String, default: null },
     // Request record retention in days. Records older than this are auto-purged daily.
-    retentionDays: { type: Number, default: 90 },
+    retentionDays: { type: Number, default: PRIVACY_DEFAULTS.retentionDays },
     // PII masking: when enabled, PII patterns are redacted from prompts before logging.
-    piiMaskingEnabled: { type: Boolean, default: false },
+    piiMaskingEnabled: { type: Boolean, default: PRIVACY_DEFAULTS.piiMaskingEnabled },
     // Custom PII patterns (admin-defined regex strings applied in addition to built-ins).
     customPiiPatterns: { type: [{ name: String, pattern: String }], default: [] },
     // Global gateway rate limit. When set, all requests across all API keys share this RPM ceiling.
     globalRpmGuardrail: { type: Number, default: null },
     // When false, messages and responseText are NOT stored in RequestRecord. Costs, latency, and
     // routing metadata are always logged regardless.
-    captureRequestPayloads: { type: Boolean, default: true },
+    captureRequestPayloads: { type: Boolean, default: PRIVACY_DEFAULTS.captureRequestPayloads },
     // Error-rate alerting: fires the webhook when the rolling 1-hour error rate exceeds threshold.
     alertErrorRateEnabled:   { type: Boolean, default: false },
     alertErrorRateThreshold: { type: Number,  default: 5 },  // percent, 0–100
@@ -118,3 +126,4 @@ settingsSchema.statics.invalidateCache = function invalidateCache() {
 };
 
 module.exports = mongoose.model("Settings", settingsSchema);
+module.exports.privacyDefaults = privacyDefaults;

--- a/server/test/unit/evalDataset.test.js
+++ b/server/test/unit/evalDataset.test.js
@@ -82,4 +82,8 @@ test("projectText honors metadata_only (no text) and masked modes", () => {
   const masked = projectText(rec, "masked", false, []);
   assert.ok(masked.messages); // present
   assert.ok(!JSON.stringify(masked.messages).includes("a@b.com")); // email masked
+
+  const globallyDisabled = projectText(rec, "raw_allowed", false, [], false);
+  assert.equal(globallyDisabled.messages, null);
+  assert.equal(globallyDisabled.productionResponse, null);
 });

--- a/server/test/unit/payloadPrivacy.test.js
+++ b/server/test/unit/payloadPrivacy.test.js
@@ -1,0 +1,72 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const Settings = require("../../src/models/Settings");
+const { payloadFields } = require("../../src/logging/logger");
+const { projectText } = require("../../src/eval/dataset");
+const { shadowPayload } = require("../../src/eval/shadow");
+
+test("production privacy defaults are metadata-only, masked, and 30 days", () => {
+  assert.deepEqual(Settings.privacyDefaults(true), {
+    retentionDays: 30,
+    piiMaskingEnabled: true,
+    captureRequestPayloads: false,
+  });
+  assert.deepEqual(Settings.privacyDefaults(false), {
+    retentionDays: 90,
+    piiMaskingEnabled: false,
+    captureRequestPayloads: true,
+  });
+});
+
+test("metadata-only logging strips payloads from every gateway record shape", () => {
+  const flows = {
+    native: { messages: [{ role: "user", content: "native secret" }], responseText: "native response" },
+    openaiCompat: { messages: [{ role: "user", content: "compat secret" }], responseText: "compat response" },
+    streaming: { messages: [{ role: "user", content: "stream secret" }], responseText: "assembled stream" },
+    embeddings: { messages: [{ role: "user", content: "embedding secret" }], responseText: null },
+  };
+
+  for (const [name, record] of Object.entries(flows)) {
+    assert.deepEqual(
+      payloadFields(record, { captureRequestPayloads: false }),
+      { messages: undefined, responseText: null },
+      `${name} must not retain payload text`
+    );
+  }
+});
+
+test("metadata-only mode strips request-derived and shadow eval payloads", () => {
+  const record = {
+    messages: [{ role: "user", content: "partner prompt" }],
+    responseText: "production response",
+  };
+  assert.deepEqual(
+    projectText(record, "raw_allowed", false, [], false),
+    { messages: null, productionResponse: null }
+  );
+  assert.deepEqual(
+    shadowPayload(
+      { messages: record.messages, prodText: record.responseText, candidateText: "candidate response" },
+      { captureRequestPayloads: false }
+    ),
+    { messages: null, prodResponse: null, candidateResponse: null }
+  );
+});
+
+test("opted-in payloads are masked before request and shadow-eval storage", () => {
+  const record = {
+    messages: [{ role: "user", content: "email partner@example.com" }],
+    responseText: "call 415-555-1212",
+  };
+  const request = payloadFields(record, { captureRequestPayloads: true, piiMaskingEnabled: true });
+  assert.ok(!JSON.stringify(request).includes("partner@example.com"));
+  assert.ok(!JSON.stringify(request).includes("415-555-1212"));
+
+  const shadow = shadowPayload(
+    { messages: record.messages, prodText: record.responseText, candidateText: "email candidate@example.com" },
+    { captureRequestPayloads: true, piiMaskingEnabled: true }
+  );
+  assert.ok(!JSON.stringify(shadow).includes("partner@example.com"));
+  assert.ok(!JSON.stringify(shadow).includes("candidate@example.com"));
+});

--- a/web/src/pages/Governance.jsx
+++ b/web/src/pages/Governance.jsx
@@ -518,13 +518,22 @@ function GuardrailsTab({ gov, setGov, save, saving, ok, err }) {
             >
               <Toggle
                 checked={gov.captureRequestPayloads !== false}
-                onChange={(v) => setGov({ ...gov, captureRequestPayloads: v })}
+                onChange={(v) => {
+                  if (v && !window.confirm(
+                    "Enable payload capture? Full prompts and model responses will be stored in MongoDB and may contain confidential or personal data. Confirm that your data policy permits this."
+                  )) return;
+                  setGov({ ...gov, captureRequestPayloads: v });
+                }}
                 label="capture payloads"
               />
             </SettingRow>
-            {gov.captureRequestPayloads === false && (
+            {gov.captureRequestPayloads !== false ? (
+              <div className="mt-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+                Sensitive-data warning: full prompts and responses will be retained in MongoDB. Enable PII masking, choose the shortest practical retention period, and confirm partner consent before saving.
+              </div>
+            ) : (
               <div className="mt-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700">
-                Request and response text will not be saved. You cannot view prompt/response content in the Requests drilldown.
+                Metadata-only mode is active. Request and response text will not be saved in request logs or evaluation artifacts.
               </div>
             )}
           </div>
@@ -699,12 +708,12 @@ function ObservabilityTab({ gov, setGov, save, saving, ok, err }) {
             className="input w-32"
             type="number"
             min="0"
-            placeholder="90"
+            placeholder="30"
             value={gov.retentionDays ?? ""}
             onChange={(e) => setGov({ ...gov, retentionDays: e.target.value !== "" ? Number(e.target.value) : null })}
           />
           <div className="mt-1 text-xs text-gray-400">
-            Set to 0 for indefinite retention. Purge runs nightly.
+            Production defaults to 30 days. Set to 0 for indefinite retention. Purge runs at startup and every 24 hours.
           </div>
         </div>
         <form onSubmit={(e) => { e.preventDefault(); save("retention")({ retentionDays: gov.retentionDays }); }}>


### PR DESCRIPTION
## Summary
- PR #160 ("fix(privacy): default production to metadata-only logging") was merged into `codex/fail-closed-production`, but that branch had already been merged into `main` via PR #159 ~13s earlier. #160's commit never reached `main` despite showing as merged on GitHub.
- This PR cherry-picks that commit (`de37540`) cleanly onto current `main`.

## What it restores
- Production defaults to metadata-only logging (payload capture off, masking on, 30-day retention).
- Eval dataset/replay/shadow paths respect the same privacy defaults.
- `docs/privacy.md` and related documentation.
- `server/test/unit/payloadPrivacy.test.js` (new).

## Test plan
- [x] Cherry-pick applied with no conflicts.
- [x] `server/test/unit/payloadPrivacy.test.js` and `evalDataset.test.js` pass (14/14).
- [x] Full unit suite passes (166/166).
- [x] Integration suite fails locally only due to a known macOS-13 mongod version mismatch (unrelated, pre-existing on this machine) — not run in CI-equivalent conditions here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)