### PR TITLE
docs: fix stale "Settings → Connections" nav references

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ Open **http://localhost:4100** and follow the demo lifecycle:
 1. Inspect workload cost and model usage on **Overview**.
 2. Open **Recommendations → Recompute** to discover an optimisation opportunity.
 3. Inspect its projected savings and evidence requirements.
-4. Add a provider under **Settings → Connections** when you are ready to run a live
-   candidate evaluation and guarded rollout.
+4. Add a provider on the **Models** page when you are ready to run a live candidate
+   evaluation and guarded rollout.
 
 ### Option B — Local (Node + your own MongoDB)
 
@@ -112,10 +112,10 @@ touches user-created entries. To re-seed models only: `npm run seed:models`.
 
 Two ways, and you can mix them:
 
-- **Dashboard** — open **Settings → Connections**, paste a key, and the provider goes live
-  immediately (no restart). Keys are stored **encrypted at rest**, shown only masked, and
-  never returned to the browser. Set `ARBR_ENCRYPTION_KEY` so they're encrypted under your
-  own secret (a dev fallback is used otherwise, with a warning).
+- **Dashboard** — open the **Models** page, paste a key on the provider's card, and the
+  provider goes live immediately (no restart). Keys are stored **encrypted at rest**, shown
+  only masked, and never returned to the browser. Set `ARBR_ENCRYPTION_KEY` so they're
+  encrypted under your own secret (a dev fallback is used otherwise, with a warning).
 - **Environment** — set `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` in `.env`
   (or your secrets manager). **Env vars take precedence** over dashboard-stored keys — the
   recommended path for production.
@@ -230,7 +230,7 @@ Arbr doesn't replace your existing LiteLLM proxy — it sits **in front of it** 
 observability, routing, and governance. Configure LiteLLM as an OpenAI-compatible provider
 in Arbr and route requests to it like any other:
 
-**1. Register LiteLLM in Arbr Settings → Connections**
+**1. Register LiteLLM in Arbr on the Models page**
 
 Add it as an OpenAI-compatible provider. In your `.env` (or dashboard):
 
@@ -333,11 +333,11 @@ provider pricing pages at the time of last update.
 
 ### Adding a new model
 
-**Option A — Dashboard (Settings → Models)**
+**Option A — Dashboard (Models page)**
 
 Click **"+ Add model"** and fill in:
 - **Model ID** — the exact string sent in `"model":` in API requests
-- **Provider** — must match a live provider key in Settings → Connections
+- **Provider** — must match a live provider key on the Models page
 - **Label** — human-readable display name (optional)
 - **Tier** — `light` / `mid` / `premium` (drives guardrail and recommendations)
 - **Input $/1M** and **Output $/1M** — from the provider's pricing page

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,7 +51,7 @@ Environment variables take **precedence** over dashboard-stored keys.
 
 | Variable | Default | Description |
 |---|---|---|
-| `DEFAULT_PROVIDER` | first live provider | Initial default-provider preference. Runtime-selectable in Settings → Connections (takes precedence). |
+| `DEFAULT_PROVIDER` | first live provider | Initial default-provider preference. Runtime-selectable in Settings → General → Default gateway (takes precedence). |
 | `ARBR_DEFAULT_MAX_TOKENS` | `4096` | Completion token ceiling applied when the caller omits `max_tokens`. The gateway also clamps this value to each model's known output ceiling (e.g. 8192 for `nova-lite`), so setting a higher value is safe — it is capped per-model automatically. |
 
 ## Docker / seeding

--- a/docs/deployment-gcp.md
+++ b/docs/deployment-gcp.md
@@ -132,7 +132,7 @@ In GCP Console → **VPC Network → Firewall rules** — confirm there is **no 
 
 1. Open **https://arbr.yourco.com** — the login screen appears
 2. Enter your `ARBR_ADMIN_KEY` value
-3. **Settings → Connections** — add at least one provider key
+3. **Models** page — add at least one provider key
 4. **Settings → API Keys** — create a gateway key per developer app; the one-time reveal shows a ready-to-paste snippet for each developer
 5. Toggle **Require API Keys** ON once every app has a key
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -91,11 +91,11 @@ You can route to **any model on any live provider** without a registry entry. En
 
 ## Adding a model
 
-### Dashboard (Settings → Models)
+### Dashboard (Models page)
 
 Click **+ Add model** and fill in:
 - **Model ID** — the exact string you'll send in `"model":` requests
-- **Provider** — must match a live provider in Settings → Connections
+- **Provider** — must match a live provider on the Models page
 - **Label** — human-readable display name (optional)
 - **Tier** — `light` / `mid` / `premium`
 - **Input $/1M** and **Output $/1M** — from the provider's pricing page

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -11,7 +11,7 @@ ANTHROPIC_API_KEY=sk-ant-...
 ```
 
 ```
-Dashboard: Settings → Connections → Anthropic → API Key
+Dashboard: Models → Anthropic → API Key
 ```
 
 :::

--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -15,7 +15,7 @@ AWS_REGION=us-east-1   # optional, defaults to us-east-1
 ```
 
 ```
-Dashboard: Settings → Connections → Amazon Bedrock → Access Key ID + Secret Key
+Dashboard: Models → Amazon Bedrock → Access Key ID + Secret Key
 ```
 
 :::

--- a/docs/providers/deepseek.md
+++ b/docs/providers/deepseek.md
@@ -13,7 +13,7 @@ DEEPSEEK_API_KEY=...
 ```
 
 ```
-Dashboard: Settings → Connections → DeepSeek → API Key
+Dashboard: Models → DeepSeek → API Key
 ```
 
 :::

--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -11,7 +11,7 @@ GEMINI_API_KEY=...
 ```
 
 ```
-Dashboard: Settings → Connections → Google Gemini → API Key
+Dashboard: Models → Google Gemini → API Key
 ```
 
 :::

--- a/docs/providers/groq.md
+++ b/docs/providers/groq.md
@@ -13,7 +13,7 @@ GROQ_API_KEY=...
 ```
 
 ```
-Dashboard: Settings → Connections → Groq → API Key
+Dashboard: Models → Groq → API Key
 ```
 
 :::

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -13,7 +13,7 @@ MOONSHOT_API_KEY=...
 ```
 
 ```
-Dashboard: Settings → Connections → Moonshot AI (Kimi) → API Key
+Dashboard: Models → Moonshot AI (Kimi) → API Key
 ```
 
 :::

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -19,7 +19,7 @@ OPENAI_API_KEY=sk-...
 ```
 
 ```
-Dashboard: Settings → Connections → OpenAI → API Key
+Dashboard: Models → OpenAI → API Key
 ```
 
 :::

--- a/docs/providers/overview.md
+++ b/docs/providers/overview.md
@@ -18,7 +18,7 @@ Arbr supports 8 providers out of the box. All use the same connection interface 
 ## Two ways to connect
 
 **Dashboard (runtime, no restart):**
-1. Open **Settings → Connections**
+1. Open the **Models** page
 2. Click **Connect** next to a provider
 3. Paste the key — it's stored encrypted immediately and the provider goes live
 
@@ -38,7 +38,7 @@ If no provider keys are configured, Arbr starts in **demo mode**: every dashboar
 
 ## Default provider
 
-The default provider is the one used when `model: "auto"` finds no matching rule. Set it in **Settings → Connections** (runtime) or via the `DEFAULT_PROVIDER` environment variable.
+The default provider is the one used when `model: "auto"` finds no matching rule. Set it in **Settings → General → Default gateway** (runtime) or via the `DEFAULT_PROVIDER` environment variable.
 
 ## Provider pages
 

--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -13,7 +13,7 @@ XAI_API_KEY=...
 ```
 
 ```
-Dashboard: Settings → Connections → xAI (Grok) → API Key
+Dashboard: Models → xAI (Grok) → API Key
 ```
 
 :::

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -33,7 +33,7 @@ Open **http://localhost:4100** — the dashboard loads with seeded demo data. Go
 
 The demo dashboard works without any keys. To make real AI calls:
 
-1. Open **Settings → Connections**
+1. Open the **Models** page
 2. Paste a key for any provider (OpenAI, Anthropic, Gemini, DeepSeek, …)
 3. The provider goes live immediately — no restart
 


### PR DESCRIPTION
## Summary

Provider connections live on the **Models** page today, not under a "Settings → Connections" submenu — that nav structure doesn't exist (confirmed against `web/src/components/Layout.jsx` and `web/src/pages/Models.jsx`). This was a stale reference repeated across 16 spots in README + 13 docs pages.

- Fixed all "Settings → Connections" references to point at the **Models** page (adding/connecting a provider key).
- The one legitimately-Settings-scoped reference (the default-provider picker) now points at **Settings → General → Default gateway**, where that control actually lives (`web/src/pages/Settings.jsx`).

No code changes — docs/README only.

## Test plan

- [x] `grep -rl "Settings → Connections"` across README + docs — empty
- [x] `npm run docs:build` — clean, no dead links

🤖 Generated with [Claude Code](https://claude.com/claude-code)