### PR TITLE
docs: mention per-user identity (SSO/RBAC) in README and configuration.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,14 @@ Two credentials, two planes (full details in [DEPLOYMENT.md](DEPLOYMENT.md)):
 - **Admin key** (`ARBR_ADMIN_KEY`) gates the dashboard and the entire admin API. Unset
   (local dev) the dashboard is open and the boot log warns.
 
+For more than one operator, `ARBR_ADMIN_KEY` alone doesn't give individual revocation or
+per-user audit attribution. Set `ARBR_AUTH_MODE=oidc` (any OIDC provider — Okta, Auth0, Google
+Workspace, Keycloak, ...) or `trusted-header` (GCP IAP or a reverse proxy) to add real
+per-user identity: viewer/operator/administrator roles, a **Users** page to manage individual
+access, and an audit log that names the actual person behind every change. The admin key keeps
+working alongside either mode as a break-glass credential for automation. See
+[Accountable admin access](docs/auth.md) for setup.
+
 ---
 
 ## Production deployment

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,8 +17,9 @@ Copy `.env.example` to `.env` and set what you need.
 
 | Variable | Default | Description |
 |---|---|---|
-| `ARBR_ADMIN_KEY` | — (open) | **Required in production.** Master key for the dashboard and admin API (`/api/*`). Unset = open (local dev; boot log warns). |
+| `ARBR_ADMIN_KEY` | — (open) | **Required in production.** Master key for the dashboard and admin API (`/api/*`). Unset = open (local dev; boot log warns). Stays valid as a break-glass credential in every `ARBR_AUTH_MODE` below. |
 | `ARBR_ENCRYPTION_KEY` | dev fallback | **Required in production.** Encrypts dashboard-stored provider keys at rest. Unset = dev fallback key (boot log warns). |
+| `ARBR_AUTH_MODE` | `adminkey` | `adminkey` (shared secret, above) \| `oidc` \| `trusted-header` — adds real per-user identity (roles, a Users page, per-user audit attribution). See [Accountable admin access](/auth) for the full OIDC/IAP/reverse-proxy env vars and setup. |
 
 Generate strong keys:
 


### PR DESCRIPTION
## Summary
F-04 (#163) shipped `ARBR_AUTH_MODE=oidc`/`trusted-header` — real per-user identity, roles, a Users page, per-user audit attribution — but the two most-read overview docs never mentioned it:

- README's **Authentication** section still described only the single shared `ARBR_ADMIN_KEY`.
- `docs/configuration.md`'s env var table had no `ARBR_AUTH_MODE` row at all.

Both now briefly describe the option and point to the existing `docs/auth.md` (already written and linked in the VitePress sidebar as part of F-04) for full OIDC/GCP IAP/reverse-proxy setup — no duplication of that detail here.

## Test plan
- [x] `npm run docs:build` succeeds, no new warnings/dead links.
- [x] Confirmed the `/auth` link path matches this repo's existing internal-link convention (checked against `quickstart.md`'s `/gateway/overview`, `/routing`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)