### PR TITLE
fix(analytics): stop Arbr's own AI spend polluting customer views

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -119,6 +119,27 @@ nobody mistakes a demo-grade mechanism for a hardened one. Several of these are 
 single-instance tradeoffs; they matter most if you run multiple replicas or high burst
 traffic.
 
+- **Arbr's own AI spend is counted but never attributed to a customer.** Arbr makes LLM
+  calls for itself (task classification on the routing path, AI policy generation, eval
+  judging, connection/model tests). Those are real money on the customer's provider key,
+  so they are stamped with `RequestRecord.internalKind` and **included in headline
+  `totalCost`** — a cost dashboard that hid them would understate the actual provider bill.
+  They are **excluded** from every per-application/workflow/user dimension view, from
+  facets, recommendations, eval datasets, canary baselines, policy simulation, observed
+  task types, provider health, and error-rate alerting, because they belong to no customer
+  application. `analytics/aggregate.js` `buildMatch` is **default-deny**: a view that does
+  not pass `internalScope` gets customer traffic only. Two consequences worth knowing:
+  (a) a **global** cost cap counts this overhead and can therefore breach on spend the
+  customer did not directly cause, while **scoped** (application/provider) caps never see
+  it — `capEngine._matches`, `analytics.spend({ includeInternal })` and the Budgets page
+  must stay in agreement or the displayed number diverges from the enforced one;
+  (b) records written before `internalKind` existed have no such field, which query
+  predicates treat as customer traffic — but **aggregation expressions do not**, so the
+  internal/customer split uses `$ifNull` rather than a bare `$eq` against null.
+  `RequestRecord` remains the single money ledger: eval collections (`EvalPair.prodCost`,
+  `EvalRun.actualCostUsd`) intentionally re-state costs for domain reporting and are never
+  summed into analytics totals.
+
 - **Budgets use hard CapSpend counters (multi-replica safe).** `routing/capEngine.js` keeps
   per-cap atomic spend counters (`CapSpend`, Mongo `$inc`) keyed by calendar window. The
   gateway reads those counters on every request for `block`/`downgrade` caps; successful

--- a/server/src/analytics/aggregate.js
+++ b/server/src/analytics/aggregate.js
@@ -5,6 +5,14 @@ const ApiKey = require("../models/ApiKey");
 const { computeRealisedSavings } = require("./savings");
 
 // Build a $match stage from filter query params.
+//
+// internalScope decides whether Arbr's own internal calls (classification, policy
+// generation, eval judging, …) are in scope. It defaults to "customer" — DEFAULT DENY —
+// so a view that knows nothing about internal spend cannot accidentally attribute
+// Arbr's overhead to a customer application. Callers opt in explicitly:
+//   "customer" (default) — customer traffic only
+//   "internal"           — Arbr's own calls only (the overhead detail view)
+//   "all"                — everything (headline totals, which include real overhead)
 function buildMatch(filter = {}) {
   const m = {};
   if (filter.from || filter.to) {
@@ -16,41 +24,86 @@ function buildMatch(filter = {}) {
     if (filter[f]) m[f] = filter[f];
   }
   if (filter.requestId) m.requestId = filter.requestId;
+
+  const scope = filter.internalScope || "customer";
+  if (scope === "customer") m.internalKind = null;
+  else if (scope === "internal") m.internalKind = { $ne: null };
+  // "all" — no constraint
   return m;
 }
 
+// True when the filter narrows to a customer dimension (not just a time range).
+// Internal records carry no application/workflow/user, so any such view is
+// customer-scoped by definition and must report zero overhead.
+function isDimensionScoped(filter = {}) {
+  return ["application", "workflow", "department", "taskType", "userId"].some((f) => filter[f]);
+}
+
+// Headline view. `totalCost` deliberately INCLUDES Arbr's own internal spend, because
+// that is real money on the customer's provider key and a cost dashboard that hides it
+// would understate their actual bill. It is also reported separately as `internalCost`
+// so it can be shown as its own line rather than smeared across customer applications.
+//
+// Every OTHER metric here is customer-only: internal calls have their own latency and
+// never hit the response cache, so counting them would distort avgLatency and the cache
+// hit rate. A dimension-scoped view reports zero overhead by definition.
 async function overview(filter) {
-  const match = buildMatch(filter);
+  const scoped = isDimensionScoped(filter);
+  const match = buildMatch({ ...filter, internalScope: scoped ? "customer" : "all" });
+  // $ifNull is load-bearing: a *query* predicate like { internalKind: null } matches
+  // documents where the field is absent, but an aggregation expression does not —
+  // $eq: ["$internalKind", null] is false for a missing field. Records written before
+  // this field existed have no internalKind, so without this they'd count as neither
+  // customer nor internal and silently vanish from the split.
+  const isCustomer = { $eq: [{ $ifNull: ["$internalKind", null] }, null] };
+  const customerSum = (expr) => ({ $sum: { $cond: [isCustomer, expr, 0] } });
+
   const [row] = await RequestRecord.aggregate([
     { $match: match },
     {
       $group: {
         _id: null,
-        totalRequests: { $sum: 1 },
+        // Headline: everything in scope, overhead included.
         totalCost: { $sum: "$totalCost" },
-        avgLatency: { $avg: "$latencyMs" },
-        totalTokens: { $sum: "$totalTokens" },
-        failures: { $sum: { $cond: [{ $eq: ["$status", "failure"] }, 1, 0] } },
-        cacheHits: { $sum: { $cond: ["$cacheHit", 1, 0] } },
-        cachedReadTokens: { $sum: "$cachedReadTokens" },
-        cacheSavingUsd: { $sum: "$cacheSavingUsd" },
+        // The overhead split.
+        internalCost: { $sum: { $cond: [isCustomer, 0, "$totalCost"] } },
+        internalRequests: { $sum: { $cond: [isCustomer, 0, 1] } },
+        // Customer-only from here down.
+        totalRequests: customerSum(1),
+        totalTokens: customerSum("$totalTokens"),
+        failures: { $sum: { $cond: [{ $and: [isCustomer, { $eq: ["$status", "failure"] }] }, 1, 0] } },
+        cacheHits: { $sum: { $cond: [{ $and: [isCustomer, "$cacheHit"] }, 1, 0] } },
+        cachedReadTokens: customerSum("$cachedReadTokens"),
+        cacheSavingUsd: customerSum("$cacheSavingUsd"),
         // Pass-through models with no pricing entry log $0; surface them so cost isn't read as complete.
-        unknownPricingRequests: { $sum: { $cond: [{ $eq: ["$knownPricing", false] }, 1, 0] } },
+        unknownPricingRequests: {
+          $sum: { $cond: [{ $and: [isCustomer, { $eq: ["$knownPricing", false] }] }, 1, 0] },
+        },
+        customerCost: customerSum("$totalCost"),
+        customerLatencySum: customerSum("$latencyMs"),
       },
     },
   ]);
   const totalRequests = row?.totalRequests || 0;
   const totalCost = row?.totalCost || 0;
+  const customerCost = row?.customerCost || 0;
+  const internalCost = row?.internalCost || 0;
   const cacheHits = row?.cacheHits || 0;
   const unknownPricingRequests = row?.unknownPricingRequests || 0;
   const pricedRequests = totalRequests - unknownPricingRequests;
   return {
     totalRequests,
     totalCost,
-    // Average over priced requests only — $0 unknown-pricing records would otherwise deflate it.
-    avgCostPerRequest: pricedRequests ? totalCost / pricedRequests : 0,
+    // The overhead split. internalShare is of the headline total, so the two read together.
+    customerCost,
+    internalCost,
+    internalRequests: row?.internalRequests || 0,
+    internalShare: totalCost ? internalCost / totalCost : 0,
+    // Average over priced CUSTOMER requests only — $0 unknown-pricing records would
+    // otherwise deflate it, and overhead isn't attributable to a customer request.
+    avgCostPerRequest: pricedRequests ? customerCost / pricedRequests : 0,
     unknownPricingRequests,
-    avgLatency: row?.avgLatency || 0,
+    avgLatency: totalRequests ? (row?.customerLatencySum || 0) / totalRequests : 0,
     totalTokens: row?.totalTokens || 0,
     failures: row?.failures || 0,
     // Caching observability: response-cache hit rate + provider prompt-cache reuse and savings.
@@ -151,11 +204,16 @@ async function realisedSavings(filter) {
 
 // Total cost for a scope over a window — powers cost caps. dimension/value are
 // optional (omit both for global spend); from/to bound the window.
-async function spend({ dimension, value, from, to } = {}) {
+//
+// includeInternal defaults to false so any caller that hasn't thought about Arbr's
+// own overhead gets the customer-only number. Only a GLOBAL cap should pass true:
+// a scoped cap is a control over scoped traffic, and overhead belongs to no scope.
+async function spend({ dimension, value, from, to, includeInternal = false } = {}) {
   const filter = {};
   if (from) filter.from = from;
   if (to) filter.to = to;
   if (dimension && value) filter[dimension] = value;
+  if (includeInternal) filter.internalScope = "all";
   const match = buildMatch(filter);
   const [row] = await RequestRecord.aggregate([
     { $match: match },
@@ -165,15 +223,18 @@ async function spend({ dimension, value, from, to } = {}) {
 }
 
 // Distinct values for filter dropdowns.
+// Customer-only: Arbr's own internal calls must never become a selectable dimension
+// value, or the console offers "filter by Arbr's overhead" as if it were an application.
 async function facets() {
+  const customer = RequestRecord.CUSTOMER_ONLY;
   const [applications, workflows, departments, models, providers, taskTypes, users, keyApps] = await Promise.all([
-    RequestRecord.distinct("application"),
-    RequestRecord.distinct("workflow"),
-    RequestRecord.distinct("department"),
-    RequestRecord.distinct("model"),
-    RequestRecord.distinct("provider"),
-    RequestRecord.distinct("taskType"),
-    RequestRecord.distinct("userId"),
+    RequestRecord.distinct("application", customer),
+    RequestRecord.distinct("workflow", customer),
+    RequestRecord.distinct("department", customer),
+    RequestRecord.distinct("model", customer),
+    RequestRecord.distinct("provider", customer),
+    RequestRecord.distinct("taskType", customer),
+    RequestRecord.distinct("userId", customer),
     ApiKey.distinct("application", { enabled: true, revokedAt: null }),
   ]);
   // Apps that have a key but have never made a request — shown as "newly added".
@@ -184,10 +245,13 @@ async function facets() {
 
 // Per-provider health over the last 24h: error rate and average latency.
 // Surfaces in the Connections page so operators can spot degraded providers.
+// Customer-only: internal call volume is small and bursty (a run of connection tests
+// would swing the numbers), and this panel answers "how are my providers serving my
+// traffic". Arbr's own calls do exercise the provider, so this is a deliberate choice.
 async function providerHealth() {
   const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
   const rows = await RequestRecord.aggregate([
-    { $match: { timestamp: { $gte: since } } },
+    { $match: { timestamp: { $gte: since }, ...RequestRecord.CUSTOMER_ONLY } },
     {
       $group: {
         _id: "$provider",
@@ -262,9 +326,41 @@ async function latencyPercentiles(filter) {
   return row || { p50: null, p95: null, p99: null, ttftP50: null, ttftP95: null, overheadP50: null, overheadP95: null, overheadP99: null };
 }
 
+// Arbr's own overhead, broken down by what it was spent on. This is the one view that
+// deliberately looks at internal records — everything else excludes them.
+async function internalSpend(filter = {}) {
+  const scoped = { ...filter, internalScope: "internal" };
+  const [byKind, byModel, [totals]] = await Promise.all([
+    groupBy("internalKind", scoped),
+    groupBy("model", scoped),
+    RequestRecord.aggregate([
+      { $match: buildMatch(scoped) },
+      {
+        $group: {
+          _id: null,
+          totalCost: { $sum: "$totalCost" },
+          totalRequests: { $sum: 1 },
+          totalTokens: { $sum: "$totalTokens" },
+          failures: { $sum: { $cond: [{ $eq: ["$status", "failure"] }, 1, 0] } },
+        },
+      },
+    ]),
+  ]);
+  return {
+    totalCost: totals?.totalCost || 0,
+    totalRequests: totals?.totalRequests || 0,
+    totalTokens: totals?.totalTokens || 0,
+    failures: totals?.failures || 0,
+    byKind,
+    byModel,
+  };
+}
+
 module.exports = {
   buildMatch,
+  isDimensionScoped,
   overview,
+  internalSpend,
   spend,
   timeseries,
   byApplication,

--- a/server/src/api/routes/_shared.js
+++ b/server/src/api/routes/_shared.js
@@ -19,6 +19,10 @@ async function capStatus(cap) {
       dimension: cap.dimension,
       value: cap.value,
       from: capWindowStart(cap.period),
+      // Must mirror capEngine._matches, or the Budgets page shows a different
+      // number than the one being enforced: global caps see Arbr's own overhead,
+      // scoped caps do not.
+      includeInternal: !cap.dimension,
     });
   }
   const pct = cap.limit > 0 ? spent / cap.limit : 0;

--- a/server/src/api/routes/analytics.js
+++ b/server/src/api/routes/analytics.js
@@ -12,6 +12,14 @@ router.get("/analytics/overview", async (req, res, next) => {
   try { res.json(await analytics.overview(req.query)); } catch (e) { next(e); }
 });
 
+// Arbr's own overhead — what the control plane spent on the customer's provider keys
+// making calls for itself (task classification, policy generation, eval judging,
+// connection tests). Real money, counted in the headline total, but excluded from every
+// customer dimension view because it belongs to no application.
+router.get("/analytics/internal-spend", async (req, res, next) => {
+  try { res.json(await analytics.internalSpend(req.query)); } catch (e) { next(e); }
+});
+
 // Adoption / acceptance-rate — the "production truth" beside benchmark scores: what humans actually
 // did with Arbr's suggestions (accepted vs dismissed) and its canaries (promoted vs rolled back).
 router.get("/analytics/acceptance", async (_req, res, next) => {

--- a/server/src/api/routes/policy.js
+++ b/server/src/api/routes/policy.js
@@ -13,7 +13,7 @@ router.get("/policy", async (_req, res, next) => {
   try {
     const d = await policyEngine.describe();
     // Merge built-in task types with any app-provided task types observed in traffic.
-    const observed = (await RequestRecord.distinct("taskType")).filter(Boolean).map((x) => String(x).toLowerCase());
+    const observed = (await RequestRecord.distinct("taskType", RequestRecord.CUSTOMER_ONLY)).filter(Boolean).map((x) => String(x).toLowerCase());
     const allTypes = [...new Set([...TASK_TYPES, ...observed])].sort();
     res.json({ ...d, taskTypes: allTypes });
   } catch (e) { next(e); }
@@ -25,7 +25,7 @@ router.put("/policy", requireRole("administrator"), async (req, res, next) => {
     // Validate task types against built-in catalog + any task types observed in traffic.
     let cheapTaskTypes;
     if (Array.isArray(body.cheapTaskTypes)) {
-      const observed = (await RequestRecord.distinct("taskType")).filter(Boolean).map((x) => String(x).toLowerCase());
+      const observed = (await RequestRecord.distinct("taskType", RequestRecord.CUSTOMER_ONLY)).filter(Boolean).map((x) => String(x).toLowerCase());
       const known = new Set([...TASK_TYPES, ...observed]);
       cheapTaskTypes = body.cheapTaskTypes.map((x) => String(x).toLowerCase()).filter((x) => known.has(x));
     }

--- a/server/src/eval/dataset.js
+++ b/server/src/eval/dataset.js
@@ -17,7 +17,9 @@ const FETCH_MULTIPLIER = 5; // over-fetch before dedupe/stratify so we can still
 // Mongo query for a recommendation's scope. Only successful, single-shot, non-cache records
 // with a stored response are eligible (tools/multi-turn are excluded downstream via isSingleShot).
 function buildScopeQuery(rec, since) {
-  const q = { status: "success", cacheHit: { $ne: true } };
+  // Customer traffic only — Arbr's own internal prompts must never become items in a
+  // customer's evaluation dataset.
+  const q = { status: "success", cacheHit: { $ne: true }, ...RequestRecord.CUSTOMER_ONLY };
   if (rec.taskType) q.taskType = rec.taskType;
   if (rec.currentModel) q.model = rec.currentModel;
   if (rec.application) q.application = rec.application;

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -14,6 +14,7 @@ const { handleOpenAICompat } = require("./gateway/openaiCompat");
 const { handleEmbeddings } = require("./gateway/embeddings");
 const { handleUpgrade, closeAll: closeRealtimeSessions } = require("./gateway/wsAuth");
 const { purgeOldRecords } = require("./maintenance/purge");
+const { backfillInternalKind } = require("./maintenance/backfillInternalKind");
 const errorAlertMonitor = require("./routing/errorAlertMonitor");
 const canaryMonitor = require("./routing/canaryMonitor");
 const evalWorker = require("./eval/worker");
@@ -36,6 +37,7 @@ async function start() {
 
   await mongoose.connect(config.mongoUri);
   await registry.init(); // seed ModelEntry if empty + warm in-memory cache
+  await backfillInternalKind(); // idempotent; no-op after the first run
 
   // Production: force data-plane API keys on so anonymous /v1 calls are rejected.
   if (config.isProduction) {

--- a/server/src/logging/logger.js
+++ b/server/src/logging/logger.js
@@ -73,6 +73,8 @@ async function write(record) {
         capEngine.recordSpend(totalCost, {
           application: record.application,
           provider: record.provider,
+          // Arbr's own overhead counts against a global cap but not a scoped one.
+          internalKind: record.internalKind || null,
         }).catch(() => {})
       );
     }

--- a/server/src/maintenance/backfillInternalKind.js
+++ b/server/src/maintenance/backfillInternalKind.js
@@ -1,0 +1,58 @@
+// One-off relabel of records written before `internalKind` existed.
+//
+// The AI task classifier used to log its own calls as a synthetic application named
+// "arbr-internal" (gateway/handler.js). Nothing read that sentinel, so those records
+// showed up as a fake application in every dimension view. This converts them to the
+// real discriminator and clears the fake dimensions.
+//
+// Safe to run on every boot:
+//   • idempotent — the predicate stops matching after the first pass
+//   • matches nothing on a fresh install
+//   • a single indexed updateMany, not a cursor
+//   • failure degrades to CURRENT behaviour, never worse: exclusion keys on
+//     `internalKind: null`, which already matches these records, so an unmigrated
+//     record simply stays visible exactly as it is today
+const RequestRecord = require("../models/RequestRecord");
+const Recommendation = require("../models/Recommendation");
+
+const LEGACY_APPLICATION = "arbr-internal";
+
+async function backfillInternalKind() {
+  try {
+    const { modifiedCount } = await RequestRecord.updateMany(
+      { application: LEGACY_APPLICATION, internalKind: null },
+      {
+        $set: {
+          internalKind: "classifier",
+          internalContext: { migratedFrom: LEGACY_APPLICATION },
+          // Clear the fake dimensions so no group-by can surface them. The only value
+          // being discarded is the constant above, preserved in internalContext.
+          application: null,
+          workflow: null,
+          department: null,
+          taskType: null,
+        },
+      }
+    );
+
+    // Recommendations generated against the fake application. Pending ones would clear
+    // themselves on the next recompute, but accepted/dismissed ones persist forever.
+    const { deletedCount } = await Recommendation.deleteMany({
+      dedupeKey: new RegExp(`:${LEGACY_APPLICATION}:`),
+    });
+
+    if (modifiedCount || deletedCount) {
+      console.log(
+        `[migrate] internal spend: relabelled ${modifiedCount} request record(s), ` +
+        `removed ${deletedCount} stale recommendation(s)`
+      );
+    }
+    return { modifiedCount, deletedCount };
+  } catch (err) {
+    // Never block boot. An unmigrated record behaves exactly as it does today.
+    console.error("[migrate] internal-spend backfill failed (non-fatal):", err.message);
+    return { modifiedCount: 0, deletedCount: 0, error: err.message };
+  }
+}
+
+module.exports = { backfillInternalKind, LEGACY_APPLICATION };

--- a/server/src/maintenance/purge.js
+++ b/server/src/maintenance/purge.js
@@ -15,7 +15,9 @@ async function purgeOldRecords() {
     if (!days || days <= 0) return; // 0 / null = keep forever
     const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
 
-    const { deletedCount } = await RequestRecord.deleteMany({ timestamp: { $lt: cutoff } });
+    // Intentionally not filtered by internalKind: Arbr's own internal records age out on
+  // the same retention window as customer traffic. Don't "fix" this.
+  const { deletedCount } = await RequestRecord.deleteMany({ timestamp: { $lt: cutoff } });
     if (deletedCount > 0) {
       console.log(`[purge] deleted ${deletedCount} request records older than ${days} days`);
     }

--- a/server/src/models/RequestRecord.js
+++ b/server/src/models/RequestRecord.js
@@ -3,6 +3,20 @@
 // savings are measurable and later phases can learn which substitutions held up.
 const mongoose = require("mongoose");
 
+// The kinds of LLM call Arbr makes on its own behalf. One entry per internal call
+// site; see server/src/internal/ for the wrapper that stamps these.
+const INTERNAL_KINDS = [
+  "classifier",         // routing-path task classification
+  "policy-generation",  // AI routing policy / per-app policy generation
+  "shadow-candidate",   // shadow campaign candidate call
+  "shadow-judge",       // shadow campaign LLM-as-judge
+  "eval-replay",        // eval run candidate replay
+  "eval-judge",         // eval run rubric judge
+  "eval-disprove",      // eval run "disprove worse" second pass
+  "connection-test",    // admin: test a provider connection
+  "model-test",         // admin: test a registry model
+];
+
 const requestRecordSchema = new mongoose.Schema(
   {
     requestId: { type: String, required: true, unique: true, index: true },
@@ -37,6 +51,26 @@ const requestRecordSchema = new mongoose.Schema(
     // false = pass-through model with no pricing entry; cost is logged as $0 and must be
     // EXCLUDED from spend/savings claims rather than treated as free. Surfaced in analytics.
     knownPricing: { type: Boolean, default: true, index: true },
+
+    // Non-null = a call Arbr made FOR ITSELF (task classification, policy generation,
+    // eval judging, connection tests) rather than customer traffic it proxied. This is
+    // real money on the customer's provider key, so it COUNTS in headline spend — but it
+    // is excluded from every per-application / workflow / user dimension view, from
+    // facets, recommendations, eval datasets and error alerting, because it belongs to
+    // no customer application.
+    //
+    // null (or absent, on records written before this field existed) = customer traffic.
+    // Mongo matches missing fields with `{ internalKind: null }`, so the exclusion
+    // predicate is already correct for historical records without a backfill.
+    internalKind: {
+      type: String,
+      enum: [...INTERNAL_KINDS, null],
+      default: null,
+      index: true, // deliberately not sparse: null is the value most queries filter on
+    },
+    // Debug-only provenance (which request/campaign/run triggered this overhead).
+    // Deliberately NOT a top-level indexed dimension, so no group-by can surface it.
+    internalContext: { type: mongoose.Schema.Types.Mixed, default: null },
 
     // performance + outcome
     latencyMs: { type: Number, default: 0 },
@@ -96,4 +130,11 @@ const requestRecordSchema = new mongoose.Schema(
   { collection: "request_records" }
 );
 
-module.exports = mongoose.model("RequestRecord", requestRecordSchema);
+const RequestRecord = mongoose.model("RequestRecord", requestRecordSchema);
+
+// Predicates for the internal/customer split, so no caller hand-writes the shape.
+RequestRecord.CUSTOMER_ONLY = { internalKind: null };
+RequestRecord.INTERNAL_ONLY = { internalKind: { $ne: null } };
+RequestRecord.INTERNAL_KINDS = INTERNAL_KINDS;
+
+module.exports = RequestRecord;

--- a/server/src/recommend/engine.js
+++ b/server/src/recommend/engine.js
@@ -89,7 +89,10 @@ async function recompute() {
   // Aggregate token totals per (application, taskType, model, provider) so recommendations can
   // be scoped to the app whose traffic justifies them (routing is already app-aware).
   const agg = await RequestRecord.aggregate([
-    { $match: { status: "success" } },
+    // Customer traffic only. Recommending that Arbr downgrade its own classifier is
+    // not actionable advice for a customer, and it would be scoped to an application
+    // that doesn't exist.
+    { $match: { status: "success", ...RequestRecord.CUSTOMER_ONLY } },
     {
       $group: {
         _id: { application: "$application", taskType: "$taskType", model: "$model", provider: "$provider" },
@@ -180,7 +183,7 @@ function analyzeGroups(groups, cheapTaskTypes, { isPremium, suggestLightTarget, 
 async function analyze() {
   const policy = await getEffective();
   const agg = await RequestRecord.aggregate([
-    { $match: { status: "success" } },
+    { $match: { status: "success", ...RequestRecord.CUSTOMER_ONLY } },
     { $group: {
         _id: { taskType: "$taskType", model: "$model", provider: "$provider" },
         requests: { $sum: 1 },

--- a/server/src/routing/aiPolicy.js
+++ b/server/src/routing/aiPolicy.js
@@ -121,7 +121,8 @@ const DOMAIN_KEYWORDS = {
 
 // Task types apps have actually sent (lowercased), from the request log.
 async function observedTaskTypes() {
-  const seen = await RequestRecord.distinct("taskType");
+  // Customer traffic only — Arbr's own task types must not become routable policy entries.
+  const seen = await RequestRecord.distinct("taskType", RequestRecord.CUSTOMER_ONLY);
   return seen.filter(Boolean).map((t) => String(t).toLowerCase());
 }
 
@@ -386,7 +387,9 @@ async function regenerate({ router, eff, goal }) {
 // logged tokens; `capabilityIndex` is a heuristic PROXY (capability scores, not measured quality).
 async function simulate({ assignments = {}, application = null, windowDays = 14 } = {}) {
   const since = new Date(Date.now() - windowDays * 86400000);
-  const match = { status: "success", timestamp: { $gte: since } };
+  // Customer traffic only — simulating a policy against Arbr's own overhead would
+  // re-price internal tokens as if a routing rule could have changed them.
+  const match = { status: "success", timestamp: { $gte: since }, ...RequestRecord.CUSTOMER_ONLY };
   if (application) match.application = application;
   const agg = await RequestRecord.aggregate([
     { $match: match },

--- a/server/src/routing/canaryMonitor.js
+++ b/server/src/routing/canaryMonitor.js
@@ -48,8 +48,11 @@ async function metricsFor(exp) {
   if (exp.scope?.taskType) scope.taskType = exp.scope.taskType;
   const proj = { status: 1, totalCost: 1, latencyMs: 1 };
 
-  const cand = await RequestRecord.find({ ...scope, timestamp: { $gte: since }, routingDecision: "canary", model: exp.candidateModel }, proj).lean();
-  const base = await RequestRecord.find({ ...scope, timestamp: { $gte: since }, routingDecision: { $ne: "canary" }, model: exp.baselineModel }, proj).lean();
+  // Customer traffic only. An internal call that happens to use the baseline model
+  // would otherwise land in the baseline arm and skew the comparison.
+  const customer = RequestRecord.CUSTOMER_ONLY;
+  const cand = await RequestRecord.find({ ...scope, ...customer, timestamp: { $gte: since }, routingDecision: "canary", model: exp.candidateModel }, proj).lean();
+  const base = await RequestRecord.find({ ...scope, ...customer, timestamp: { $gte: since }, routingDecision: { $ne: "canary" }, model: exp.baselineModel }, proj).lean();
 
   const stats = (rows) => {
     const total = rows.length;

--- a/server/src/routing/capEngine.js
+++ b/server/src/routing/capEngine.js
@@ -42,8 +42,17 @@ function windowKey(period, now = new Date()) {
   return `month:${y}-${m}`;
 }
 
-function _matches(cap, { application, provider }) {
-  if (!cap.dimension) return true; // global
+// Which caps a given spend event counts against.
+//
+// Arbr's own internal calls (classification, policy generation, eval judging) are real
+// money on the customer's provider key, so they DO count against a global cap. They do
+// NOT count against a scoped cap: a per-application or per-provider cap is a control
+// over that scope's traffic, and overhead belongs to no customer scope. Internal
+// records carry no application, so the application branch already excludes them; the
+// provider branch needs an explicit guard because they do carry a real provider.
+function _matches(cap, { application, provider, internalKind = null }) {
+  if (!cap.dimension) return true; // global — includes internal spend
+  if (internalKind) return false;  // scoped caps never see Arbr's own overhead
   if (cap.dimension === "application") return cap.value === application;
   if (cap.dimension === "provider") return cap.value === provider;
   return false; // other dimensions not enforced at the gateway (yet)
@@ -63,14 +72,14 @@ async function getSpend(cap, now = new Date()) {
 }
 
 // Atomic $inc after a priced request. No-ops for zero/negative cost.
-async function recordSpend(totalCost, { application, provider } = {}) {
+async function recordSpend(totalCost, { application, provider, internalKind = null } = {}) {
   const cost = Number(totalCost) || 0;
   if (cost <= 0) return;
   const caps = await _enforcingCaps();
   const now = new Date();
   const ops = [];
   for (const cap of caps) {
-    if (!_matches(cap, { application, provider })) continue;
+    if (!_matches(cap, { application, provider, internalKind })) continue;
     const key = windowKey(cap.period, now);
     ops.push(
       CapSpend.findOneAndUpdate(
@@ -148,6 +157,9 @@ async function reconcileFromAnalytics() {
       dimension: cap.dimension,
       value: cap.value,
       from: windowStart(cap.period, now.getTime()),
+      // Must mirror _matches, or reconciliation would overwrite the counters with a
+      // differently-scoped total and reintroduce the drift it exists to fix.
+      includeInternal: !cap.dimension,
     });
     const key = windowKey(cap.period, now);
     await CapSpend.findOneAndUpdate(

--- a/server/src/routing/errorAlertMonitor.js
+++ b/server/src/routing/errorAlertMonitor.js
@@ -18,7 +18,9 @@ async function check() {
 
     const since = new Date(Date.now() - WINDOW_MS);
     const [row] = await RequestRecord.aggregate([
-      { $match: { timestamp: { $gte: since } } },
+      // Customer traffic only — Arbr's own internal calls failing is an operator
+      // concern, not a reason to alert someone about *their* error rate.
+      { $match: { timestamp: { $gte: since }, ...RequestRecord.CUSTOMER_ONLY } },
       { $group: {
           _id: null,
           total:    { $sum: 1 },

--- a/server/test/integration/internalSpend.test.js
+++ b/server/test/integration/internalSpend.test.js
@@ -1,0 +1,205 @@
+"use strict";
+// Arbr's own internal spend must be counted in headline cost but never attributed to a
+// customer application. These are regression tests for a real bug: before internalKind
+// existed, the AI classifier logged itself as application "arbr-internal", which nothing
+// filtered — so it appeared as a fake app, fed recommendations, and counted against
+// customer budget caps.
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+const mongoose = require("mongoose");
+const express = require("express");
+const supertest = require("supertest");
+
+process.env.ARBR_ADMIN_KEY = "";
+
+const RequestRecord = require("../../src/models/RequestRecord");
+const Cap = require("../../src/models/Cap");
+const Recommendation = require("../../src/models/Recommendation");
+const apiRoutes = require("../../src/api/routes");
+const analytics = require("../../src/analytics/aggregate");
+const engine = require("../../src/recommend/engine");
+const { backfillInternalKind } = require("../../src/maintenance/backfillInternalKind");
+
+let mongod;
+let agent;
+
+const stubAdmin = (req, _res, next) => { req.user = { id: "test", email: "t@t", role: "administrator" }; next(); };
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(stubAdmin);
+  app.use("/api", apiRoutes);
+  return app;
+}
+
+let seq = 0;
+function rec(over = {}) {
+  seq += 1;
+  return {
+    requestId: `r-${seq}`,
+    timestamp: new Date(),
+    application: "checkout", workflow: "wf", department: "eng", userId: "u1",
+    provider: "openai", model: "gpt-4o-mini", modelRequested: "gpt-4o-mini",
+    taskType: "summarization",
+    promptTokens: 100, completionTokens: 50, totalTokens: 150,
+    totalCost: 1, latencyMs: 100, status: "success", knownPricing: true,
+    ...over,
+  };
+}
+// An internal record as the wrapper will write it: no customer dimensions at all.
+function internalRec(over = {}) {
+  return rec({
+    application: null, workflow: null, department: null, userId: null, taskType: null,
+    internalKind: "classifier", totalCost: 0.25, latencyMs: 9999,
+    ...over,
+  });
+}
+
+before(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  agent = supertest(buildApp());
+});
+after(async () => { await mongoose.disconnect(); await mongod.stop(); });
+beforeEach(async () => {
+  await Promise.all([RequestRecord.deleteMany({}), Cap.deleteMany({}), Recommendation.deleteMany({})]);
+});
+
+test("internal spend is in the headline total but split out", async () => {
+  await RequestRecord.create([rec(), rec(), internalRec()]);
+  const { body } = await agent.get("/api/analytics/overview").expect(200);
+
+  assert.equal(body.totalCost, 2.25, "headline total includes overhead — it is real money");
+  assert.equal(body.customerCost, 2);
+  assert.equal(body.internalCost, 0.25);
+  assert.equal(body.internalRequests, 1);
+  assert.ok(Math.abs(body.internalShare - 0.25 / 2.25) < 1e-9);
+  assert.equal(body.totalCost, body.customerCost + body.internalCost, "the split must reconcile");
+
+  // Customer-only metrics must not be distorted by the internal record's 9999ms latency.
+  assert.equal(body.totalRequests, 2, "request count is customer-only");
+  assert.equal(body.avgLatency, 100, "avgLatency must ignore internal calls");
+});
+
+test("a dimension-scoped overview reports zero overhead", async () => {
+  await RequestRecord.create([rec(), internalRec()]);
+  const { body } = await agent.get("/api/analytics/overview?application=checkout").expect(200);
+  assert.equal(body.internalCost, 0);
+  assert.equal(body.internalShare, 0);
+  assert.equal(body.totalCost, 1, "scoped views see customer traffic only");
+});
+
+test("internal records never appear as an application", async () => {
+  await RequestRecord.create([rec(), internalRec()]);
+
+  const byApp = (await agent.get("/api/analytics/by/application").expect(200)).body;
+  assert.deepEqual(byApp.map((r) => r.key), ["checkout"]);
+
+  const facets = (await agent.get("/api/analytics/facets").expect(200)).body;
+  assert.ok(!facets.applications.includes("arbr-internal"), "the legacy sentinel must be gone");
+  assert.deepEqual(facets.applications, ["checkout"]);
+  assert.ok(!facets.taskTypes.includes(null));
+});
+
+test("the request list hides internal records unless asked", async () => {
+  await RequestRecord.create([rec(), internalRec()]);
+
+  const dflt = (await agent.get("/api/requests").expect(200)).body;
+  assert.equal(dflt.items.length, 1);
+  assert.equal(dflt.items[0].application, "checkout");
+
+  const internal = (await agent.get("/api/requests?internalScope=internal").expect(200)).body;
+  assert.equal(internal.items.length, 1);
+  assert.equal(internal.items[0].internalKind, "classifier");
+});
+
+test("internal-spend endpoint breaks overhead down by kind and model", async () => {
+  await RequestRecord.create([
+    rec(),
+    internalRec({ internalKind: "classifier", totalCost: 0.25 }),
+    internalRec({ internalKind: "policy-generation", totalCost: 2, model: "gpt-4o" }),
+  ]);
+  const { body } = await agent.get("/api/analytics/internal-spend").expect(200);
+
+  assert.equal(body.totalCost, 2.25);
+  assert.equal(body.totalRequests, 2);
+  const kinds = Object.fromEntries(body.byKind.map((r) => [r.key, r.cost]));
+  assert.deepEqual(kinds, { "policy-generation": 2, classifier: 0.25 });
+  // byModel is what surfaces an expensive surprise, e.g. policy generation on a premium model.
+  assert.ok(body.byModel.some((r) => r.key === "gpt-4o" && r.cost === 2));
+});
+
+// The highest-value test here: this is the path that can 429 real customer traffic.
+test("global caps count internal spend; scoped caps do not", async () => {
+  const from = new Date(Date.now() - 60_000);
+  await RequestRecord.create([rec(), internalRec()]);
+
+  const global = await analytics.spend({ from, includeInternal: true });
+  assert.equal(global, 1.25, "a global cap sees Arbr's overhead — it is real spend");
+
+  const scoped = await analytics.spend({ dimension: "application", value: "checkout", from });
+  assert.equal(scoped, 1, "an application cap must not see overhead");
+
+  const providerScoped = await analytics.spend({ dimension: "provider", value: "openai", from });
+  assert.equal(providerScoped, 1, "a provider cap must not see overhead either");
+
+  // Default is customer-only, so a caller that forgets the flag can't over-count.
+  assert.equal(await analytics.spend({ from }), 1);
+});
+
+test("recommendations ignore internal traffic", async () => {
+  // Enough volume to clear the engine's minimum-requests threshold.
+  const many = [];
+  for (let i = 0; i < 60; i++) {
+    many.push(internalRec({ internalKind: "classifier", model: "gpt-4o", totalCost: 5, promptTokens: 5000, completionTokens: 2000 }));
+  }
+  await RequestRecord.create(many);
+  await engine.recompute();
+
+  const recs = await Recommendation.find().lean();
+  assert.ok(
+    !recs.some((r) => String(r.dedupeKey).includes("arbr-internal") || r.application === null),
+    "no recommendation should be generated from Arbr's own spend"
+  );
+});
+
+test("records written before internalKind existed count as customer traffic", async () => {
+  // Insert through the driver so the schema default can't backfill the field —
+  // this is what a genuinely old document looks like.
+  await mongoose.connection.collection("request_records").insertOne({
+    requestId: "legacy-1", timestamp: new Date(),
+    application: "legacy-app", provider: "openai", model: "gpt-4o-mini",
+    totalCost: 3, latencyMs: 10, status: "success", knownPricing: true,
+    promptTokens: 1, completionTokens: 1, totalTokens: 2,
+  });
+  const { body } = await agent.get("/api/analytics/overview").expect(200);
+  assert.equal(body.customerCost, 3, "a missing internalKind must read as customer traffic");
+  assert.equal(body.internalCost, 0);
+});
+
+test("backfill relabels legacy arbr-internal records and is idempotent", async () => {
+  await mongoose.connection.collection("request_records").insertOne({
+    requestId: "legacy-internal-1", timestamp: new Date(),
+    application: "arbr-internal", workflow: "auto-classifier", department: "arbr",
+    taskType: "classification", provider: "openai", model: "gpt-4o-mini",
+    totalCost: 0.5, latencyMs: 10, status: "success", knownPricing: true,
+    promptTokens: 1, completionTokens: 1, totalTokens: 2,
+  });
+
+  const first = await backfillInternalKind();
+  assert.equal(first.modifiedCount, 1);
+
+  const doc = await RequestRecord.findOne({ requestId: "legacy-internal-1" }).lean();
+  assert.equal(doc.internalKind, "classifier");
+  assert.equal(doc.application, null, "the fake application must be cleared");
+  assert.equal(doc.taskType, null, "the fake task type must be cleared");
+  assert.equal(doc.internalContext.migratedFrom, "arbr-internal");
+
+  // Second run must be a no-op.
+  const second = await backfillInternalKind();
+  assert.equal(second.modifiedCount, 0);
+
+  const facets = (await agent.get("/api/analytics/facets").expect(200)).body;
+  assert.ok(!facets.applications.includes("arbr-internal"));
+});

--- a/server/test/unit/buildMatch.test.js
+++ b/server/test/unit/buildMatch.test.js
@@ -3,9 +3,30 @@ const { test } = require("node:test");
 const assert = require("node:assert/strict");
 const { buildMatch } = require("../../src/analytics/aggregate");
 
-test("empty filter returns empty match object", () => {
-  assert.deepEqual(buildMatch({}), {});
-  assert.deepEqual(buildMatch(), {});
+// Default-deny: an empty filter is NOT an empty match. Every view that doesn't opt in
+// gets customer traffic only, so Arbr's own internal calls can never be attributed to a
+// customer application by a query that forgot to exclude them.
+test("empty filter excludes internal records by default", () => {
+  assert.deepEqual(buildMatch({}), { internalKind: null });
+  assert.deepEqual(buildMatch(), { internalKind: null });
+});
+
+test("internalScope selects the internal/customer split", () => {
+  assert.deepEqual(buildMatch({ internalScope: "customer" }), { internalKind: null });
+  assert.deepEqual(buildMatch({ internalScope: "internal" }), { internalKind: { $ne: null } });
+  // "all" imposes no constraint — headline totals include real overhead.
+  assert.deepEqual(buildMatch({ internalScope: "all" }), {});
+});
+
+test("internalScope composes with dimension filters", () => {
+  assert.deepEqual(
+    buildMatch({ application: "checkout", internalScope: "all" }),
+    { application: "checkout" }
+  );
+  assert.deepEqual(
+    buildMatch({ application: "checkout" }),
+    { application: "checkout", internalKind: null }
+  );
 });
 
 test("from/to builds timestamp range", () => {


### PR DESCRIPTION
## Summary

Arbr makes LLM calls **for itself** — task classification on the routing path, AI policy generation, eval judging, connection and model tests. Ten call sites; exactly one logged a cost record, and it tagged itself with a synthetic application name, `"arbr-internal"`.

That string appears **once in the entire repo — at the writer. Nothing ever read it.** So Arbr's own overhead flowed into every consumer with no exclusion at all.

This is PR 1 of 4 for #158: fix the pollution first, then instrument the remaining nine sites. Sequencing is deliberate — with one internal writer the damage is bounded, but instrumenting ten sites before the exclusion logic lands would multiply internal volume into views that still can't filter it.

## What was actually broken

| Consumer | Effect |
|---|---|
| `capEngine` | **Scoped caps counted internal spend** — a provider cap could 429-block or force-downgrade a customer's traffic because of Arbr's own classifier |
| `recommend/engine.js` | Arbr generated customer-facing recommendations to downgrade **its own classifier** |
| `facets()` | Unfiltered `distinct("application")` → a fake app card and a selectable filter value |
| `overview()` | Inflated total cost, avg cost/request, cache-hit rate, and latency |
| `distinct("taskType")` ×3 | Arbr's `classification` became a **routable policy task type** |
| `errorAlertMonitor` | Internal failures paged the customer about *their* error rate |
| `eval/dataset.js` | Internal records were dataset-eligible |
| `canaryMonitor` | Internal calls on a baseline model skewed canary comparisons |
| `aiPolicy.simulate` | Re-priced internal tokens as customer traffic |

## Approach

**A real discriminator, not a sentinel.** `RequestRecord.internalKind` (nullable, indexed, nine kinds). The sentinel encoded ownership in a *dimension value*, so every dimension query was wrong by default and had to opt out by name — which is exactly why it was never read. A nullable field inverts the default.

**Default-deny.** `buildMatch` now excludes internal records unless a caller passes `internalScope`. A future view that knows nothing about internal spend gets the correct behaviour for free.

**Counted, not hidden.** Headline `totalCost` still **includes** the overhead — it is real money on the customer's provider key, and a dashboard that hid it would understate their actual bill. It is reported separately as `internalCost` / `internalShare` rather than smeared across applications. Every *other* overview metric is customer-only, so a 9999ms internal call can't distort `avgLatency`.

**Caps stay honest.** A global cap counts the overhead; a scoped application/provider cap does not. `capEngine._matches`, `_shared.capStatus` and `reconcileFromAnalytics` all pass the same flag, so the number on the Budgets page cannot diverge from the number being enforced.

**A migration that isn't load-bearing.** The boot backfill relabels legacy `arbr-internal` records, but exclusion keys on `internalKind` being null — which already matches unmigrated records. A failed migration degrades to *current* behaviour, never worse.

## One thing reviewers should look at

The internal/customer split uses `$ifNull`, not a bare `$eq` against null:

```js
const isCustomer = { $eq: [{ $ifNull: ["$internalKind", null] }, null] };
```

A **query predicate** (`find({ internalKind: null })`) matches documents where the field is absent. An **aggregation expression** does not. Without `$ifNull`, every record written before this field existed would count as neither customer nor internal and silently vanish from the split. A test caught this — `records written before internalKind existed count as customer traffic` inserts through the driver to bypass the schema default, and it failed before the fix.

## Testing

11 new tests. The highest-value one is `global caps count internal spend; scoped caps do not`, since that path can throttle real customer traffic.

Also covered: the headline split reconciles (`totalCost === customerCost + internalCost`) and `avgLatency` ignores internal calls; a dimension-scoped overview reports zero overhead; internal records never appear in `by/application` or facets; the request list hides them unless `?internalScope=internal`; recommendations ignore internal traffic; the backfill is idempotent and clears the fake dimensions.

`buildMatch({})` is no longer `{}` — the existing assertion was updated, and that change is itself the canary that default-deny took effect.

**Suite: 239 tests, 7 failures — identical to the count on `main`** (all environment-dependent, which is why CI is green). Lint unchanged at 0 errors / 20 warnings.

## Follow-ups

- PR 2 — route all ten internal call sites through one accounting wrapper. Expect headline `totalCost` to rise: nine currently-invisible spend sources become real. Worth instrumenting `policy-generation` first and alone — `GET /api/ai-policy` auto-regenerates on page load using the default (possibly premium) model at 1200 max tokens.
- PR 3 — eval `maxRunCostUsd` excludes judge spend, so runs can exceed their stated cap.
- PR 4 — surface the overhead in the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)