### PR TITLE
feat(auth): ARBR_OIDC_ALLOWED_DOMAINS for OAuth clients shared with other apps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,13 @@ MONGO_URI=mongodb://localhost:27017/arbr-control-plane
 # ARBR_OIDC_CLIENT_ID=
 # ARBR_OIDC_CLIENT_SECRET=
 # ARBR_OIDC_REDIRECT_URI=https://arbr.your-domain.com/api/auth/callback
+#
+# If this OAuth client is shared with another app that accepts any account
+# (e.g. one already registered for a public-signup product), restrict who can
+# actually sign into arbr regardless — comma-separated, case-insensitive.
+# Leave unset if the client itself is already restricted (e.g. an "Internal"
+# Google Workspace consent screen used by no other app).
+# ARBR_OIDC_ALLOWED_DOMAINS=your-company.com
 
 # --- Trusted header (ARBR_AUTH_MODE=trusted-header) ---
 # "iap" verifies GCP Identity-Aware Proxy's signed header; "proxy" trusts any

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -54,6 +54,14 @@ existing administrator must promote them before they can mutate anything. Sessio
 server-side (not stateless JWTs): disabling a user in the Users page deletes their sessions
 immediately, without touching anyone else's.
 
+**Reusing an OAuth client registered for another app?** Nothing stops it technically — each app
+still does its own independent token exchange, so there's no session sharing or leakage between
+them. But if that client's consent screen accepts *any* account (common when it's shared with a
+public-signup product, since the consent-screen restriction is project-wide, not per-client), set
+`ARBR_OIDC_ALLOWED_DOMAINS` (comma-separated) so arbr rejects anyone outside your organization
+before they're ever provisioned — even as a `viewer`. Leave it unset only if the client itself is
+already restricted to your organization and used by no other, more permissive app.
+
 ## GCP IAP setup
 
 If arbr runs behind [Identity-Aware Proxy](https://cloud.google.com/iap) (Cloud Run, GCE, or a

--- a/server/src/api/authProviders/oidc.js
+++ b/server/src/api/authProviders/oidc.js
@@ -17,6 +17,15 @@ const pendingSecret = crypto.randomBytes(32);
 
 const router = express.Router();
 
+// For OAuth clients shared with other apps (e.g. one already registered for a
+// public-signup product) that accept any account — restrict who can actually
+// reach arbr regardless. Empty allowlist = no restriction.
+function isAllowedEmailDomain(email, allowedDomains) {
+  if (!allowedDomains.length) return true;
+  const domain = String(email).toLowerCase().split("@")[1] || "";
+  return allowedDomains.includes(domain);
+}
+
 let clientPromise = null;
 function getClient() {
   if (!clientPromise) {
@@ -88,6 +97,11 @@ router.get("/callback", requireOidcMode, async (req, res, next) => {
       return res.status(400).send("Your identity provider did not return an email claim.");
     }
     const email = String(claims.email).toLowerCase();
+    if (!isAllowedEmailDomain(email, config.oidc.allowedDomains)) {
+      return res.status(403).send(
+        `Sign-in is restricted to ${config.oidc.allowedDomains.join(", ")}. Contact an administrator if this is unexpected.`
+      );
+    }
 
     let user = await User.findOne({ email });
     if (!user) {
@@ -122,3 +136,4 @@ router.post("/logout", async (req, res) => {
 });
 
 module.exports = router;
+module.exports.isAllowedEmailDomain = isAllowedEmailDomain;

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -174,6 +174,13 @@ const config = {
     clientId: process.env.ARBR_OIDC_CLIENT_ID || null,
     clientSecret: process.env.ARBR_OIDC_CLIENT_SECRET || null,
     redirectUri: process.env.ARBR_OIDC_REDIRECT_URI || null,
+    // Optional allowlist for shared OAuth clients that accept any account (e.g.
+    // one registered for a public app too) — comma-separated. Empty = no
+    // restriction beyond whatever the identity provider itself enforces.
+    allowedDomains: (process.env.ARBR_OIDC_ALLOWED_DOMAINS || "")
+      .split(",")
+      .map((d) => d.trim().toLowerCase())
+      .filter(Boolean),
   },
   trustedHeader: {
     // "iap" verifies a signed Google IAP JWT; "proxy" trusts a forwarded-identity

--- a/server/test/unit/oidcAllowedDomain.test.js
+++ b/server/test/unit/oidcAllowedDomain.test.js
@@ -1,0 +1,33 @@
+"use strict";
+// Guards shared OAuth clients (e.g. one already registered for a public-signup
+// app) from letting any Google account reach arbr — see ARBR_OIDC_ALLOWED_DOMAINS.
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { isAllowedEmailDomain } = require("../../src/api/authProviders/oidc");
+
+test("no allowlist configured means no restriction", () => {
+  assert.equal(isAllowedEmailDomain("anyone@example.com", []), true);
+});
+
+test("accepts an email in the allowlist", () => {
+  assert.equal(isAllowedEmailDomain("alice@gyde.ai", ["gyde.ai"]), true);
+});
+
+test("rejects an email outside the allowlist", () => {
+  assert.equal(isAllowedEmailDomain("alice@gmail.com", ["gyde.ai"]), false);
+});
+
+test("domain match is case-insensitive on the email side", () => {
+  assert.equal(isAllowedEmailDomain("Alice@GYDE.AI", ["gyde.ai"]), true);
+});
+
+test("supports multiple allowed domains", () => {
+  const allowed = ["gyde.ai", "partner.com"];
+  assert.equal(isAllowedEmailDomain("bob@partner.com", allowed), true);
+  assert.equal(isAllowedEmailDomain("bob@other.com", allowed), false);
+});
+
+test("a bare domain name is not treated as a suffix match (no subdomain bypass)", () => {
+  // "notgyde.ai" must not pass an allowlist of "gyde.ai" via naive suffix checks.
+  assert.equal(isAllowedEmailDomain("eve@notgyde.ai", ["gyde.ai"]), false);
+});


### PR DESCRIPTION
## Summary
Came up while planning to enable OIDC on arbr.gyde.ai: the plan was to reuse an existing Google OAuth client already registered for `air.gyde.ai` (a public, open-signup app) and `chat.gyde.ai`. Google's consent-screen Internal/External restriction is **project-wide**, not per-client — so restricting it to lock down arbr would also lock down `air.gyde.ai`, which needs to stay open.

Adds `ARBR_OIDC_ALLOWED_DOMAINS` (comma-separated), checked in the OIDC callback before any `User` record is touched. An email outside the list is rejected outright — never even auto-provisioned as a `viewer`. Same pattern `chat.gyde.ai` (a LibreChat fork) already uses at the application level for the same reason.

Empty/unset (default) preserves today's behavior exactly — no restriction beyond whatever the identity provider itself enforces.

## Test plan
- [x] New unit tests for the extracted `isAllowedEmailDomain` helper: no-allowlist passthrough, allow/reject, case-insensitivity, multiple domains, and a `notgyde.ai`-vs-`gyde.ai` case confirming it's an exact domain match, not a naive suffix check.
- [x] 250/250 server tests pass (`MONGOMS_VERSION=7.0.14 npm run test:server`).
- [x] `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)