### PR TITLE
docs(gateway): fix stale API reference and streaming claims

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -47,6 +47,26 @@ OpenAI-compatible endpoint. See [OpenAI-compatible endpoint](/gateway/openai-com
 
 Reports metadata for calls that already happened elsewhere (a partner's own gateway, LiteLLM, ...) with no live provider call. See [Observe-only ingestion](/gateway/observe-only-ingestion) for full docs.
 
+### `POST /v1/embeddings`
+
+OpenAI-compatible embeddings endpoint — routes to Gemini or an OpenAI-compat provider based on the model ID, with the same observability as the chat endpoints.
+
+### `GET /v1/models`
+
+Lists models whose provider is currently connected (live), in the OpenAI model-list shape, with a `toolCallSupported` flag per model.
+
+### `GET /v1/task-types`
+
+Lists all supported task types with tier and description.
+
+### `GET /v1/providers`
+
+Lists which providers are currently live and the model IDs each one serves. No credentials exposed.
+
+### `/v1/realtime` (WebSocket)
+
+Realtime voice session proxy. Authenticated the same way as the HTTP gateway (`Authorization: Bearer ab_…`) at the WebSocket upgrade — see `server/src/gateway/wsAuth.js`.
+
 ---
 
 ## Model registry
@@ -86,7 +106,7 @@ Update label, tier, prices, or enabled state. Only the fields you send are chang
 
 ### `DELETE /api/models/:id`
 
-Delete a custom model entry. Returns 403 for built-in models (disable them with `enabled: false` instead).
+Delete a custom model entry. Returns 400 for built-in models (disable them with `enabled: false` instead).
 
 ---
 
@@ -149,32 +169,39 @@ List all gateway API keys (raw key never returned — only metadata).
   "_id": "abc123",
   "prefix": "ab_abc1",
   "application": "support-chat",
-  "rpmLimit": 60,
+  "rpm": 60,
   "enabled": true,
+  "expiresAt": null,
   "createdAt": "2024-01-01T00:00:00.000Z"
 }]
 ```
 
 ### `POST /api/keys`
 
-Create a new gateway key. The raw key is returned **once** — it cannot be retrieved again.
+Create a new gateway key. The raw key is returned **once** — it cannot be retrieved again. `name` and `application` are both required (400 if either is missing).
 
 ```json
-{ "application": "support-chat", "rpmLimit": 60 }
+{ "name": "Support bot", "application": "support-chat", "rpm": 60, "expiresAt": "2026-12-31T00:00:00.000Z" }
 ```
+
+`expiresAt` is optional — omit it (or pass `null`) for a key that never expires. Once it passes, the key is rejected with `401 expired_api_key`.
 
 Response:
 ```json
-{ "key": "ab_abc1…", "prefix": "ab_abc1", "application": "support-chat" }
+{ "key": "ab_abc1…", "prefix": "ab_abc1", "application": "support-chat", "expiresAt": null }
 ```
 
 ### `PATCH /api/keys/:id`
 
-Enable/disable a key or update its RPM limit.
+Enable/disable a key, update its RPM limit, or change `expiresAt`.
 
 ### `DELETE /api/keys/:id`
 
 Revoke a key permanently.
+
+### `POST /api/keys/:id/rotate`
+
+Revoke the key and create a replacement with identical settings (name, application, `rpm`, `allowedModels`, `defaultModel`). Returns the new key's metadata plus its raw secret **once**, same shape as `POST /api/keys`.
 
 ---
 
@@ -208,11 +235,11 @@ Delete a rule.
 
 ## Routing settings
 
-### `GET /api/routing/mode`
+### `GET /api/routing-mode`
 
 Current routing mode: `"off"` | `"guardrail"` | `"ai"`.
 
-### `POST /api/routing/mode`
+### `PUT /api/routing-mode`
 
 Set routing mode.
 
@@ -220,13 +247,15 @@ Set routing mode.
 { "mode": "guardrail" }
 ```
 
-### `GET /api/routing/policy`
+### `GET /api/policy`
 
-The current AI routing policy (task → model map).
+The current automated-routing policy (cost-guardrail knobs: cheap task types, light-model targets, mode).
 
-### `POST /api/routing/policy/regenerate`
+### `PUT /api/policy`
 
-Regenerate the AI routing policy using the default model.
+Update the automated-routing policy.
+
+> This is a different feature from `POST /api/ai-policy/regenerate` (`server/src/api/routes/aiPolicy.js`), which regenerates the AI-routing task→model assignment map using the connected providers. `/api/policy` only holds the guardrail-mode knobs above.
 
 ---
 
@@ -234,13 +263,11 @@ Regenerate the AI routing policy using the default model.
 
 ### `GET /api/analytics/overview`
 
-Aggregated cost, token, and request counts. Includes:
-- `cacheHitRate`, `cachedReadTokens`, `cacheSavingUsd` — prompt-cache observability
-- `totalSaved` — realised savings from model substitutions (requests served cheaper than requested)
+Aggregated cost, token, and request counts. Includes `cacheHitRate`, `cachedReadTokens`, `cacheSavingUsd` — prompt-cache observability. Realised savings from model substitutions is a separate metric, not part of this response — see `GET /api/analytics/realised-savings` below.
 
-### `GET /api/analytics/by-dimension`
+### `GET /api/analytics/by/:dimension`
 
-Breakdown by `application`, `model`, `provider`, `department`, `workflow`, `taskType`, or `user`. Pass `?dimension=user&from=2024-01-01`. Null `userId` groups as `(unattributed)`.
+Breakdown by `application`, `team`, `workflow`, `model`, `provider`, `taskType`, or `user` — `dimension` is a path segment, e.g. `/api/analytics/by/user?from=2024-01-01`. `team` groups by the underlying `department` field. Null `userId` groups as `(unattributed)`.
 
 ### `GET /api/analytics/realised-savings`
 
@@ -275,7 +302,7 @@ Re-run the recommendation engine against recent request records.
 
 Accept a recommendation — creates a disabled routing rule ready to review and enable.
 
-### `DELETE /api/recommendations/:id`
+### `POST /api/recommendations/:id/dismiss`
 
 Dismiss a recommendation.
 
@@ -287,10 +314,30 @@ Dismiss a recommendation.
 
 List all providers with their connection status and default model.
 
-### `POST /api/connections/:providerId`
+### `PUT /api/connections/:provider`
 
 Store or update a provider credential (encrypted at rest).
 
-### `DELETE /api/connections/:providerId`
+### `DELETE /api/connections/:provider`
 
 Remove a stored credential (falls back to env var if set).
+
+### `POST /api/connections/:provider/test`
+
+Make a live test call to the provider using its currently effective credential.
+
+### `PUT /api/default-provider`
+
+Set the default provider used when a request names none.
+
+```json
+{ "provider": "openai" }
+```
+
+### `PUT /api/default-model`
+
+Set the default model (applies to the default provider; used in auto mode).
+
+```json
+{ "model": "gpt-4o-mini" }
+```

--- a/docs/gateway/native.md
+++ b/docs/gateway/native.md
@@ -78,7 +78,7 @@ curl -X POST http://localhost:4100/v1/chat \
 | `model` | Model that actually served the response |
 | `modelRequested` | Model you asked for (`"auto"` when you deferred) |
 | `provider` | Provider that served the response |
-| `routingDecision` | `explicit` \| `passthrough` \| `rule` \| `auto` \| `ai` \| `cache` \| `fallback` \| `budget` |
+| `routingDecision` | `explicit` \| `passthrough` \| `rule` \| `auto` \| `ai` \| `cache` \| `semantic_cache` \| `fallback` \| `budget` \| `canary` \| `external` |
 | `classifiedBy` | How `taskType` was determined: `provided` \| `keyword` \| `ai` |
 | `cacheHit` | Whether the response was served from Arbr's response cache |
 | `usage.inputTokens` | Total prompt tokens (includes any cached tokens) |
@@ -108,11 +108,19 @@ Cost is logged as `$0` until you add a pricing entry for the model in **Settings
 
 ## Error responses
 
+The `error` field is usually a short code, but a couple of cases below put the literal message text there instead — check `message` (or the note) rather than assuming `error` is always machine-matchable.
+
 | Status | `error` field | Meaning |
 |---|---|---|
-| 400 | `invalid_request` | Missing or malformed fields |
-| 401 | `invalid_api_key` | Missing/unknown gateway API key when Require API keys is on |
+| 400 | `"messages array is required"` (literal text, not a code) | `messages` is missing, empty, or not an array |
+| 400 | `prompt_injection_detected` | Request blocked by prompt-injection detection |
+| 401 | `invalid_api_key` | Missing/unknown/revoked gateway API key when Require API keys is on |
+| 401 | `expired_api_key` | The gateway API key's `expiresAt` has passed |
+| 403 | (the model's own message text; also carries `code: "model_not_allowed"`) | Resolved model isn't in the key's `allowedModels` |
+| 422 | `guardrail_violation` | Response blocked by an output guardrail rule |
 | 429 | `budget_exceeded` | A `block` budget cap is breached |
 | 429 | `rate_limited` | Per-key RPM limit hit |
 | 502 | `provider_error` | All providers failed |
 | 503 | `demo_mode` | No provider keys configured |
+| 503 | `maintenance_mode` | Maintenance mode is enabled |
+| 503 | `app_kill_switch` | The calling application's kill-switch is enabled |

--- a/docs/gateway/openai-compat.md
+++ b/docs/gateway/openai-compat.md
@@ -135,6 +135,8 @@ client.chat.completions.create(
 | `extra_body.provider` | `provider` (pass-through routing) |
 | — | `application` → mapped from gateway API key |
 
+`workflow`, `department`, and `userId` aren't OpenAI fields, but Arbr still captures them for attribution: `workflow` from an `x-arbr-workflow` header, `department` from an `x-arbr-department` header or the API key's own `department`, and `userId` from the standard OpenAI `user` field, an `x-arbr-user-id` header, or the API key's `userId` — checked in that order.
+
 ## Chat UI integration (LibreChat, OpenWebUI, etc.)
 
 Set the base URL to `http://your-arbr-host:4100` and your gateway key as the API key. The UI works immediately — every message is now routed, logged, and governed by Arbr.

--- a/docs/gateway/overview.md
+++ b/docs/gateway/overview.md
@@ -8,7 +8,7 @@ Arbr exposes two endpoints — an Arbr-native API and an OpenAI-compatible API. 
 Applications ──▶ POST /v1/chat              ──▶ auth ──▶ route ──▶ invoke ──▶ respond
                  POST /v1/chat/completions        │        │         │
                  (OpenAI-compat, SSE)             │        │         └── provider call (+ fallback)
-                                                  │        └── pinned model? budget? cache? rule? auto?
+                                                  │        └── pinned model? rule? auto? → then budget → then cache?
                                                   └── validate API key, capture metadata
                                                                          │
                                          after response (async): classify · cost · log RequestRecord
@@ -42,17 +42,22 @@ Both the model **requested** and the model **served** are recorded — so realiz
 
 ## Routing precedence
 
-The model a developer explicitly pins is honored as-is. Routing only applies when the app says `"auto"` or omits the model:
+Routing fully decides *which model gets served* before budgets or caching ever run. The model a developer explicitly pins is honored as-is; routing tiers below only apply when the app says `"auto"` or omits the model:
 
 | Priority | What | Tag |
 |---|---|---|
-| 1 | **Budget enforcement** — `block` rejects (429); `downgrade` forces the light model | `budget` |
-| 2 | **Explicit pin** — connected model specified → used as-is, all policies skipped | `explicit` |
-| 3a | **Cache** — identical messages + model → cached response | `cache` |
-| 3b | **Human routing rules** — first matching enabled rule | `rule` |
-| 3c | **Automated routing** — cost guardrail or AI policy (if enabled) | `auto` / `ai` |
-| 3d | **Default** — configured default provider + model | `passthrough` |
-| 4 | **Fallback** — on provider error, try other live providers | `fallback` |
+| 1 | **Explicit pin** — connected model specified → used as-is, all policy tiers below skipped | `explicit` |
+| 2 | **Human routing rules** — first matching enabled rule | `rule` |
+| 3 | **Automated routing** — cost guardrail or AI policy (if enabled) | `auto` / `ai` |
+| 4 | **Default** — configured default provider + model | `passthrough` |
+| 5 | **Canary** — an eval-approved candidate diverts a % of AUTO-routed traffic (never touches an explicit pin) | `canary` |
+
+Once a model is decided, two more steps can still change what happens — but neither is a competing *routing* tier:
+
+- **Budget enforcement** runs next, against the resolved model. A breached `block` cap rejects the request (429); a breached `downgrade` cap forces the provider's light model — this overrides even an explicit pin, since enforcement is meant to hold no matter what was requested.
+- **Response cache lookup runs last**, keyed on the already-decided served model. It's a "skip the provider call" shortcut, not an earlier-ranked tier: if an identical prompt was already answered for that exact model, Arbr returns the cached text instead of invoking the provider (tagged `cache`, or `semantic_cache` for an embedding-similarity match).
+
+**Fallback** — if the provider call itself fails, Arbr retries on another live provider/model (tagged `fallback`).
 
 See [Routing](/routing) for the full breakdown.
 
@@ -60,5 +65,6 @@ See [Routing](/routing) for the full breakdown.
 
 - **Gateway API keys** (`ab_…`) authenticate data-plane calls (`POST /v1/chat*`). Create them in **Settings → API keys**. Anonymous calls are accepted until you flip **Require API keys** on.
 - **Admin key** (`ARBR_ADMIN_KEY`) gates the dashboard and admin API. Unset = open (local dev only).
+- In production, a second identity layer — OIDC login or a trusted reverse-proxy header — can also gate the admin API, independent of whether `ARBR_ADMIN_KEY` is set: either a valid session/header or the admin key grants access. See [Authentication](/auth) for the full setup.
 
 See [Deployment](/deployment) for the two-key model in production.

--- a/docs/gateway/streaming.md
+++ b/docs/gateway/streaming.md
@@ -1,21 +1,31 @@
 # Streaming
 
-Arbr supports real token-by-token SSE streaming through the OpenAI-compatible endpoint. The stream flows all the way from the provider through Arbr to your client with no intermediate buffering.
+Arbr supports real, token-by-token SSE streaming through the OpenAI-compatible endpoint — but only for the **OpenAI-compat provider set**: `openai`, `deepseek`, `moonshot`, `xai`, `groq`, `litellm` (and any custom OpenAI-compatible provider you add). For these, Arbr raw-proxies the upstream response over `fetch`, byte-for-byte, with no LangChain in the path and no intermediate buffering.
+
+> **Native providers don't stream token-by-token.** For `anthropic`, `gemini`, and `bedrock-nova` (without tool calls), Arbr calls LangChain's `invoke()` — not `.stream()` — waits for the *entire* response, and then emits it as three SSE frames back to back: a role-delta, one chunk containing the full response text, and a finish chunk. The response is still valid SSE and still arrives on `stream: true`, but nothing is incremental: the client sees no chunks at all until the whole answer is ready, then gets it all at once. This is deliberate, not a bug — LangChain's `.stream()` filters out thinking tokens per-chunk for thinking models (Gemini 2.5 Pro/Flash, Claude 3.x), which truncates the visible answer; `invoke()` assembles the full response correctly. See `server/src/gateway/openaiCompat.js` for the buffered-emit path. Every Claude/Gemini/Bedrock example below is therefore "streaming" in protocol only, not in delivery.
 
 ## How it works
 
 ```
-Client ──stream:true──▶ Arbr /v1/chat/completions ──▶ LangChain model.stream() ──▶ Provider
-                               │                                                       │
-                               ◀─── SSE chunk (data: {...}) ◀─── token ───────────────┘
+OpenAI-compat providers (openai, deepseek, moonshot, xai, groq, litellm):
+Client ──stream:true──▶ Arbr /v1/chat/completions ──▶ raw fetch proxy ──▶ Provider
+                               │                                              │
+                               ◀─── SSE chunk (data: {...}) ◀─── token ──────┘
+
+Native providers (anthropic, gemini, bedrock-nova w/o tools):
+Client ──stream:true──▶ Arbr /v1/chat/completions ──▶ LangChain model.invoke() ──▶ Provider
+                               │                                                        │
+                               ◀── 3 SSE frames (role, full text, finish) ◀── full response ─┘
 ```
 
-When `stream: true` is set:
+When `stream: true` is set for an **OpenAI-compat** model:
 
 1. Arbr sends the `200 OK` + `Content-Type: text/event-stream` headers **immediately** (before any tokens arrive), so clients and proxies know they're getting an SSE stream
-2. LangChain's `.stream()` makes a real streaming HTTP request to the provider (or LiteLLM)
+2. Arbr opens a raw streaming `fetch` to the upstream (or LiteLLM) and relays the bytes unchanged
 3. Each token chunk is forwarded as a `data: {...}` SSE event
 4. The stream ends with `data: [DONE]`
+
+For a **native** model, the same headers go out immediately, but no data follows until the full `invoke()` response comes back — then Arbr writes all three SSE frames and ends the stream. There is no step 2/3 equivalent: no incremental chunks exist to forward.
 
 ## Basic streaming call
 
@@ -103,7 +113,7 @@ for chunk in stream:
 
 :::
 
-Each token arrives in real-time. Arbr pipes LangChain chunks to the SSE response without buffering — the chain is Application → Arbr → LiteLLM → Bedrock → back with no delays between hops.
+Each token arrives in real-time. Because `provider: "openai"` routes through the OpenAI-compat raw proxy (LiteLLM speaks the OpenAI protocol), there's no LangChain in this path at all — Arbr relays the raw upstream SSE bytes without buffering, so the chain is Application → Arbr → LiteLLM → Bedrock → back with no delays between hops. (Calling a Bedrock model directly through the native `bedrock-nova` provider, instead of via LiteLLM, hits the buffered path described above.)
 
 ## Streaming vs buffered `stream()`
 
@@ -112,9 +122,9 @@ The arbr-client SDKs have a `stream()` / `astream()` method that works different
 | | OpenAI-compat SSE | arbr-client `stream()` |
 |---|---|---|
 | Endpoint | `POST /v1/chat/completions` | `POST /v1/chat` |
-| Token delivery | Real-time, token by token | Buffered — full call, then yields chunks |
+| Token delivery | Real-time, token by token — **only for OpenAI-compat providers** (see the callout above; native providers buffer the full response and emit it as one chunk even here) | Buffered — full call, then yields chunks |
 | Routing metadata | Not in stream chunks | Available on generator return value |
-| Use when | Chat UIs, latency-sensitive streaming | Buffered streaming with routing metadata |
+| Use when | Chat UIs, latency-sensitive streaming (OpenAI-compat models) | Buffered streaming with routing metadata |
 
 ## Nginx configuration for SSE
 


### PR DESCRIPTION
## Summary

Found via a documentation-accuracy audit comparing gateway/API docs against the actual routes and handler code.

- `docs/api-reference.md`: fixed wrong HTTP methods/paths (`routing-mode`/`policy` were documented as different, nonexistent endpoints), analytics `by/:dimension` path shape and dimension list, gateway-keys field name (`rpmLimit`→`rpm`) and missing `expiresAt`/rotate endpoint, a nonexistent recommendation-delete route, connections method/path, and a wrong model-delete status code (403→400). Added several real, mounted `/v1/*` endpoints that were undocumented entirely (embeddings, models, task-types, providers, realtime).
- `docs/gateway/native.md`: corrected the error-response table (the actual 400 body is raw text, not a coded error) and added missing error rows; brought the `routingDecision` enum list in sync with the schema.
- `docs/gateway/overview.md`: fixed the routing-precedence description (cache is a post-decision shortcut, not a competing tier) and added a note on the OIDC/trusted-header identity layer gating the admin API.
- `docs/gateway/streaming.md`: the substantial one — corrected the core claim that all providers stream token-by-token. Only the OpenAI-compat provider set actually streams; native providers (Anthropic/Gemini/Bedrock) buffer the full response and emit it as 3 fixed SSE frames. Added a prominent callout and annotated the comparison table.

**Note:** this PR documents `semantic_cache` as a valid `routingDecision` value in a couple of places, since the gateway already writes it — but the schema enum itself doesn't include it until #174 merges (currently open). Not a blocker, just flagging the dependency so the two land close together.

## Test plan

- [x] `npm run docs:build` — clean, no dead links
- [x] Every route/field fix verified against the actual route files and `RequestRecord.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)