### PR TITLE
fix(logging): add semantic_cache to routingDecision enum

### DIFF
--- a/server/src/models/RequestRecord.js
+++ b/server/src/models/RequestRecord.js
@@ -97,7 +97,7 @@ const requestRecordSchema = new mongoose.Schema(
     // routing transparency
     routingDecision: {
       type: String,
-      enum: ["passthrough", "explicit", "rule", "auto", "ai", "budget", "cache", "fallback", "canary", "external"],
+      enum: ["passthrough", "explicit", "rule", "auto", "ai", "budget", "cache", "semantic_cache", "fallback", "canary", "external"],
       default: "passthrough",
       index: true,
     },

--- a/server/test/unit/requestRecordEnum.test.js
+++ b/server/test/unit/requestRecordEnum.test.js
@@ -1,0 +1,24 @@
+"use strict";
+// Regression test: handler.js writes routingDecision: "semantic_cache" on every
+// semantic-cache hit (server/src/gateway/handler.js:482,511). That value silently
+// missed the schema enum, so logger.write's try/catch (logger.js:92-98) swallowed a
+// Mongoose validation error on every hit — semantic-cache traffic went unlogged with
+// no error surfaced anywhere. This locks the value into the enum going forward.
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const RequestRecord = require("../../src/models/RequestRecord");
+
+test("routingDecision accepts every value the gateway actually writes", () => {
+  const values = ["passthrough", "explicit", "rule", "auto", "ai", "budget", "cache", "semantic_cache", "fallback", "canary", "external"];
+  for (const routingDecision of values) {
+    const doc = new RequestRecord({ requestId: `t-${routingDecision}`, model: "m", routingDecision });
+    const err = doc.validateSync();
+    assert.equal(err, undefined, `"${routingDecision}" should be a valid routingDecision, got: ${err}`);
+  }
+});
+
+test("routingDecision rejects an unknown value", () => {
+  const doc = new RequestRecord({ requestId: "t-bad", model: "m", routingDecision: "not_a_real_value" });
+  const err = doc.validateSync();
+  assert.ok(err, "an unrecognized routingDecision should fail validation");
+});


### PR DESCRIPTION
## Summary

- `server/src/gateway/handler.js` has written `routingDecision: "semantic_cache"` on every semantic-cache hit since that feature shipped (#155), but `RequestRecord.routingDecision`'s enum never included it.
- Every write for a semantic-cache hit failed Mongoose schema validation. `logger.write`'s try/catch (`server/src/logging/logger.js:92-98`) exists specifically so a logging failure can't break the user-facing response — but it also means this failed silently with no error surfaced anywhere.
- **Production impact:** semantic-cache hits since #155 deployed have zero `RequestRecord` row — invisible to analytics, budget/cap spend tracking, and realised-savings reporting.

Found via a documentation-accuracy audit (checking `docs/gateway/native.md`'s documented `routingDecision` enum against the actual schema) that surfaced this as a real bug, not just a doc gap.

## Fix

Added `"semantic_cache"` to the enum. Added `server/test/unit/requestRecordEnum.test.js`, which asserts every `routingDecision` value the gateway actually writes (grepped from `handler.js`) passes schema validation — this test fails without the fix and passes with it.

## Test plan

- [x] New unit test fails on `main`, passes after the fix
- [x] `MONGOMS_VERSION=7.0.14 npm run test:server` — 281/281 pass
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)