### PR TITLE
fix(web): sign-out showed the admin-key form even in oidc/trusted-header mode

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -26,6 +26,14 @@ export default function App() {
   const [authMode, setAuthMode] = useState("adminkey");
   const [user, setUser] = useState(null); // { id, email, role } once authed under oidc/trusted-header
 
+  // Always re-fetch the real auth mode before showing Login — its default value
+  // is only ever correct by accident (e.g. never updated if the very first
+  // refreshStatus() call succeeds, since that path has no reason to touch it).
+  const goToLogin = async () => {
+    try { setAuthMode((await api.authMode()).mode); } catch { /* keep prior value */ }
+    setAuthState("login");
+  };
+
   const refreshStatus = () =>
     api.status()
       .then(async (s) => {
@@ -33,10 +41,9 @@ export default function App() {
         setAuthState("open");
         try { setUser((await api.currentUser()).user); } catch { setUser(null); }
       })
-      .catch(async (e) => {
+      .catch((e) => {
         if (e.status !== 401) return;
-        try { setAuthMode((await api.authMode()).mode); } catch { /* keep default */ }
-        setAuthState("login");
+        return goToLogin();
       });
   useEffect(() => { refreshStatus(); }, []);
 
@@ -46,7 +53,7 @@ export default function App() {
     resetCsrfToken();
     setStatus(null);
     setUser(null);
-    setAuthState("login");
+    await goToLogin();
   };
 
   if (authState === "login") return <Login mode={authMode} onAuthed={refreshStatus} />;


### PR DESCRIPTION
## Summary
Found live on arbr.gyde.ai right after enabling `ARBR_AUTH_MODE=oidc`: signing out redirected to the old `ARBR_ADMIN_KEY` entry form instead of the "Sign in with SSO" button.

Root cause: `authMode` (state driving which `Login.jsx` variant renders) was only ever fetched inside `refreshStatus()`'s 401-catch branch. If the user was already authenticated when the page first loaded — the common case — that branch never ran, so `authMode` stayed at its `useState` default (`"adminkey"`) for the whole session. `signOut()` then jumped straight to `authState="login"` without fetching the real mode, so `Login.jsx` rendered against the stale default regardless of what `ARBR_AUTH_MODE` actually was.

Extracted `goToLogin()` (fetch the real mode, then show the login screen) and used it from both the 401-catch path and `signOut()`, so the mode is always current whenever the login screen is about to render.

## Test plan
- [x] `npm --prefix web run build` succeeds.
- [x] Reproduced against production before the fix: signed in via OIDC, signed out, saw the admin-key form. Not re-verifiable against prod post-fix without another live deploy, but the fix directly addresses the confirmed root cause (dead code path that only updates `authMode` on 401, never on explicit sign-out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)