### PR TITLE
docs: fix SDK/client docs, changelog gap, roadmap, and stale claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,18 @@ changelogs under `clients/`.
 - Engineering: server unit + integration test suite and testing strategy (#58), routing
   benchmark harness across LiveBench, Arena-Hard, and SWE-bench (#63), and a gated,
   image-based, rollback-safe deploy pipeline (#61, #74).
+- Security & hardening: CI gates for secret scanning, npm audit, CodeQL, and Trivy image
+  scans (#151); graceful shutdown on SIGTERM/SIGINT (#152); a production profile that
+  fails closed instead of booting without required secrets (#159); metadata-only logging
+  as the production default (#160, #162).
+- Guardrails & caching: built-in and custom per-app prompt injection detection (#154), and
+  a semantic response cache with a configurable similarity threshold (#155).
+- API keys: expiry dates and one-click rotation (#156).
+- Access control: OIDC/RBAC accountable admin access with a per-user audit trail (#163),
+  an allowed-domains setting for OIDC clients shared with other apps (#165), and SSO/RBAC
+  documentation (#170).
+- Providers: LiteLLM connection type is now discoverable from the UI (#171).
+- Ingestion: an observe-only ingestion API (#172).
 
 ### Changed
 - Console reoriented around the five stages (Connect, See, Recommend, Route, Govern)
@@ -46,6 +58,12 @@ changelogs under `clients/`.
   (#39).
 - `/api/about` 500 that broke the deploy seed-version check (#89); `/health` demoMode
   now reflects effective provider state (#147).
+- Audit page blanked on the new object-shaped `AuditLog.actor` (#164).
+- Docker Compose wasn't passing the accountable-admin-access auth env vars through
+  (#166).
+- Arbr's own AI spend was polluting customer analytics views (#167).
+- Sign-out showed the admin-key form even in OIDC/trusted-header mode (#168).
+- Sidebar tagline pushed Users out of view without scrolling (#169).
 
 ## [0.2.0] - 2026-06-29
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,8 +9,9 @@ Want to help? Look for [`good first issue`][gfi] and [`help wanted`][hw] labels.
 ## Themes
 
 ### Hardening & contributor experience
-Make the project safe and easy to contribute to: a linter, a server-side test suite,
-reproducible Docker builds, and orientation docs ([ARCHITECTURE.md](ARCHITECTURE.md)).
+Make the project safe and easy to contribute to: reproducible Docker builds (the current
+Dockerfile floats on `node:20-alpine` and runs `apk upgrade` at build time, so images
+aren't byte-for-byte reproducible across builds).
 
 ### Observability
 A metrics endpoint (Prometheus / OpenTelemetry) for request counts, latency, cost, and

--- a/clients/js/README.md
+++ b/clients/js/README.md
@@ -17,7 +17,6 @@ rules and cost policies, and logs every call with full cost attribution — visi
 
 ```sh
 npm install arbr-client
-# (pre-release: npm install /path/to/arbr-client-0.1.0.tgz)
 ```
 
 ## 60-second quickstart
@@ -130,6 +129,34 @@ for await (const chunk of arbr.stream({ messages: "…" })) {
 
 Use the OpenAI-compat endpoint when you need real token-by-token delivery or are integrating with
 chat UIs. Use `stream()` when you want the routing metadata the OpenAI endpoint doesn't expose.
+
+### `client.embeddings(request) → Promise<EmbeddingsResponse>`
+
+Generate vector embeddings — `POST /v1/embeddings`. OpenAI-compatible wire format, same
+observability as `chat()`.
+
+```js
+const res = await arbr.embeddings({
+  model: "gemini-embedding-001",
+  input: "Summarise the customer's pain points",
+  dimensions: 768,   // must match your vector index size
+});
+const vector = res.data[0].embedding;   // float[] of length 768
+
+// Batch
+const batch = await arbr.embeddings({
+  model: "gemini-embedding-001",
+  input: ["sentence one", "sentence two", "sentence three"],
+});
+const vectors = batch.data.map((d) => d.embedding);   // float[][]
+```
+
+Request fields: `model` (required — an embedding model whose provider is connected, e.g.
+`"gemini-embedding-001"`, `"text-embedding-3-small"`), `input` (required — string or array of
+strings), `dimensions` (optional; truncates output — for Gemini this becomes
+`outputDimensionality`), plus per-call `timeoutMs`, `retries`, `signal`.
+
+Response: `{ object: "list", data: [{ object: "embedding", index, embedding }], model, usage: { prompt_tokens, total_tokens } }`.
 
 ### `client.status() → Promise<StatusResponse>`
 

--- a/clients/js/index.d.ts
+++ b/clients/js/index.d.ts
@@ -25,8 +25,11 @@ export type RoutingDecision =
   | "auto"
   | "ai"
   | "cache"
+  | "semantic_cache"
   | "fallback"
-  | "budget";
+  | "budget"
+  | "canary"
+  | "external";
 
 export type ClassifiedBy = "provided" | "keyword" | "ai";
 

--- a/clients/js/index.d.ts
+++ b/clients/js/index.d.ts
@@ -25,7 +25,8 @@ export type RoutingDecision =
   | "auto"
   | "ai"
   | "cache"
-  | "fallback";
+  | "fallback"
+  | "budget";
 
 export type ClassifiedBy = "provided" | "keyword" | "ai";
 

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -18,7 +18,6 @@ rules and cost policies, and logs every call with full cost attribution — visi
 ```sh
 pip install arbr-client                # core (zero deps)
 pip install "arbr-client[langchain]"   # + the LangChain BaseChatModel adapter
-# (pre-release: pip install /path/to/arbr_client-0.1.0-py3-none-any.whl)
 ```
 
 ## 60-second quickstart
@@ -212,8 +211,8 @@ llm = as_langchain_model(client, workflow="answer-drafting")
 msg = llm.invoke(messages)        # .invoke()/.ainvoke(); AIMessage-shaped result
 ```
 
-Out of gateway scope either way: tool calling / `with_structured_output`, embeddings, and
-token-level streaming — keep those on direct provider SDKs.
+Out of gateway scope either way: tool calling / `with_structured_output` and token-level
+streaming — keep those on direct provider SDKs.
 
 ## Gradual rollout pattern
 

--- a/docs/competitive-analysis-portkey.md
+++ b/docs/competitive-analysis-portkey.md
@@ -107,7 +107,7 @@
 | 2 | Automatic retries | Exponential backoff per provider | Single-fallback retry on failure | Partial |
 | 3 | Provider fallback | ✅ | ✅ Falls back to next live provider | Covered |
 | 4 | Load balancing (multi-instance) | ✅ Weighted, round-robin | ❌ | Missing |
-| 5 | Traffic splitting / canary | ✅ Route X% to model A, Y% to B | ❌ | Missing |
+| 5 | Traffic splitting / canary | ✅ Route X% to model A, Y% to B | ✅ Eval-gated canary rollout with configurable rolloutPct, guardrails, auto-rollback | Covered |
 | 6 | Conditional routing | ✅ | ✅ Rule-based + AI policy routing | Covered |
 | 7 | Request timeouts | ✅ | ✅ | Covered |
 | 8 | Exact-match caching | ✅ | ✅ | Covered |
@@ -224,6 +224,10 @@ The four items formerly listed as Priority 1 have since shipped:
 | **API key expiry + rotation** | `expiresAt` on the ApiKey model, enforced at the gateway; one-click rotation via the admin API. |
 | **Prompt injection detection** | Built-in pattern library plus custom per-app rules, alongside PII masking. |
 
+Separately, **traffic splitting / canary rollout** (previously listed under Priority 2) has
+also shipped: eval-gated canary experiments with configurable `rolloutPct`, guardrails
+(error rate, latency, cost saving, shadow worse-rate), and automatic rollback on breach.
+
 ### Priority 1 — Build Next
 
 Nothing carried over from the prior Priority 1 list — see Priority 2 below for the next
@@ -233,7 +237,6 @@ candidates.
 
 | Feature | Why | Effort |
 |---------|-----|--------|
-| **Traffic splitting / canary** | Route X% of production traffic to model A, Y% to model B. Builds directly on existing routing infrastructure. Core governance use case: "send 5% to GPT-4o-mini, compare cost/quality." | Medium (2 days) |
 | **Cache TTL configuration** | Expose TTL setting in admin UI; reuses existing cache infrastructure. Admins need control over how long cached responses remain valid. | Small (0.5 day) |
 | **Feedback collection** | Thumbs up/down per response, piped back to Arbr. Enables quality-weighted analytics and eventual fine-tuning signal. | Medium (1.5 days) |
 | **Monitoring-only guardrail mode** | Log guardrail violations without blocking requests. Critical for rolling out new guardrail rules without disrupting production. | Small (0.5 day) |
@@ -278,10 +281,9 @@ Portkey wins on breadth — 1600+ providers, 12+ guardrail partners, full prompt
 Arbr's moat is **routing intelligence** — AI-generated policies, cost-aware downgrade, per-app overrides, shadow eval campaigns, realised savings tracking, and benchmark-integrated decision-making. Portkey has none of this. Portkey routes but doesn't optimize; Arbr routes and learns.
 
 **The gap that matters most:**
-Output guardrails and semantic caching have since shipped, closing Arbr's two most visible gaps
-against Portkey. The next-clearest gaps are traffic splitting / canary rollouts and prompt
-versioning + templates (see Priority 2) — those are where Arbr users would see the next
-measurable value.
+Output guardrails, semantic caching, and canary rollouts have since shipped, closing
+Arbr's most visible gaps against Portkey. The next-clearest gap is prompt versioning +
+templates (see Priority 2) — that's where Arbr users would see the next measurable value.
 
 **The positioning play:**
 Arbr shouldn't try to match Portkey's provider breadth (1600 vs. 15 is a losing race). The winning angle is: *intelligent, cost-optimizing, self-hosted gateway for teams that want their AI spend to be data-driven, not just routed.*

--- a/docs/competitive-analysis-portkey.md
+++ b/docs/competitive-analysis-portkey.md
@@ -111,7 +111,7 @@
 | 6 | Conditional routing | ✅ | ✅ Rule-based + AI policy routing | Covered |
 | 7 | Request timeouts | ✅ | ✅ | Covered |
 | 8 | Exact-match caching | ✅ | ✅ | Covered |
-| 9 | Semantic caching | ✅ | ❌ | **Missing** |
+| 9 | Semantic caching | ✅ | ✅ Embedding-similarity cache, configurable threshold | Covered |
 | 10 | Cache TTL configuration | ✅ | ❌ | Missing |
 | 11 | Batching API | ✅ | ❌ | Missing |
 | 12 | Multimodal (vision, audio) | ✅ | ❌ Text/chat only | Missing |
@@ -124,11 +124,11 @@
 | # | Feature | Portkey | Arbr | Gap |
 |---|---------|---------|------|-----|
 | 16 | Input guardrails (pre-model) | ✅ Full suite | ✅ PII masking, max tokens, RPM | Partial |
-| 17 | Output guardrails (post-model) | ✅ | ❌ No post-response validation | **Missing** |
+| 17 | Output guardrails (post-model) | ✅ | ✅ Keyword/regex deny-list checked before returning to caller | Covered |
 | 18 | PII detection and masking | ✅ | ✅ 5 built-in + custom regex patterns | Covered |
 | 19 | JSON schema validation | ✅ | ❌ | **Missing** |
 | 20 | RegEx content filtering | ✅ | ✅ Custom PII patterns cover this partially | Partial |
-| 21 | Prompt injection detection | ✅ | ❌ | **Missing** |
+| 21 | Prompt injection detection | ✅ | ✅ Built-in patterns + custom per-app rules | Covered |
 | 22 | Monitoring-only guardrail mode | ✅ | ❌ | Missing |
 | 23 | Route on guardrail verdict | ✅ Deny / retry / switch | ✅ Fallback routing exists; not guardrail-triggered | Partial |
 | 24 | Custom sync guardrail webhooks | ✅ | ❌ Webhooks are async alerts only | Missing |
@@ -172,8 +172,8 @@
 | 47 | Virtual keys / aliases | ✅ | ✅ API keys with `ab_` prefix display | Covered |
 | 48 | Per-key rate limiting | ✅ | ✅ Per-key RPM sliding windows | Covered |
 | 49 | Per-key cost budgets | ✅ | ✅ Budget caps by dimension | Covered |
-| 50 | Key rotation policy | ✅ | ❌ Keys are permanent until revoked | **Missing** |
-| 51 | Key expiry dates | ✅ | ❌ No `expiresAt` on ApiKey model | **Missing** |
+| 50 | Key rotation policy | ✅ | ✅ One-click rotation (`POST /api/keys/:id/rotate`) | Covered |
+| 51 | Key expiry dates | ✅ | ✅ `expiresAt` on ApiKey, enforced at the gateway | Covered |
 | 52 | Per-key usage analytics | ✅ | ✅ Filter analytics by key/app | Covered |
 
 ### Enterprise / Governance
@@ -213,14 +213,21 @@ These are Arbr's differentiators — the moat that justifies choosing Arbr over 
 
 Prioritized by **Impact** (closes the Portkey gap / competitive) × **Usefulness** (Arbr users actually benefit) × **Effort**.
 
+### Recently Shipped
+
+The four items formerly listed as Priority 1 have since shipped:
+
+| Feature | What landed |
+|---------|-------------|
+| **Output guardrails** | Keyword/regex deny-list checked against response text before it returns to the caller, scoped per app. |
+| **Semantic caching** | Embedding-similarity match against the recent-request cache, with a configurable threshold. |
+| **API key expiry + rotation** | `expiresAt` on the ApiKey model, enforced at the gateway; one-click rotation via the admin API. |
+| **Prompt injection detection** | Built-in pattern library plus custom per-app rules, alongside PII masking. |
+
 ### Priority 1 — Build Next
 
-| Feature | Why | Effort |
-|---------|-----|--------|
-| **Output guardrails** | Validate model responses in-flight before returning to caller. JSON schema, regex deny-list, max length, format checks. Portkey's biggest differentiator in the guardrails space. Arbr currently only masks PII at log time — nothing intercepts bad outputs before they reach the caller. | Medium (2 days) |
-| **Semantic caching** | Embed incoming requests; cosine-similarity match against recent cache (configurable threshold). 10–30% cost reduction for repetitive workloads. Direct cost-saving value prop missing entirely from Arbr. | Medium (2–3 days) |
-| **API key expiry + rotation** | Add `expiresAt` date to ApiKey model; gateway rejects expired keys; admin sees "expires in N days" warning. Table-stakes security compliance feature. Low effort, high credibility. | Small (0.5 day) |
-| **Prompt injection detection** | Heuristic/pattern-based detection of common injection strings in input messages. No external service needed; can be a built-in input guardrail alongside PII masking. | Small (1 day) |
+Nothing carried over from the prior Priority 1 list — see Priority 2 below for the next
+candidates.
 
 ### Priority 2 — Next Quarter
 
@@ -271,7 +278,10 @@ Portkey wins on breadth — 1600+ providers, 12+ guardrail partners, full prompt
 Arbr's moat is **routing intelligence** — AI-generated policies, cost-aware downgrade, per-app overrides, shadow eval campaigns, realised savings tracking, and benchmark-integrated decision-making. Portkey has none of this. Portkey routes but doesn't optimize; Arbr routes and learns.
 
 **The gap that matters most:**
-Output guardrails and semantic caching are the two features where Portkey is most clearly ahead and where Arbr users would see immediate, measurable value. These should be the first additions post-governance overhaul.
+Output guardrails and semantic caching have since shipped, closing Arbr's two most visible gaps
+against Portkey. The next-clearest gaps are traffic splitting / canary rollouts and prompt
+versioning + templates (see Priority 2) — those are where Arbr users would see the next
+measurable value.
 
 **The positioning play:**
 Arbr shouldn't try to match Portkey's provider breadth (1600 vs. 15 is a losing race). The winning angle is: *intelligent, cost-optimizing, self-hosted gateway for teams that want their AI spend to be data-driven, not just routed.*

--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -36,9 +36,9 @@ global config). Register Arbr as an OpenAI-compatible provider:
         "apiKey": "ARBR_API_KEY"
       },
       "models": {
-        "claude-haiku-4-5": { "name": "Claude Haiku 4.5 (via Arbr)" },
-        "gpt-4o":           { "name": "GPT-4o (via Arbr)" },
-        "bedrock-nova-pro": { "name": "Nova Pro (via Arbr)" }
+        "claude-haiku-4-5":          { "name": "Claude Haiku 4.5 (via Arbr)" },
+        "gpt-4o":                    { "name": "GPT-4o (via Arbr)" },
+        "us.amazon.nova-pro-v1:0":   { "name": "Nova Pro (via Arbr)" }
       }
     }
   }

--- a/docs/sdk/js.md
+++ b/docs/sdk/js.md
@@ -135,10 +135,17 @@ if (model && !model.toolCallSupported) {
 
 **`toolCallSupported` rules:**
 
-| Value | Providers / models |
+`true` for `openai`, `deepseek`, `groq`, `xai`, `moonshot`, `litellm` — these proxy tools
+natively. For Bedrock (`provider: "bedrock-nova"`), it's a pattern-matched allowlist against the
+model id, not a blanket Nova-only rule:
+
+| Value | Bedrock models |
 |-------|--------------------|
-| `true` | `openai`, `deepseek`, `groq`, `xai`, `moonshot`, `litellm` (all proxy tools natively); Amazon Nova models on Bedrock (`nova-lite`, `nova-micro`, `nova-pro`) |
-| `false` | `gemini`, `anthropic`, DeepSeek R1 on Bedrock (`us.deepseek.r1-v1:0`), GLM, Llama, and other non-Nova Bedrock models |
+| `true` | Amazon Nova (`nova-lite`, `nova-micro`, `nova-pro`, `nova-premier`), Claude 3.x (Haiku, Sonnet, Opus, 3.5, 3.7), Llama 3.x, Command R / R+, Mistral Large / Small, AI21 Jamba, Writer Palmyra X5, Kimi K2.5 |
+| `false` | Everything else on Bedrock not matched above (e.g. Mistral 7B, Mixtral 8x7B, DeepSeek R1 (`us.deepseek.r1-v1:0`)) |
+
+`false` outright for `gemini` and direct `anthropic` (not proxied through Bedrock's Converse API).
+See `BEDROCK_TOOL_PATTERNS` in `server/src/gateway/capabilities.js` for the exact list.
 
 ## `client.taskTypes() → Promise<TaskTypesResponse>`
 

--- a/docs/sdk/python.md
+++ b/docs/sdk/python.md
@@ -153,10 +153,17 @@ if not models_by_id.get("us.deepseek.r1-v1:0", {}).get("toolCallSupported"):
 
 **`toolCallSupported` rules:**
 
-| Value | Providers / models |
+`True` for `openai`, `deepseek`, `groq`, `xai`, `moonshot`, `litellm` — these proxy tools
+natively. For Bedrock (`provider: "bedrock-nova"`), it's a pattern-matched allowlist against the
+model id, not a blanket Nova-only rule:
+
+| Value | Bedrock models |
 |-------|--------------------|
-| `True` | `openai`, `deepseek`, `groq`, `xai`, `moonshot`, `litellm` (all proxy tools natively); Amazon Nova models on Bedrock (`nova-lite`, `nova-micro`, `nova-pro`) |
-| `False` | `gemini`, `anthropic`, DeepSeek R1 on Bedrock (`us.deepseek.r1-v1:0`), GLM, Llama, and other non-Nova Bedrock models |
+| `True` | Amazon Nova (`nova-lite`, `nova-micro`, `nova-pro`, `nova-premier`), Claude 3.x (Haiku, Sonnet, Opus, 3.5, 3.7), Llama 3.x, Command R / R+, Mistral Large / Small, AI21 Jamba, Writer Palmyra X5, Kimi K2.5 |
+| `False` | Everything else on Bedrock not matched above (e.g. Mistral 7B, Mixtral 8x7B, DeepSeek R1 (`us.deepseek.r1-v1:0`)) |
+
+`False` outright for `gemini` and direct `anthropic` (not proxied through Bedrock's Converse API).
+See `BEDROCK_TOOL_PATTERNS` in `server/src/gateway/capabilities.js` for the exact list.
 
 ## `Client.task_types() → dict`
 


### PR DESCRIPTION
## Summary

Found via a documentation-accuracy audit.

- `clients/python/README.md` wrongly listed `embeddings()` as out of gateway scope — it shipped (both sync and async variants). `clients/js/README.md` was missing an `embeddings()` section entirely despite the method existing in the client and being documented on the docs site. Both fixed; stale `0.1.0` pre-release install comments removed.
- `clients/js/index.d.ts`'s `RoutingDecision` type was missing `budget`, `canary`, `external`, and `semantic_cache` — all real, server-emitted values.
- Both SDK docs (`docs/sdk/js.md`, `docs/sdk/python.md`) claimed Bedrock tool-calling support was Nova-only. It's actually a pattern-matched allowlist (`server/src/gateway/capabilities.js`) covering Nova, Claude 3.x, Llama 3.x, Command R/R+, Mistral, AI21 Jamba, Writer Palmyra X5, and Kimi K2.5 — rewrote both tables to match.
- Fixed a nonexistent model id (`bedrock-nova-pro`) in the OpenCode integration example → the real id (`us.amazon.nova-pro-v1:0`).
- `CHANGELOG.md`'s `[Unreleased]` section was missing ~15 merged PRs (#151–#172) — added, verified against `git log`.
- `ROADMAP.md` listed linter/test-suite/architecture-docs as future work — all three already exist; trimmed to the one genuinely open item (reproducible Docker builds — verified the Dockerfile floats on `node:20-alpine` + runs `apk upgrade` at build time).
- `docs/competitive-analysis-portkey.md`: flipped 5 stale "missing" rows to "covered" for features that have since shipped (semantic caching, output guardrails, prompt injection detection, key rotation, key expiry), and — caught during review, not in the original audit scope — fixed a 6th: the doc still claimed traffic-splitting/canary rollout was missing, but that's real and shipped too (confirmed independently while writing `docs/routing.md`'s new canary section in a sibling PR this session). Updated the closing "gap that matters most" paragraph accordingly.
- `CONTRIBUTING.md` was checked (Node 20+ vs. `package.json`'s `>=18`) — left unchanged; CI (`.github/workflows/ci.yml`) pins Node 20, which is the authoritative dev/CI requirement, so the doc already matches the right number.

## Test plan

- [x] `npm run docs:build` — clean, no dead links
- [x] `CHANGELOG.md` additions verified against `git log --oneline` on `main`
- [x] All capability-table claims verified against `server/src/gateway/capabilities.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)