### PR TITLE
fix(web): drop the sidebar tagline so Users stays visible without scrolling

### DIFF
--- a/web/src/components/Layout.jsx
+++ b/web/src/components/Layout.jsx
@@ -219,10 +219,6 @@ export default function Layout({ status, user, onSignOut, children }) {
             </button>
           )}
         </div>
-
-        <div className="px-5 pb-4 pt-1 font-mono text-[10px] text-gray-400">
-          Human approves · rules override.
-        </div>
       </aside>
 
       <div className="flex min-w-0 flex-1 flex-col">


### PR DESCRIPTION
## Summary
Removes the "Human approves · rules override." tagline from the bottom of the sidebar. It sat below the nav/user-identity/sign-out block, pushing the last nav items (Docs, Users, added by F-04) below the fold on shorter viewports.

## Test plan
- [x] `npm --prefix web run build` succeeds.
- [x] Confirmed no other references to this string in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)