### PR TITLE
docs(providers): fix invalid message examples and litellm/bedrock errors

### DIFF
--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -15,7 +15,7 @@ AWS_REGION=us-east-1   # optional, defaults to us-east-1
 ```
 
 ```
-Dashboard: Settings → Connections → Amazon Bedrock → Access Key ID + Secret Key
+Dashboard: Settings → Connections → Amazon Bedrock → Access Key ID + Secret Access Key + Region
 ```
 
 :::
@@ -31,18 +31,20 @@ The IAM user or role needs `bedrock:InvokeModel` and `bedrock:InvokeModelWithRes
 | `us.amazon.nova-pro-v1:0` | Nova Pro | mid | $0.80 | $3.20 |
 | `us.amazon.nova-lite-v1:0` | Nova Lite | light | $0.06 | $0.24 |
 | `us.amazon.nova-micro-v1:0` | Nova Micro | light | $0.035 | $0.14 |
+| `amazon.nova-premier-v1:0` | Nova Premier | premium | $2.50 | $12.50 |
 
 ### Cross-inference (third-party models on Bedrock)
 
 | Model ID | Label | Tier | Input $/1M | Output $/1M |
 |---|---|---|---|---|
 | `zai.glm-5` | GLM-5 | mid | $1.00 | $3.20 |
-| `moonshotai.kimi-k2.5` | Kimi K2.5 | mid | $0.60 | $3.00 |
+| `moonshotai.kimi-k2.5` | Kimi K2.5 | mid | $0.14 | $0.14 |
 | `qwen.qwen3-next-80b-a3b-instruct` | Qwen3 Next | light | $0.50 | $1.20 |
 | `deepseek.v3.2` | DeepSeek V3.2 | light | $0.62 | $1.85 |
 | `us.deepseek.r1-v1:0` | DeepSeek R1 | premium | $1.35 | $5.40 |
 | `google.gemma-3-12b-it` | Gemma 3 12B | light | $0.09 | $0.29 |
 | `anthropic.claude-3-5-sonnet-20241022-v2:0` | Claude 3.5 Sonnet (Bedrock) | premium | $3.00 | $15.00 |
+| `anthropic.claude-3-7-sonnet-20250219-v1:0` | Claude 3.7 Sonnet (Bedrock) | premium | $3.00 | $15.00 |
 | `meta.llama3-70b-instruct-v1:0` | Llama 3 70B | mid | $0.99 | $0.99 |
 | `meta.llama3-8b-instruct-v1:0` | Llama 3 8B | light | $0.22 | $0.22 |
 
@@ -56,7 +58,7 @@ curl -X POST http://localhost:4100/v1/chat \
   -d '{
     "provider": "bedrock-nova",
     "model": "us.amazon.nova-lite-v1:0",
-    "messages": "Summarise the following meeting notes in 3 bullet points: ..."
+    "messages": [{ "role": "user", "content": "Summarise the following meeting notes in 3 bullet points: ..." }]
   }'
 ```
 
@@ -71,7 +73,7 @@ OPENAI_API_KEY=your-litellm-master-key
 
 ```sh
 curl -X POST http://localhost:4100/v1/chat \
-  -d '{ "provider": "openai", "model": "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0", "messages": "Hi" }'
+  -d '{ "provider": "openai", "model": "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0", "messages": [{ "role": "user", "content": "Hi" }] }'
 ```
 
 See [OpenAI / LiteLLM proxy](/providers/openai) and [Streaming](/gateway/streaming) for the full chain guide.

--- a/docs/providers/deepseek.md
+++ b/docs/providers/deepseek.md
@@ -35,6 +35,6 @@ curl -X POST http://localhost:4100/v1/chat \
   -d '{
     "provider": "deepseek",
     "model": "deepseek-chat",
-    "messages": "Explain REST APIs in one paragraph."
+    "messages": [{ "role": "user", "content": "Explain REST APIs in one paragraph." }]
   }'
 ```

--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -36,7 +36,7 @@ curl -X POST http://localhost:4100/v1/chat \
   -d '{
     "provider": "gemini",
     "model": "gemini-2.5-flash",
-    "messages": "Translate to French: The database is down."
+    "messages": [{ "role": "user", "content": "Translate to French: The database is down." }]
   }'
 ```
 

--- a/docs/providers/groq.md
+++ b/docs/providers/groq.md
@@ -35,7 +35,7 @@ curl -X POST http://localhost:4100/v1/chat \
   -d '{
     "provider": "groq",
     "model": "llama-3.1-8b-instant",
-    "messages": "What is the capital of France?"
+    "messages": [{ "role": "user", "content": "What is the capital of France?" }]
   }'
 ```
 

--- a/docs/providers/litellm.md
+++ b/docs/providers/litellm.md
@@ -23,11 +23,23 @@ recommendations, evaluation gates, and rollout.
 Streaming works the same way as any other provider — requests flow Application → Arbr →
 LiteLLM → the underlying provider, response bytes streamed back unchanged.
 
-## Already using `LITELLM_BASE_URL`?
+## Env-only setup via `LITELLM_BASE_URL`
 
-There's an older, still-supported path: set `OPENAI_BASE_URL` to your LiteLLM instance and
-requests with `provider: "openai"` get forwarded there, accepting any model string LiteLLM
-understands — even ones not in Arbr's registry. That flexibility comes at a cost: models
-never explicitly imported have no pricing data, so cost tracking and recommendations can't see
-them accurately. See [OpenAI](/providers/openai#using-as-a-litellm-proxy) for that setup. The
-dashboard flow above is recommended whenever cost visibility matters.
+There's also a builtin, env-configured path that registers a genuine `litellm` provider in
+Arbr's provider registry, distinct from the dashboard flow above (which creates a
+`CustomProvider` record) and from the unrelated `OPENAI_BASE_URL` redirect trick documented in
+[OpenAI](/providers/openai#using-as-a-litellm-proxy) (which reuses the `openai` provider
+instead of registering a new one):
+
+```env [.env]
+LITELLM_BASE_URL=http://localhost:4000
+LITELLM_API_KEY=your-litellm-master-key
+LITELLM_DEFAULT_MODEL=gpt-4o-mini   # optional
+```
+
+Set these before starting the server — `litellm` is only added to the provider registry at
+boot, and a restart is required to pick up changes. Once set, route requests with
+`"provider": "litellm"`. As with the `OPENAI_BASE_URL` trick, models aren't pre-registered
+with pricing this way — register them via `POST /api/models` with `{ "provider": "litellm" }`
+if you want cost tracking, or use the dashboard **Connect** flow above for automatic pricing
+import instead.

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -36,6 +36,6 @@ curl -X POST http://localhost:4100/v1/chat \
   -d '{
     "provider": "moonshot",
     "model": "moonshot-v1-8k",
-    "messages": "Write a product description for wireless earbuds."
+    "messages": [{ "role": "user", "content": "Write a product description for wireless earbuds." }]
   }'
 ```

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -39,7 +39,7 @@ curl -X POST http://localhost:4100/v1/chat \
   -d '{
     "provider": "openai",
     "model": "gpt-4o-mini",
-    "messages": "Summarise this ticket in two sentences: my order never arrived."
+    "messages": [{ "role": "user", "content": "Summarise this ticket in two sentences: my order never arrived." }]
   }'
 ```
 
@@ -60,7 +60,7 @@ curl -X POST http://localhost:4100/v1/chat \
   -d '{
     "provider": "openai",
     "model": "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
-    "messages": "Hello"
+    "messages": [{ "role": "user", "content": "Hello" }]
   }'
 ```
 

--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -35,6 +35,6 @@ curl -X POST http://localhost:4100/v1/chat \
   -d '{
     "provider": "xai",
     "model": "grok-3-mini",
-    "messages": "What are the key features of a good API?"
+    "messages": [{ "role": "user", "content": "What are the key features of a good API?" }]
   }'
 ```


### PR DESCRIPTION
## Summary

Found via a documentation-accuracy audit comparing provider docs against the actual gateway/config code.

- **9 curl examples across 7 provider docs** (`openai`, `gemini`, `deepseek`, `moonshot`, `xai`, `groq`, `bedrock`) passed `messages` as a plain string. `POST /v1/chat` requires an array of `{role, content}` objects and 400s on a bare string — every one of these examples would fail if actually run. Fixed to the correct array shape. `anthropic.md` already had this right and was used as the reference format.
- `docs/providers/litellm.md`'s `## Already using LITELLM_BASE_URL?` section actually described the unrelated `OPENAI_BASE_URL` redirect trick. Rewrote it to describe the real env-only `LITELLM_BASE_URL`/`LITELLM_API_KEY` builtin provider path (`server/src/config.js`), distinct from both that redirect trick and the dashboard `CustomProvider` flow.
- `docs/providers/bedrock.md`: Kimi K2.5 pricing was off by ~4x ($0.60/$3.00 documented vs. $0.14/$0.14 in `server/src/pricing/table.js`); added two missing model rows (`amazon.nova-premier-v1:0`, `anthropic.claude-3-7-sonnet-20250219-v1:0`); fixed the dashboard field label ("Secret Key" → "Secret Access Key") and added the missing "Region" field mention.

## Test plan

- [x] `npm run docs:build` — clean, no dead links
- [x] Every `messages` fix verified against `server/src/gateway/handler.js`'s array requirement
- [x] Pricing fixes verified against `server/src/pricing/table.js`
- [x] Dashboard field labels verified against `web/src/pages/Models.jsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)