### PR TITLE
fix(deploy): pass F-04 auth env vars through docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,20 @@ services:
       DEFAULT_PROVIDER: ${DEFAULT_PROVIDER:-}
       # CORS is moot in single-port mode (same origin), but harmless.
       CORS_ORIGIN: http://localhost:4100
+      # Per-user identity (F-04). Default "adminkey" (unset) keeps today's
+      # single-shared-key behavior — everything below is opt-in.
+      ARBR_AUTH_MODE: ${ARBR_AUTH_MODE:-}
+      ARBR_OIDC_ISSUER: ${ARBR_OIDC_ISSUER:-}
+      ARBR_OIDC_CLIENT_ID: ${ARBR_OIDC_CLIENT_ID:-}
+      ARBR_OIDC_CLIENT_SECRET: ${ARBR_OIDC_CLIENT_SECRET:-}
+      ARBR_OIDC_REDIRECT_URI: ${ARBR_OIDC_REDIRECT_URI:-}
+      ARBR_OIDC_ALLOWED_DOMAINS: ${ARBR_OIDC_ALLOWED_DOMAINS:-}
+      ARBR_TRUSTED_HEADER_STRATEGY: ${ARBR_TRUSTED_HEADER_STRATEGY:-}
+      ARBR_IAP_AUDIENCE: ${ARBR_IAP_AUDIENCE:-}
+      ARBR_PROXY_AUTH_HEADER: ${ARBR_PROXY_AUTH_HEADER:-}
+      ARBR_PROXY_SECRET_HEADER: ${ARBR_PROXY_SECRET_HEADER:-}
+      ARBR_PROXY_AUTH_SECRET: ${ARBR_PROXY_AUTH_SECRET:-}
+      ARBR_SESSION_TTL_HOURS: ${ARBR_SESSION_TTL_HOURS:-}
     ports:
       # Behind a same-host reverse proxy (nginx), bind to loopback instead:
       #   - "127.0.0.1:4100:4100"


### PR DESCRIPTION
## Summary
`docker-compose.yml`'s `app` service only forwards env vars it explicitly maps in its `environment:` block. F-04 (#163) added `ARBR_AUTH_MODE` and the OIDC/trusted-header env vars, but never added them here — it was developed and tested by running the server directly (`node server/src/index.js`), not through Compose, so the gap never surfaced.

Practical effect: setting `ARBR_AUTH_MODE=oidc` (etc.) in a deployment's `.env` had **no effect** — Compose never forwards it into the container, and the app silently stays in `adminkey` mode. Caught while actually configuring OIDC on arbr.gyde.ai for the first time.

## Test plan
- [x] `docker compose -f docker-compose.yml config` — valid syntax.
- [x] `docker compose -f docker-compose.yml -f docker-compose.prod.yml config --format json` — confirmed `ARBR_AUTH_MODE`/`ARBR_OIDC_*` now actually resolve into the container's environment (empty in this check since unset locally, but the pass-through mechanism is proven).
- [x] Purely additive — no existing env var entries touched, so demo/eval profile behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)