### PR TITLE
fix(web): Audit page blanks on the new object-shaped AuditLog.actor

### DIFF
--- a/web/src/pages/Audit.jsx
+++ b/web/src/pages/Audit.jsx
@@ -69,7 +69,8 @@ export default function Audit() {
     {
       key: "actor",
       header: "By",
-      render: (r) => <Badge tone="gray">{r.actor || "admin"}</Badge>,
+      // actor is a plain string on pre-F-04 rows, { id, email, role } on new ones.
+      render: (r) => <Badge tone="gray">{(typeof r.actor === "string" ? r.actor : r.actor?.email) || "admin"}</Badge>,
     },
   ];
 


### PR DESCRIPTION
## Summary
F-04 (#163) changed `AuditLog.actor` from always-a-string to `{ id, email, role }` for every new entry. `Audit.jsx` rendered `r.actor` directly as a React child — fine for a string, but rendering an object as a child throws, and with no error boundary the whole Audit page goes blank.

Caught via manual browser testing right after deploying #163 — automated tests only exercised the API layer (`server/test/integration/identity.test.js` asserts `entry.actor.email`, never rendered it in a component), so this slipped through. Same actor-shape handling already existed on the backend CSV export (`server/src/api/routes/audit.js`); this brings the JSON-rendering frontend path in line with it.

**Production impact:** not broken yet — every entry logged since the #163 deploy is still a pre-F-04 string actor, since no admin mutation has happened on prod since. But the next one (any rule/key/cap/user action) will blank the Audit page for everyone until this lands.

## Test plan
- [x] Reproduced locally: seeded an object-shaped actor entry (via the Users role-change/disable flow in trusted-header mode), confirmed the page blanked pre-fix and renders correctly post-fix.
- [x] `npm --prefix web run build` succeeds.
- [x] Verified via `curl` that production's current audit entries are still string-actor (not yet broken) — confirms this needs to ship before the next admin action, not urgently as a hotfix for an active outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)