### PR TITLE
feat(providers): make the LiteLLM connection type discoverable (F-02)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ be the right answer. Arbr is for the next question:
 > and did the rollout deliver the expected result?
 
 - **With LiteLLM:** keep LiteLLM's provider breadth and place Arbr above it for workload
-  analysis, recommendations, evaluation gates, approvals, and measured optimisation.
+  analysis, recommendations, evaluation gates, approvals, and measured optimisation
+  (see [LiteLLM Proxy](docs/providers/litellm.md) to connect one).
 - **Standalone:** use Arbr's native and OpenAI-compatible endpoints when one self-hosted
   deployment for gateway, governance, evaluation, and routing is the simpler architecture.
 - **Human-governed by design:** recommendations remain advisory until accepted; pinned

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -45,7 +45,8 @@ export default defineConfig({
         collapsed: false,
         items: [
           { text: 'Overview', link: '/providers/overview' },
-          { text: 'OpenAI / LiteLLM proxy', link: '/providers/openai' },
+          { text: 'OpenAI', link: '/providers/openai' },
+          { text: 'LiteLLM Proxy', link: '/providers/litellm' },
           { text: 'Anthropic', link: '/providers/anthropic' },
           { text: 'Google Gemini', link: '/providers/gemini' },
           { text: 'Amazon Bedrock', link: '/providers/bedrock' },

--- a/docs/providers/litellm.md
+++ b/docs/providers/litellm.md
@@ -1,0 +1,33 @@
+# LiteLLM Proxy
+
+Connect a self-hosted LiteLLM proxy as a provider. Arbr talks to it over LiteLLM's own
+OpenAI-compatible API — the same interface any OpenAI-compatible client already uses.
+
+Arbr connects to your LiteLLM proxy as an upstream — it doesn't replace LiteLLM's provider
+routing. Keep using LiteLLM for provider breadth; Arbr sits above it for cost tracking,
+recommendations, evaluation gates, and rollout.
+
+## Connect
+
+1. Open **Models**, and find **LiteLLM Proxy** in the sidebar — it's always listed, even
+   before you've connected anything.
+2. Click **Connect** and enter:
+   - **Base URL** — your LiteLLM proxy's address, e.g. `http://localhost:4000`
+   - **API Key** — the proxy's master key
+3. **Test connection** — sends a real chat request through the proxy to confirm it's reachable.
+4. **Discover models** — lists everything your LiteLLM instance currently serves.
+5. **Import** the ones you want — each is added with its exact model ID and, where LiteLLM's
+   catalog has it, real pricing. Explicit import (rather than passing through unknown model
+   strings) is what gives Arbr accurate per-model cost data for recommendations and budgets.
+
+Streaming works the same way as any other provider — requests flow Application → Arbr →
+LiteLLM → the underlying provider, response bytes streamed back unchanged.
+
+## Already using `LITELLM_BASE_URL`?
+
+There's an older, still-supported path: set `OPENAI_BASE_URL` to your LiteLLM instance and
+requests with `provider: "openai"` get forwarded there, accepting any model string LiteLLM
+understands — even ones not in Arbr's registry. That flexibility comes at a cost: models
+never explicitly imported have no pricing data, so cost tracking and recommendations can't see
+them accurately. See [OpenAI](/providers/openai#using-as-a-litellm-proxy) for that setup. The
+dashboard flow above is recommended whenever cost visibility matters.

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -1,8 +1,12 @@
-# OpenAI / LiteLLM proxy
+# OpenAI
 
 Provider ID: `openai`
 
 Connects to OpenAI's chat API — or any OpenAI-compatible endpoint (LiteLLM, vLLM, Ollama, etc.) via `OPENAI_BASE_URL`.
+
+Connecting a LiteLLM proxy specifically? See [LiteLLM Proxy](/providers/litellm) for the
+dashboard-based setup — recommended whenever cost tracking matters, since it imports exact
+model IDs and pricing rather than passing through unregistered model strings.
 
 ## Connect
 

--- a/docs/providers/overview.md
+++ b/docs/providers/overview.md
@@ -44,7 +44,8 @@ The default provider is the one used when `model: "auto"` finds no matching rule
 
 Each provider has its own page with the exact env var, dashboard field names, seeded models, and working examples:
 
-- [OpenAI / LiteLLM proxy](/providers/openai)
+- [OpenAI](/providers/openai)
+- [LiteLLM Proxy](/providers/litellm)
 - [Anthropic](/providers/anthropic)
 - [Google Gemini](/providers/gemini)
 - [Amazon Bedrock](/providers/bedrock)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -46,6 +46,9 @@ OPENAI_API_KEY=sk-...
 
 Environment variables take precedence over dashboard-stored keys. See [Providers](/providers/overview) for all supported providers.
 
+Already running LiteLLM? See [LiteLLM Proxy](/providers/litellm) — it's an upstream Arbr
+connects to, not a replacement.
+
 ## Make your first call
 
 Once a provider is live, hit the gateway:

--- a/web/src/pages/Models.jsx
+++ b/web/src/pages/Models.jsx
@@ -15,6 +15,7 @@ function fmtCtx(n) {
 // a human-readable name in the sidebar. Anything not listed falls back to a
 // simple title-case transform of the provider ID.
 const PROVIDER_LABELS = {
+  "litellm":      "LiteLLM Proxy",
   "openai":       "OpenAI",
   "anthropic":    "Anthropic",
   "gemini":       "Google Gemini",
@@ -825,6 +826,7 @@ function CustomProviderDetail({ provider, models, onRefresh, onDeleted }) {
 // url: pre-filled value (empty = account-specific, user must supply)
 // hint: shown below the Base URL field to guide the user
 const PROVIDER_ENDPOINT_INFO = {
+  "litellm":     { url: "", hint: "e.g. http://localhost:4000 — your self-hosted LiteLLM proxy's base URL; API key is the proxy's master key" },
   "nvidia-nim":  { url: "https://integrate.api.nvidia.com/v1", hint: "Free nvapi- key from build.nvidia.com" },
   "mistral":     { url: "https://api.mistral.ai/v1" },
   "cohere":      { url: "https://api.cohere.ai/v1" },
@@ -893,7 +895,9 @@ function CatalogProviderDetail({ provider, models, onRefresh }) {
             <Badge tone="gray">not connected</Badge>
           </div>
           <p className="mt-1 text-sm text-gray-500">
-            {modelCount} models in catalog · add credentials to route traffic through Arbr.
+            {provider.provider === "litellm"
+              ? "Self-hosted — connect to discover your configured models."
+              : `${modelCount} models in catalog · add credentials to route traffic through Arbr.`}
           </p>
         </div>
         {!connecting && (
@@ -1101,6 +1105,15 @@ function buildProviderList(models, builtinData, customData) {
     if (!known.find((p) => p.provider === c.id)) {
       known.push({ provider: c.id, label: c.label, type: "custom", connected: c.enabled ?? false, ...c });
     }
+  }
+
+  // LiteLLM never earns a catalog card the normal way — unlike Databricks/Snowflake
+  // etc., it never appears as a `litellm_provider` value in its own public pricing
+  // catalog (server/src/litellm/sync.js), since it's the proxy, not a backend. Pin it
+  // so the connection type is discoverable on a fresh install. Self-removes once
+  // connected: customMap["litellm"] becomes truthy and the loop above takes over.
+  if (!customMap["litellm"] && !known.find((p) => p.provider === "litellm")) {
+    known.push({ provider: "litellm", label: providerLabel("litellm"), type: "catalog", connected: false });
   }
 
   return known.sort((a, b) => {


### PR DESCRIPTION
## Summary
F-02 from the design-partner roadmap: "first-class LiteLLM-backed mode" — a dedicated dashboard connection type with a 5-minute setup path.

Turns out the mechanism already exists: the generic custom-provider flow (`server/src/api/routes/customProviders.js` — create, test, discover-models, import-models, all sharing the fully provider-agnostic `proxyOpenAICompat` streaming path) already lets anyone connect a LiteLLM instance by typing its base URL + master key into the existing "+ Add provider" form. LiteLLM's OpenAI-compatible `/v1/models` and `/v1/chat/completions` are exactly what that flow already targets, and model IDs are preserved verbatim on import. **Zero backend changes in this PR.**

The actual gap was discoverability: LiteLLM never earns a browsable "catalog" card in the Models sidebar the way Databricks/Snowflake do — those only show up because LiteLLM's own public pricing catalog (`server/src/litellm/sync.js`) legitimately lists real models under those backend slugs. LiteLLM itself, being the proxy rather than a backend, is never a `litellm_provider` value in that catalog, so it could never earn a card that way — there was nothing to click to discover the feature exists.

## What changed
- `web/src/pages/Models.jsx`: pins a "LiteLLM Proxy" card in the sidebar unconditionally (mirroring the existing pattern for custom-providers-with-no-models-yet), so it's discoverable on a fresh install with zero models. Self-removes once actually connected (`customMap["litellm"]` becomes truthy, the existing loop takes over) — never a duplicate card.
- New `docs/providers/litellm.md`, framed as the recommended path: explicit model import gives Arbr real per-model pricing (unlike the older `OPENAI_BASE_URL` pass-through, which accepts any model string but has no cost visibility for unregistered ones). Includes the "doesn't replace LiteLLM" boundary sentence and a pointer to the still-supported legacy path.
- Cross-linked from `docs/providers/openai.md` (retitled from "OpenAI / LiteLLM proxy" back to "OpenAI" now that LiteLLM has its own page), `docs/providers/overview.md`, `docs/quickstart.md`, `docs/.vitepress/config.mjs` sidebar, and `README.md`'s "Where Arbr fits".

## Test plan
- [x] `npm --prefix web run build` succeeds.
- [x] `npm run docs:build` succeeds, no dead links.
- [x] `npm run test:server:unit` unaffected (213/213 — no server code touched).
- [x] Confirmed local dev DB has zero `litellm` `ModelEntry`/`CustomProvider` rows (clean-slate scenario) and traced the dedup guard against the exact current `buildProviderList()` code for both the pre-connect and post-connect states.
- [ ] Not done: a real browser click-through of the pinned card (no browser automation available in this session) — the underlying connect/test/discover/import flow is unchanged, already-working code reused as-is, so risk is concentrated in the frontend list-building logic reviewed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)