### PR TITLE
feat(recommend): exportable recommendation evidence report (F-05)

### DIFF
--- a/server/src/api/routes/recommendations.js
+++ b/server/src/api/routes/recommendations.js
@@ -15,6 +15,7 @@ const { sameFamily } = require("../../eval/rubricJudge");
 const { tierForTask } = require("../../classify/classifier");
 const stageBatch = require("../../recommend/stageBatch");
 const outcome = require("../../recommend/outcome");
+const evidenceReport = require("../../recommend/evidenceReport");
 
 const router = express.Router();
 
@@ -48,6 +49,26 @@ router.get("/recommendations/:id/outcome", async (req, res, next) => {
     const rec = await Recommendation.findById(req.params.id).lean();
     if (!rec) return res.status(404).json({ error: "not found" });
     res.json(await outcome.computeOutcome(rec));
+  } catch (e) { next(e); }
+});
+
+// Evidence export (F-05): a durable record of why this substitution was recommended, what
+// evidence backed it, and what happened after rollout. Computed on demand from the same
+// linked records the dashboard already reads — never stored, so it's always regenerable.
+// ?format=markdown for a human-readable download; default is the versioned JSON shape.
+router.get("/recommendations/:id/report", async (req, res, next) => {
+  try {
+    const rec = await Recommendation.findById(req.params.id).lean();
+    if (!rec) return res.status(404).json({ error: "not found" });
+    const report = await evidenceReport.buildReport(rec);
+    const base = rec.dedupeKey || String(rec._id);
+    if (req.query.format === "markdown") {
+      res.setHeader("Content-Type", "text/markdown; charset=utf-8");
+      res.setHeader("Content-Disposition", `attachment; filename="${base}-evidence-report.md"`);
+      return res.send(evidenceReport.renderMarkdown(report));
+    }
+    res.setHeader("Content-Disposition", `attachment; filename="${base}-evidence-report.json"`);
+    res.json(report);
   } catch (e) { next(e); }
 });
 

--- a/server/src/recommend/evidenceReport.js
+++ b/server/src/recommend/evidenceReport.js
@@ -1,0 +1,255 @@
+// F-05: exportable recommendation evidence report. Computed on demand, never stored — same
+// pattern as ./outcome.js — so it's always "regenerated from immutable identifiers and
+// historical records" by construction, no separate snapshot to go stale.
+//
+// Deliberately never touches EvalResult, RequestRecord.messages, or RequestRecord.responseText
+// — every section reads only aggregate/reason-string fields (EvalRun.summary/.failures,
+// RoutingExperiment.lastMetrics) or reuses outcome.js's computeOutcome() verbatim (already
+// metadata-only). This is what makes "no prompt/response text in metadata-only mode" true by
+// construction rather than a runtime filter that could be forgotten later.
+const EvalDataset = require("../models/EvalDataset");
+const EvalRun = require("../models/EvalRun");
+const EvalCampaign = require("../models/EvalCampaign");
+const RoutingExperiment = require("../models/RoutingExperiment");
+const Rule = require("../models/Rule");
+const AuditLog = require("../models/AuditLog");
+const Settings = require("../models/Settings");
+const pricing = require("../pricing/registry");
+const { deriveStage } = require("./stage");
+const { targetCountForRisk } = require("../eval/thresholds");
+const outcome = require("./outcome");
+
+const MASKING_CAVEAT =
+  "Privacy settings shown reflect the CURRENT configuration, not necessarily what was in " +
+  "effect at the time this recommendation's dataset/eval/rollout actually ran — Settings is a " +
+  "live, mutable singleton with no historical snapshot per run.";
+
+async function buildReport(rec) {
+  const [dataset, run, campaign, experiment, rules, settings] = await Promise.all([
+    rec.evalDatasetId ? EvalDataset.findById(rec.evalDatasetId).lean() : null,
+    rec.evalRunId ? EvalRun.findById(rec.evalRunId).lean() : null,
+    rec.shadowCampaignId ? EvalCampaign.findById(rec.shadowCampaignId).lean() : null,
+    rec.experimentId ? RoutingExperiment.findById(rec.experimentId).lean() : null,
+    Rule.find({ sourceRecommendation: rec._id }).lean(),
+    Settings.get(),
+  ]);
+
+  const { stage, label: stageLabel } = deriveStage({ rec, dataset, run, campaign, experiment, rules });
+  const liveRule = rules.find((r) => r.enabled) || null;
+
+  const linkedIds = [
+    rec._id, rec.evalDatasetId, rec.evalRunId, rec.shadowCampaignId, rec.experimentId,
+    ...rules.map((r) => r._id),
+  ].filter(Boolean).map(String);
+  const history = await AuditLog.find({ entityId: { $in: linkedIds } })
+    .sort({ timestamp: 1 }).lean();
+
+  const outcomeResult = liveRule ? await outcome.computeOutcome(rec) : null;
+
+  const caveats = [MASKING_CAVEAT];
+
+  const currentKnown = !!pricing.getModel(rec.currentModel);
+  const suggestedKnown = !!pricing.getModel(rec.suggestedModel);
+  if (!currentKnown) caveats.push(`Unknown pricing for the current model "${rec.currentModel}" — cost figures involving it are incomplete.`);
+  if (!suggestedKnown) caveats.push(`Unknown pricing for the suggested model "${rec.suggestedModel}" — cost figures involving it are incomplete.`);
+
+  if (run && run.summary) {
+    const target = targetCountForRisk(run.riskTier);
+    const judged = Number(run.summary.judged) || 0;
+    if (judged < target) {
+      caveats.push(`Insufficient eval sample: ${judged} judged vs. the ${target}-item target for "${run.riskTier}" risk.`);
+    }
+  }
+
+  if (outcomeResult && outcomeResult.live) {
+    const floor = (experiment && experiment.minSampleForRollback) || 20;
+    if ((outcomeResult.sampleSizes.candidateRequests || 0) < floor) {
+      caveats.push(`Insufficient outcome sample: only ${outcomeResult.sampleSizes.candidateRequests} candidate requests observed since rollout (floor: ${floor}).`);
+    }
+  }
+
+  if (experiment && experiment.status === "rolled_back") {
+    const audited = history.some((h) => h.action === "canary.rollback" && String(h.entityId) === String(experiment._id));
+    if (!audited) {
+      caveats.push("This rollback has no matching audit-log entry — reconstructed from live document state (rollbackReason/lastMetrics), consistent with an automatic guardrail-triggered rollback rather than a manually audited one.");
+    }
+  }
+
+  return {
+    reportVersion: 1,
+    generatedAt: new Date(),
+    recommendation: {
+      id: rec._id, title: rec.title, reason: rec.reason, taskType: rec.taskType,
+      application: rec.application, workflow: rec.workflow, department: rec.department,
+      currentModel: rec.currentModel, currentProvider: rec.currentProvider,
+      suggestedModel: rec.suggestedModel, suggestedProvider: rec.suggestedProvider,
+      dedupeKey: rec.dedupeKey, createdAt: rec.createdAt,
+    },
+    stage, stageLabel,
+    trafficScope: {
+      application: rec.application, workflow: rec.workflow, taskType: rec.taskType,
+      requestCount: rec.requestCount, replayableCount: rec.replayableCount,
+    },
+    models: {
+      current: { id: rec.currentModel, knownPricing: currentKnown },
+      suggested: { id: rec.suggestedModel, knownPricing: suggestedKnown },
+    },
+    privacy: {
+      current: {
+        piiMaskingEnabled: settings.piiMaskingEnabled,
+        captureRequestPayloads: settings.captureRequestPayloads,
+        retentionDays: settings.retentionDays,
+      },
+      dataset: dataset ? { piiMode: dataset.piiMode, riskTier: dataset.riskTier } : null,
+      caveat: MASKING_CAVEAT,
+    },
+    evaluation: run ? {
+      runId: run._id, status: run.status, fidelity: run.fidelity, riskTier: run.riskTier,
+      summary: run.summary, failures: run.failures,
+      sufficientSample: run.summary ? (Number(run.summary.judged) || 0) >= targetCountForRisk(run.riskTier) : null,
+    } : null,
+    shadow: campaign ? {
+      campaignId: campaign._id, status: campaign.status, statusReason: campaign.statusReason,
+      thresholds: campaign.thresholds,
+    } : null,
+    rollout: experiment ? {
+      experimentId: experiment._id, status: experiment.status, rolloutPct: experiment.rolloutPct,
+      guardrails: experiment.guardrails, lastMetrics: experiment.lastMetrics,
+      lastMonitoredAt: experiment.lastMonitoredAt, rollbackReason: experiment.rollbackReason,
+    } : null,
+    history: history.map((h) => ({
+      timestamp: h.timestamp, action: h.action, entity: h.entity, entityId: h.entityId,
+      changes: h.changes, actor: h.actor,
+    })),
+    outcome: outcomeResult,
+    caveats,
+  };
+}
+
+function fmtPct(n) {
+  if (n == null || isNaN(n)) return "n/a";
+  return `${(Number(n) * 100).toFixed(1)}%`;
+}
+function fmtUsd(n) {
+  return `$${(Number(n) || 0).toFixed(2)}`;
+}
+function fmtActor(a) {
+  if (!a) return "unknown";
+  return typeof a === "string" ? a : (a.email || a.id || "unknown");
+}
+
+// Pure — renders the report shape into a human-readable markdown document. No I/O, no DB.
+function renderMarkdown(report) {
+  const r = report.recommendation;
+  const lines = [];
+  lines.push(`# Evidence report: ${r.title || r.taskType || r.id}`);
+  lines.push("");
+  lines.push(`Generated ${new Date(report.generatedAt).toISOString()} · report version ${report.reportVersion}`);
+  lines.push(`Stage: **${report.stageLabel}**`);
+  lines.push("");
+  lines.push("## Recommendation");
+  lines.push(`- Model substitution: \`${r.currentModel}\` → \`${r.suggestedModel}\``);
+  lines.push(`- Task type: ${r.taskType || "—"} · Application: ${r.application || "any"} · Workflow: ${r.workflow || "any"}`);
+  lines.push(`- Reason: ${r.reason}`);
+  lines.push(`- Created: ${new Date(r.createdAt).toISOString()}`);
+  lines.push("");
+
+  lines.push("## Traffic scope");
+  lines.push(`- ${report.trafficScope.requestCount ?? 0} requests observed` +
+    (report.trafficScope.replayableCount != null ? `, ${report.trafficScope.replayableCount} replayable` : ""));
+  lines.push("");
+
+  lines.push("## Models");
+  lines.push(`- Current (\`${report.models.current.id}\`): pricing ${report.models.current.knownPricing ? "known" : "**UNKNOWN**"}`);
+  lines.push(`- Suggested (\`${report.models.suggested.id}\`): pricing ${report.models.suggested.knownPricing ? "known" : "**UNKNOWN**"}`);
+  lines.push("");
+
+  lines.push("## Privacy / masking policy");
+  lines.push(`- PII masking enabled (current): ${report.privacy.current.piiMaskingEnabled}`);
+  lines.push(`- Payload capture enabled (current): ${report.privacy.current.captureRequestPayloads}`);
+  lines.push(`- Retention (days, current): ${report.privacy.current.retentionDays}`);
+  if (report.privacy.dataset) {
+    lines.push(`- Eval dataset masking mode: ${report.privacy.dataset.piiMode} · risk tier: ${report.privacy.dataset.riskTier}`);
+  }
+  lines.push(`- ⚠️ ${report.privacy.caveat}`);
+  lines.push("");
+
+  lines.push("## Evaluation");
+  if (!report.evaluation) {
+    lines.push("No offline eval has been run for this recommendation yet.");
+  } else {
+    const e = report.evaluation;
+    const s = e.summary || {};
+    lines.push(`- Run status: **${e.status}** · fidelity: ${e.fidelity} · risk tier: ${e.riskTier}`);
+    lines.push(`- Judged: ${s.judged ?? "—"} · worse-rate: ${fmtPct(s.worseRate)} · critical-fail-rate: ${fmtPct(s.criticalFailRate)} · format-pass-rate: ${fmtPct(s.formatPassRate)}`);
+    lines.push(`- Cost saving: ${fmtPct(s.costSavingPct)} · avg latency delta: ${fmtPct(s.avgLatencyDeltaPct)}`);
+    lines.push(`- Sample sufficiency: ${e.sufficientSample === false ? "**INSUFFICIENT**" : e.sufficientSample === true ? "sufficient" : "n/a"}`);
+    if (e.failures && e.failures.length) {
+      lines.push("- Failure reasons:");
+      for (const f of e.failures) lines.push(`  - ${f}`);
+    }
+  }
+  lines.push("");
+
+  lines.push("## Shadow evaluation");
+  if (!report.shadow) {
+    lines.push("No shadow campaign was run for this recommendation.");
+  } else {
+    const sh = report.shadow;
+    lines.push(`- Status: **${sh.status}**${sh.statusReason ? ` (${sh.statusReason})` : ""}`);
+    lines.push(`- Safe-to-switch gate: ${sh.thresholds?.minPairs ?? "—"} judged pairs at or below ${fmtPct(sh.thresholds?.maxLossRate)} loss rate.`);
+  }
+  lines.push("");
+
+  lines.push("## Rollout");
+  if (!report.rollout) {
+    lines.push("No canary rollout was run for this recommendation.");
+  } else {
+    const ro = report.rollout;
+    const g = ro.guardrails || {};
+    const m = ro.lastMetrics || {};
+    lines.push(`- Status: **${ro.status}** · rollout: ${ro.rolloutPct}%`);
+    lines.push(`- Guardrails (configured / last observed): error rate +${fmtPct(g.maxErrorRateIncrease)} max / ${m.candErrorRate != null ? fmtPct((m.candErrorRate ?? 0) - (m.baseErrorRate ?? 0)) : "—"}, ` +
+      `latency ${fmtPct(g.maxLatencyRegressionPct)} max / ${fmtPct(m.latencyRegressionPct)}, ` +
+      `cost saving ${fmtPct(g.minCostSavingPct)} min / ${fmtPct(m.costSavingPct)}, ` +
+      `worse-rate ${fmtPct(g.maxWorseRate)} max / ${fmtPct(m.worseRate)}`);
+    if (ro.lastMonitoredAt) lines.push(`- Guardrails last checked: ${new Date(ro.lastMonitoredAt).toISOString()}`);
+    if (ro.status === "rolled_back") lines.push(`- Rollback reason: ${ro.rollbackReason || "—"}`);
+  }
+  lines.push("");
+
+  lines.push("## Approval and rollout history");
+  if (!report.history.length) {
+    lines.push("No audit-log entries found for this recommendation or its linked records.");
+  } else {
+    for (const h of report.history) {
+      lines.push(`- ${new Date(h.timestamp).toISOString()} · **${h.action}** (${h.entity}) by ${fmtActor(h.actor)}` +
+        (h.changes ? ` — ${JSON.stringify(h.changes)}` : ""));
+    }
+  }
+  lines.push("");
+
+  lines.push("## Measured outcome (projected vs. realised)");
+  if (!report.outcome) {
+    lines.push("Not applicable — no enabled rule is routing traffic for this recommendation yet.");
+  } else if (!report.outcome.live) {
+    lines.push(report.outcome.message);
+  } else {
+    const o = report.outcome;
+    lines.push(`- Projected savings: ${fmtUsd(o.projected.savings)} · Realised savings: ${fmtUsd(o.realised.savings)} (${o.realised.substitutedRequests} substituted requests)`);
+    lines.push(`- Latency — candidate: ${o.latency.candidateAvgMs ?? "—"}ms vs. baseline: ${o.latency.baselineAvgMs ?? "—"}ms (${fmtPct(o.latency.deltaPct)})`);
+    lines.push(`- Errors — candidate: ${fmtPct(o.errors.candidateRate)} vs. baseline: ${fmtPct(o.errors.baselineRate)}`);
+    lines.push(`- Sample sizes — candidate: ${o.sampleSizes.candidateRequests} · baseline: ${o.sampleSizes.baselineRequests}`);
+    lines.push(`- Live since: ${new Date(o.liveSince).toISOString()}`);
+    lines.push(`- ⚠️ ${o.caveat}`);
+  }
+  lines.push("");
+
+  lines.push("## Notes and limitations");
+  for (const c of report.caveats) lines.push(`- ${c}`);
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+module.exports = { buildReport, renderMarkdown };

--- a/server/test/integration/evidenceReport.test.js
+++ b/server/test/integration/evidenceReport.test.js
@@ -1,0 +1,184 @@
+"use strict";
+// F-05 (exportable recommendation evidence report): GET /api/recommendations/:id/report.
+process.env.ARBR_ADMIN_KEY = "";
+
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+const mongoose = require("mongoose");
+const express = require("express");
+const supertest = require("supertest");
+
+const Recommendation = require("../../src/models/Recommendation");
+const EvalRun = require("../../src/models/EvalRun");
+const EvalDataset = require("../../src/models/EvalDataset");
+const EvalCampaign = require("../../src/models/EvalCampaign");
+const RoutingExperiment = require("../../src/models/RoutingExperiment");
+const Rule = require("../../src/models/Rule");
+const AuditLog = require("../../src/models/AuditLog");
+const RequestRecord = require("../../src/models/RequestRecord");
+const ModelEntry = require("../../src/models/ModelEntry");
+const registry = require("../../src/pricing/registry");
+const apiRoutes = require("../../src/api/routes");
+
+let mongod, agent;
+const stubAdmin = (req, _res, next) => { req.user = { id: "test", email: "test-admin@test", role: "administrator" }; next(); };
+const buildApp = () => { const a = express(); a.use(express.json()); a.use(stubAdmin); a.use("/api", apiRoutes); return a; };
+
+const makeRec = (over = {}) => Recommendation.create({
+  title: "t", reason: "r", taskType: "classification", currentModel: "gpt-4o",
+  suggestedModel: "gpt-4o-mini", suggestedProvider: "openai", dedupeKey: `k-${Math.random()}`,
+  ...over,
+});
+
+before(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  agent = supertest(buildApp());
+});
+after(async () => { await mongoose.disconnect(); await mongod.stop(); });
+beforeEach(async () => {
+  await Promise.all([
+    Recommendation.deleteMany({}), EvalRun.deleteMany({}), EvalDataset.deleteMany({}),
+    EvalCampaign.deleteMany({}), RoutingExperiment.deleteMany({}), Rule.deleteMany({}),
+    AuditLog.deleteMany({}), RequestRecord.deleteMany({}), ModelEntry.deleteMany({}),
+  ]);
+  await registry.reload();
+});
+
+test("404 for an unknown recommendation id", async () => {
+  const res = await agent.get("/api/recommendations/000000000000000000000000/report");
+  assert.equal(res.status, 404);
+});
+
+test("minimal rec (no links) -> sparse report with every section null, masking caveat still present", async () => {
+  const rec = await makeRec();
+  const res = await agent.get(`/api/recommendations/${rec._id}/report`);
+  assert.equal(res.status, 200);
+  assert.equal(res.body.reportVersion, 1);
+  assert.equal(res.body.evaluation, null);
+  assert.equal(res.body.shadow, null);
+  assert.equal(res.body.rollout, null);
+  assert.equal(res.body.outcome, null);
+  assert.deepEqual(res.body.history, []);
+  assert.ok(res.body.caveats.some((c) => c.includes("CURRENT configuration")));
+});
+
+test("full rec: dataset + run + campaign + experiment + 2 rules + audit rows -> every section populated, history in order", async () => {
+  const rec = await makeRec({ application: "app-1" });
+
+  const dataset = await EvalDataset.create({ recommendationId: rec._id, status: "ready", riskTier: "medium", piiMode: "masked" });
+  const run = await EvalRun.create({
+    recommendationId: rec._id, datasetId: dataset._id, status: "passed", riskTier: "medium",
+    candidateModel: "gpt-4o-mini", baselineModel: "gpt-4o",
+    summary: { judged: 300, worseRate: 0.01 }, failures: [],
+  });
+  const campaign = await EvalCampaign.create({ application: "app-1", candidateModel: "gpt-4o-mini", status: "done" });
+  const experiment = await RoutingExperiment.create({
+    recommendationId: rec._id, scope: { application: "app-1" }, baselineModel: "gpt-4o",
+    candidateModel: "gpt-4o-mini", status: "promoted", rolloutPct: 100,
+  });
+  const rule = await Rule.create({
+    condition: { taskType: "classification" }, target: { provider: "openai", model: "gpt-4o-mini" },
+    enabled: true, sourceRecommendation: rec._id, qualityGate: "passed", note: "promoted",
+  });
+  rec.evalDatasetId = dataset._id; rec.evalRunId = run._id; rec.shadowCampaignId = campaign._id;
+  rec.experimentId = experiment._id; rec.status = "accepted"; await rec.save();
+
+  await AuditLog.create([
+    { timestamp: new Date("2026-01-01T01:00:00Z"), action: "eval.run.start", entity: "evalRun", entityId: String(run._id), changes: { recommendationId: String(rec._id) }, actor: { email: "a@b.com" } },
+    { timestamp: new Date("2026-01-01T02:00:00Z"), action: "canary.promote", entity: "routingExperiment", entityId: String(experiment._id), changes: { ruleId: String(rule._id) }, actor: { email: "a@b.com" } },
+  ]);
+
+  const res = await agent.get(`/api/recommendations/${rec._id}/report`);
+  assert.equal(res.status, 200);
+  assert.equal(res.body.stage, "promoted_live");
+  assert.equal(res.body.evaluation.status, "passed");
+  assert.equal(res.body.shadow.status, "done");
+  assert.equal(res.body.rollout.status, "promoted");
+  assert.equal(res.body.history.length, 2);
+  assert.equal(res.body.history[0].action, "eval.run.start");
+  assert.equal(res.body.history[1].action, "canary.promote");
+});
+
+test("unknown-pricing caveat fires when a model has no ModelEntry", async () => {
+  const rec = await makeRec({ currentModel: "totally-unpriced-model" });
+  const res = await agent.get(`/api/recommendations/${rec._id}/report`);
+  assert.ok(res.body.caveats.some((c) => c.includes("Unknown pricing") && c.includes("totally-unpriced-model")));
+  assert.equal(res.body.models.current.knownPricing, false);
+});
+
+test("insufficient-sample caveat fires when judged is below the risk-tier target", async () => {
+  const rec = await makeRec();
+  const dataset = await EvalDataset.create({ recommendationId: rec._id, status: "ready", riskTier: "high" });
+  const run = await EvalRun.create({
+    recommendationId: rec._id, datasetId: dataset._id, status: "failed", riskTier: "high",
+    summary: { judged: 10 }, failures: ["only 10 items judged, need 500"],
+  });
+  rec.evalDatasetId = dataset._id; rec.evalRunId = run._id; await rec.save();
+
+  const res = await agent.get(`/api/recommendations/${rec._id}/report`);
+  assert.equal(res.body.evaluation.sufficientSample, false);
+  assert.ok(res.body.caveats.some((c) => c.includes("Insufficient eval sample")));
+});
+
+test("auto-rollback caveat: rolled_back status with no matching canary.rollback audit row", async () => {
+  const rec = await makeRec();
+  const experiment = await RoutingExperiment.create({
+    scope: { application: "app-1" }, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini",
+    status: "rolled_back", rollbackReason: "error rate spike", lastMonitoredAt: new Date(),
+  });
+  rec.experimentId = experiment._id; await rec.save();
+  // Deliberately NO AuditLog.create call — simulates canaryMonitor.js's un-audited auto-rollback.
+
+  const res = await agent.get(`/api/recommendations/${rec._id}/report`);
+  assert.equal(res.body.rollout.status, "rolled_back");
+  assert.ok(res.body.caveats.some((c) => c.includes("no matching audit-log entry")));
+});
+
+test("a manually-audited rollback does NOT trigger the unaudited-rollback caveat", async () => {
+  const rec = await makeRec();
+  const experiment = await RoutingExperiment.create({
+    scope: { application: "app-1" }, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini",
+    status: "rolled_back", rollbackReason: "manual call",
+  });
+  rec.experimentId = experiment._id; await rec.save();
+  await AuditLog.create({ action: "canary.rollback", entity: "routingExperiment", entityId: String(experiment._id), changes: { reason: "manual call" }, actor: { email: "a@b.com" } });
+
+  const res = await agent.get(`/api/recommendations/${rec._id}/report`);
+  assert.ok(!res.body.caveats.some((c) => c.includes("no matching audit-log entry")));
+});
+
+test("?format=markdown returns text/markdown with a download disposition", async () => {
+  const rec = await makeRec();
+  const res = await agent.get(`/api/recommendations/${rec._id}/report?format=markdown`);
+  assert.equal(res.status, 200);
+  assert.match(res.headers["content-type"], /text\/markdown/);
+  assert.match(res.headers["content-disposition"], /attachment/);
+  assert.match(res.text, /# Evidence report/);
+});
+
+test("outcome section populates and NO prompt/response text appears anywhere, including with payload capture off", async () => {
+  await ModelEntry.create({ id: "gpt-4o", provider: "openai", inputPer1M: 5, outputPer1M: 15, tier: "premium" });
+  await registry.reload();
+
+  const rec = await makeRec({ application: "app-3" });
+  await Rule.create({
+    condition: { taskType: "classification" }, target: { provider: "openai", model: "gpt-4o-mini" },
+    enabled: true, sourceRecommendation: rec._id, qualityGate: "passed", note: "live",
+  });
+  await RequestRecord.create({
+    requestId: "r3", application: "app-3", taskType: "classification", status: "success",
+    modelRequested: "gpt-4o", model: "gpt-4o-mini", promptTokens: 1_000_000, completionTokens: 1_000_000,
+    totalCost: 1, latencyMs: 200, timestamp: new Date(),
+    messages: null, responseText: null, // payload capture off
+  });
+
+  const res = await agent.get(`/api/recommendations/${rec._id}/report`);
+  assert.equal(res.body.outcome.live, true);
+  assert.equal(res.body.outcome.realised.savings, 19);
+
+  const raw = JSON.stringify(res.body);
+  assert.ok(!raw.includes('"messages"'));
+  assert.ok(!raw.includes('"responseText"'));
+});

--- a/server/test/unit/evidenceReportMarkdown.test.js
+++ b/server/test/unit/evidenceReportMarkdown.test.js
@@ -1,0 +1,100 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { renderMarkdown } = require("../../src/recommend/evidenceReport");
+
+function baseReport(over = {}) {
+  return {
+    reportVersion: 1, generatedAt: new Date("2026-01-01T00:00:00Z"),
+    recommendation: {
+      id: "r1", title: "t", reason: "r", taskType: "classification",
+      currentModel: "gpt-4o", suggestedModel: "gpt-4o-mini", createdAt: new Date("2026-01-01T00:00:00Z"),
+    },
+    stage: "opportunity", stageLabel: "Opportunity",
+    trafficScope: { requestCount: 5, replayableCount: null },
+    models: { current: { id: "gpt-4o", knownPricing: true }, suggested: { id: "gpt-4o-mini", knownPricing: true } },
+    privacy: { current: { piiMaskingEnabled: true, captureRequestPayloads: false, retentionDays: 30 }, dataset: null, caveat: "MASKING_CAVEAT_TEXT" },
+    evaluation: null, shadow: null, rollout: null, history: [], outcome: null,
+    caveats: ["MASKING_CAVEAT_TEXT"],
+    ...over,
+  };
+}
+
+test("sparse report (no links at all) renders every section as a 'not applicable' placeholder", () => {
+  const md = renderMarkdown(baseReport());
+  assert.match(md, /## Evaluation\nNo offline eval has been run/);
+  assert.match(md, /## Shadow evaluation\nNo shadow campaign was run/);
+  assert.match(md, /## Rollout\nNo canary rollout was run/);
+  assert.match(md, /## Approval and rollout history\nNo audit-log entries found/);
+  assert.match(md, /## Measured outcome \(projected vs\. realised\)\nNot applicable/);
+});
+
+test("every caveat string appears verbatim in the rendered output", () => {
+  const report = baseReport({ caveats: ["MASKING_CAVEAT_TEXT", "Unknown pricing for the current model \"gpt-4o\"."] });
+  const md = renderMarkdown(report);
+  for (const c of report.caveats) assert.ok(md.includes(c), `expected caveat to appear verbatim: ${c}`);
+});
+
+test("full report (every section populated) renders evaluation, shadow, rollout, history, and outcome", () => {
+  const report = baseReport({
+    evaluation: {
+      runId: "run1", status: "passed", fidelity: "high", riskTier: "medium",
+      summary: { judged: 300, worseRate: 0.02, criticalFailRate: 0, formatPassRate: 0.99, costSavingPct: 0.3, avgLatencyDeltaPct: -0.1 },
+      failures: [], sufficientSample: true,
+    },
+    shadow: { campaignId: "camp1", status: "active", statusReason: null, thresholds: { minPairs: 50, maxLossRate: 0.1 } },
+    rollout: {
+      experimentId: "exp1", status: "active", rolloutPct: 25,
+      guardrails: { maxErrorRateIncrease: 0.02, maxLatencyRegressionPct: 0.25, minCostSavingPct: 0.1, maxWorseRate: 0.1 },
+      lastMetrics: { candErrorRate: 0.01, baseErrorRate: 0.01, latencyRegressionPct: 0.05, costSavingPct: 0.3, worseRate: 0.02 },
+      lastMonitoredAt: new Date("2026-01-02T00:00:00Z"), rollbackReason: null,
+    },
+    history: [
+      { timestamp: new Date("2026-01-01T01:00:00Z"), action: "recommendation.accept", entity: "recommendation", entityId: "r1", changes: { via: "passed" }, actor: { email: "a@b.com" } },
+      { timestamp: new Date("2026-01-01T02:00:00Z"), action: "canary.create", entity: "routingExperiment", entityId: "exp1", changes: { rolloutPct: 10 }, actor: { email: "a@b.com" } },
+    ],
+    outcome: {
+      live: true, ruleId: "rule1", liveSince: new Date("2026-01-01T00:00:00Z"),
+      projected: { savings: 100 }, realised: { savings: 90, substitutedRequests: 42 },
+      latency: { baselineAvgMs: 500, candidateAvgMs: 400, deltaPct: -0.2 },
+      errors: { baselineRate: 0.01, candidateRate: 0.01 },
+      sampleSizes: { baselineRequests: 100, candidateRequests: 42 },
+      caveat: "OUTCOME_CAVEAT_TEXT",
+    },
+  });
+  const md = renderMarkdown(report);
+  assert.match(md, /passed/);
+  assert.match(md, /active/);
+  assert.match(md, /25%/);
+  assert.match(md, /a@b\.com/);
+  assert.match(md, /\$90\.00/); // realised savings
+  assert.match(md, /OUTCOME_CAVEAT_TEXT/);
+});
+
+test("auto-rollback (rolled_back status, no matching audit history) is a plausible input and renders without crashing", () => {
+  const report = baseReport({
+    rollout: {
+      experimentId: "exp1", status: "rolled_back", rolloutPct: 15,
+      guardrails: {}, lastMetrics: { candErrorRate: 0.2, baseErrorRate: 0.01 },
+      lastMonitoredAt: new Date("2026-01-02T00:00:00Z"), rollbackReason: "error rate spike",
+    },
+    history: [], // no canary.rollback entry — the reconstructed-from-live-state case
+    caveats: ["MASKING_CAVEAT_TEXT", "This rollback has no matching audit-log entry — reconstructed from live document state"],
+  });
+  const md = renderMarkdown(report);
+  assert.match(md, /rolled_back/);
+  assert.match(md, /error rate spike/);
+  assert.ok(md.includes("reconstructed from live document state"));
+});
+
+test("rendered output never contains raw prompt/response payload markers, even if some future caller wired them in by mistake", () => {
+  // Defensive: renderMarkdown must never format messages/responseText fields even if a
+  // malformed report object somehow carried them — it should only ever read the fields this
+  // module itself defines. This asserts the ABSENCE of those substrings in a realistic report.
+  const report = baseReport({
+    evaluation: { runId: "r", status: "failed", fidelity: "masked", riskTier: "low", summary: { judged: 10 }, failures: ["worse-rate 10% exceeds 5%"] },
+  });
+  const md = renderMarkdown(report);
+  assert.ok(!md.includes("\"messages\""));
+  assert.ok(!md.includes("\"responseText\""));
+});

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -114,6 +114,17 @@ export const api = {
   createCanary: (id, body = {}) => req(`/recommendations/${id}/create-canary`, { method: "POST", body: JSON.stringify(body) }),
   overrideRecommendation: (id, body) => req(`/recommendations/${id}/override`, { method: "POST", body: JSON.stringify(body) }),
   recommendationOutcome: (id) => req(`/recommendations/${id}/outcome`),
+  // F-05: evidence export. Server sets Content-Disposition, so a plain anchor click
+  // downloads it directly — same pattern as exportRequests/exportAuditLog.
+  exportRecommendationReport: (id, format = "json") => {
+    const url = `/api/recommendations/${id}/report${format === "markdown" ? "?format=markdown" : ""}`;
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${id}-evidence-report.${format === "markdown" ? "md" : "json"}`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  },
   evalDatasets: (recommendationId) => req(`/evals/datasets${qs({ recommendationId })}`),
   evalDataset: (id) => req(`/evals/datasets/${id}`),
   createEval: (body) => req("/evals", { method: "POST", body: JSON.stringify(body) }),

--- a/web/src/pages/Recommendations.jsx
+++ b/web/src/pages/Recommendations.jsx
@@ -308,6 +308,12 @@ function RecCard({ rec, models, onChange }) {
               </span>
             )}
           </p>
+          <p className="mt-1 text-[11px] text-gray-400">
+            Evidence report:{" "}
+            <button className="text-arbr-accent-600 hover:underline" onClick={() => api.exportRecommendationReport(rec._id, "markdown")}>.md</button>
+            {" · "}
+            <button className="text-arbr-accent-600 hover:underline" onClick={() => api.exportRecommendationReport(rec._id, "json")}>.json</button>
+          </p>
         </div>
         <div className="flex items-center gap-2 shrink-0">
           {isPreRollout ? (


### PR DESCRIPTION
## Summary

**Stacked on #180 (F-03) — base branch is `feat/unified-optimization-workflow`, not `main`.** This reuses `recommend/stage.js` and `recommend/outcome.js` directly, which only exist on that branch. Merge #180 first, then retarget/merge this one into `main`.

First P1 item, unblocked by F-03 (whose own "Depends on" field names it). Stakeholders need a durable record of why a model switch was approved and what happened afterward — today that's scattered across 6 collections with no export.

- **`GET /recommendations/:id/report`** — computed on demand (never stored), so it's always regenerable from immutable identifiers per the roadmap's own acceptance criterion. `?format=markdown` for a human-readable download; JSON by default. Both use `Content-Disposition: attachment`, mirroring the existing CSV export convention (`GET /api/requests/export`, `GET /api/audit/export`).
- **No prompt/response text, by construction.** The report never queries `EvalResult` (where actual judge rationale text lives) or touches `RequestRecord.messages`/`.responseText` — every section reads only aggregate fields (`EvalRun.summary`/`.failures`, `RoutingExperiment.lastMetrics`) or reuses `outcome.js`'s `computeOutcome()` verbatim. This is a structural guarantee, not a runtime filter someone could forget to apply later.
- **Honest about real gaps instead of papering over them:**
  - `canaryMonitor.js`'s auto-rollback writes no audit entry (confirmed by grep — only manual rollback is audited). A rolled-back experiment with no matching `canary.rollback` row is flagged as "reconstructed from live document state," not silently presented as audited fact.
  - `Settings.piiMaskingEnabled`/`captureRequestPayloads` are live mutable singletons with no historical snapshot per eval run. The report states *current* values with an unmissable, always-present caveat rather than fabricating historical accuracy it doesn't have.
  - Unknown model pricing and insufficient eval/outcome sample sizes are checked against real thresholds already established elsewhere (`eval/thresholds.js`'s risk-tier targets, `RoutingExperiment.minSampleForRollback`) and surfaced as caveats, not silently absorbed into the numbers.
- History is one flat chronological audit-log timeline (`AuditLog` queried by an `$in` of every linked id — the recommendation, dataset, run, campaign, experiment, and every sourced rule), not a fabricated "approval vs. rollout" split the underlying data doesn't actually support (audit payload shapes are inconsistent across actions, confirmed by reading every `logAction` call site).

## Test plan

- [x] 5 new unit tests (`renderMarkdown`) — sparse/full/auto-rollback inputs, every caveat appears verbatim, defensive check that output never contains `messages`/`responseText` substrings
- [x] 9 new integration tests — 404, sparse report, full report (every section populated, history in order), unknown-pricing caveat, insufficient-sample caveat, auto-rollback caveat fires / manually-audited rollback doesn't, `?format=markdown` headers, and a payload-capture-off case with an explicit no-leaked-text scan over the full JSON response
- [x] `MONGOMS_VERSION=7.0.14 npm run test:server` — 330/330 pass
- [x] `npm run lint` — clean
- [x] `npm --prefix web run build` — clean
- [x] Manual: booted the server, generated both JSON and Markdown reports for a real recommendation via curl, confirmed download headers and coherent markdown output

🤖 Generated with [Claude Code](https://claude.com/claude-code)