### PR TITLE
feat(demo): end-to-end design-partner demo fixture (F-06)

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -64,6 +64,7 @@ export default defineConfig({
           { text: 'Model registry', link: '/models' },
           { text: 'Budgets & governance', link: '/budgets' },
           { text: 'Accountable admin access', link: '/auth' },
+          { text: 'Design-partner demo fixture', link: '/demo-fixture' },
         ]
       },
       {

--- a/docs/demo-fixture.md
+++ b/docs/demo-fixture.md
@@ -1,0 +1,96 @@
+# Design-partner demo fixture
+
+A scripted, ~10-minute walkthrough of the full optimization lifecycle — opportunity → eval →
+canary → promote → measured outcome, plus a rollback — that runs entirely without a live
+provider key. Use it to show a design partner the complete product story live, not a tour of
+already-finished dashboard pages.
+
+## How this works without any provider key
+
+Two things make this possible:
+
+1. **Traffic, dashboards, and every stage transition already work on stored data alone** — the
+   Recommendations page, canary guardrail table, and evidence report (`GET
+   /recommendations/:id/report`) all render entirely from what's in MongoDB. Nothing needs a
+   live call to be *displayed*.
+2. **"Run eval" is the one step that normally needs a live provider** (to get a candidate
+   model's real response and judge it). For fixture recommendations only, the server detects
+   there's no live provider configured and synthesizes a result instead — using the exact same
+   pass/fail gating logic production uses (`aggregate()` + `evaluateRun()`), just fed synthetic
+   per-item data. The button in the real UI still does something real; it just isn't a live
+   LLM call for this one demo-only case.
+
+## Setup
+
+```sh
+npm run demo:seed
+```
+
+**Prerequisite: payload capture must be on** (it's the dev default — `captureRequestPayloads`
+under Settings → Observability). The seed script writes real, replayable synthetic traffic so
+"Build eval dataset" samples genuine documents through the real dataset builder; if payload
+capture is off, that step will fail with the same message it would for any real recommendation
+("Turn on payload capture..."). This is the only prerequisite — no provider keys needed.
+
+This creates 3 recommendations, visible on the **Recommendations** page:
+
+| Recommendation | Starts at | What it's for |
+|---|---|---|
+| `demo-fixture:happy-path` | Opportunity | Walk live to a passing eval → canary → promote |
+| `demo-fixture:failing-candidate` | Opportunity | Walk live to a failing eval (quality gate blocks it) |
+| `demo-fixture:rollback-scenario` | Canary running, already breaching | Trigger a live manual rollback |
+
+## The script (~10 minutes)
+
+**1. The opportunity (1 min).** Open `demo-fixture:happy-path`. Point out the projected
+savings, the model substitution (`gpt-4o` → `gpt-4o-mini`), and the request count — this
+recommendation was generated from real (synthetic) traffic, the same way a real one would be.
+
+**2. Build the dataset, run the eval (2 min).** Click **Build eval dataset**, then **Run
+offline eval**. The result lands in seconds: **passed**, with a real summary (worse-rate,
+cost saving, latency delta) computed by the same gating logic that decides every real eval.
+
+**3. The failing candidate (2 min).** Switch to `demo-fixture:failing-candidate`. Build its
+dataset, run its eval — this one **fails**, with real reasons (`worse-rate X% exceeds Y%`,
+etc.). This is the point: a bad substitution gets caught before it ever reaches production
+traffic. Try **Accept as rule** without an override — the gate blocks it (`409 eval_required`).
+
+**4. Roll out the passing one (2 min).** Back on `demo-fixture:happy-path`: click **Start
+canary** (or **Accept as rule** first, then **Enable rule** — both paths exist). Watch the
+card's stage badge move to *Canary running* and the guardrail table appear — configured
+threshold beside the live value, with a red/green status dot per row, same as what an active
+canary shows for real traffic.
+
+**5. Promote (1 min).** Click **Promote**. The stage badge moves to *Live*. Expand **Show
+measured outcome** — projected vs. realised savings, latency, and error rate, with the
+approximation caveat always visible (realised savings will read close to $0 here, honestly,
+since no live traffic has actually flowed through the promoted rule during the demo — point
+this out as the real, non-fabricated behavior it is).
+
+**6. Export the evidence (1 min).** Click **Report (.md)** on the same card — a durable,
+regenerable record of the whole journey: scope, eval summary, rollout history, and the outcome
+section, all in one file.
+
+**7. The rollback (1 min).** Switch to `demo-fixture:rollback-scenario` — already at *Canary
+running* with a breached guardrail (a genuinely elevated error rate baked into its seeded
+traffic, not just a fabricated number). Click **Roll back**, enter a reason. The stage moves
+to *Rolled back*, with the reason visible on the card.
+
+## Reset
+
+```sh
+npm run demo:reset
+```
+
+Deletes only documents created by this fixture (every one is tagged `isDemoFixture: true`
+internally) — safe to run in a database that also has real recommendations; nothing else is
+touched. Idempotent: `demo:seed` can be re-run any number of times without duplicating data.
+
+## Troubleshooting
+
+- **"Create a ready eval dataset first" / dataset build fails immediately** — payload capture
+  is off. Enable it under Settings → Observability and re-run `npm run demo:seed`, or just
+  retry the "Build eval dataset" click once it's on (the seeded traffic doesn't need
+  re-creating).
+- **A recommendation from `demo:seed` is missing after `demo:reset`** — that's the point; reset
+  is meant to remove it. Re-run `demo:seed`.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "web:build": "npm --prefix web run build",
     "seed": "node server/src/seed/seed.js",
     "seed:models": "node server/src/seed/seedModels.js",
+    "demo:seed": "node server/scripts/demo-fixture.js seed",
+    "demo:reset": "node server/scripts/demo-fixture.js reset",
     "bootstrap:admin": "node server/scripts/bootstrap-admin.js",
     "setup": "npm install && npm --prefix web install && npm run seed:models && npm run seed",
     "dev": "concurrently -n server,web -c blue,green \"npm run server:dev\" \"npm run web\"",

--- a/server/scripts/demo-fixture.js
+++ b/server/scripts/demo-fixture.js
@@ -1,0 +1,203 @@
+// F-06: design-partner demo fixture. Seeds 3 recommendations that walk the full
+// opportunity → dataset → eval → canary → promote → outcome journey (plus a rollback), all
+// without a live provider key — see server/src/eval/demoFixture.js for how "Run eval" stays
+// live-clickable without one. See docs/demo-fixture.md for the facilitator script.
+//
+//   node server/scripts/demo-fixture.js seed
+//   node server/scripts/demo-fixture.js reset
+//
+// Idempotent (upsert by a fixed dedupeKey per fixture row) and scoped: reset only ever
+// deletes documents with isDemoFixture:true, never touching real data in the same database.
+require("dotenv").config();
+const mongoose = require("mongoose");
+const { config } = require("../src/config");
+const RequestRecord = require("../src/models/RequestRecord");
+const Recommendation = require("../src/models/Recommendation");
+const EvalDataset = require("../src/models/EvalDataset");
+const EvalRun = require("../src/models/EvalRun");
+const EvalResult = require("../src/models/EvalResult");
+const RoutingExperiment = require("../src/models/RoutingExperiment");
+const Rule = require("../src/models/Rule");
+const ModelEntry = require("../src/models/ModelEntry");
+const registry = require("../src/pricing/registry");
+const demoFixture = require("../src/eval/demoFixture");
+
+// Deterministic PRNG — same LCG shape as seed/seed.js's rnd(), independent instance so this
+// script's output never depends on seed.js having run first (or at all).
+let _s = 7331;
+function rnd() { _s = (_s * 1103515245 + 12345) & 0x7fffffff; return _s / 0x7fffffff; }
+
+const CURRENT_MODEL = "gpt-4o";
+const SUGGESTED_MODEL = "gpt-4o-mini";
+const APPLICATION = "demo-support-chat";
+const TASK_TYPE = "classification";
+const TICKETS = [
+  "My card was declined at checkout, can you help?",
+  "I was charged twice for the same order.",
+  "How do I reset my password?",
+  "The app crashes when I open the settings page.",
+  "Can I get a refund for my last purchase?",
+  "My shipment says delivered but I never received it.",
+  "I want to cancel my subscription.",
+  "The discount code isn't applying at checkout.",
+];
+
+// Registered directly rather than via registry.init()'s LiteLLM sync — the demo must not
+// depend on outbound network access. Real OpenAI list prices, so F-05's evidence report
+// never flags "unknown pricing" for this fixture.
+async function ensureModelsRegistered() {
+  await ModelEntry.findOneAndUpdate(
+    { id: CURRENT_MODEL },
+    { id: CURRENT_MODEL, provider: "openai", inputPer1M: 5, outputPer1M: 15, tier: "premium", enabled: true },
+    { upsert: true }
+  );
+  await ModelEntry.findOneAndUpdate(
+    { id: SUGGESTED_MODEL },
+    { id: SUGGESTED_MODEL, provider: "openai", inputPer1M: 0.15, outputPer1M: 0.6, tier: "light", enabled: true },
+    { upsert: true }
+  );
+  await registry.reload();
+}
+
+// Real, replayable traffic (status:success, single-shot messages+responseText) so the demo's
+// "Build eval dataset" step samples genuine documents through the real eval/dataset.js builder
+// — no short-circuit needed there, only "Run eval" needs one (see eval/demoFixture.js).
+async function seedTraffic(dedupeKeyPrefix, count = 60) {
+  const rows = [];
+  for (let i = 0; i < count; i++) {
+    const ticket = TICKETS[i % TICKETS.length];
+    rows.push({
+      requestId: `${dedupeKeyPrefix}-req-${i}`,
+      timestamp: new Date(Date.now() - rnd() * 6 * 86400000),
+      application: APPLICATION, taskType: TASK_TYPE,
+      provider: "openai", model: CURRENT_MODEL, modelRequested: CURRENT_MODEL,
+      promptTokens: 60 + Math.floor(rnd() * 40), completionTokens: 10 + Math.floor(rnd() * 15),
+      totalCost: 0.008 + rnd() * 0.004, latencyMs: 500 + rnd() * 300,
+      status: "success", cacheHit: false, knownPricing: true, routingDecision: "passthrough",
+      classifiedBy: "provided",
+      messages: [{ role: "user", content: ticket }],
+      responseText: "support response category",
+      isDemoFixture: true,
+    });
+  }
+  await RequestRecord.deleteMany({ requestId: { $regex: `^${dedupeKeyPrefix}-req-` } });
+  await RequestRecord.insertMany(rows);
+}
+
+async function upsertRec(dedupeKey, over) {
+  return Recommendation.findOneAndUpdate(
+    { dedupeKey },
+    {
+      dedupeKey, type: "premium_model_overuse", taskType: TASK_TYPE,
+      application: APPLICATION, currentModel: CURRENT_MODEL, currentProvider: "openai",
+      suggestedModel: SUGGESTED_MODEL, suggestedProvider: "openai",
+      isDemoFixture: true,
+      ...over,
+    },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
+}
+
+async function seed() {
+  await ensureModelsRegistered();
+
+  // Rec 1 — the happy path: opportunity → live eval (synthesizes to PASS) → canary → promote.
+  await seedTraffic("demo-fixture-happy", 60);
+  await upsertRec("demo-fixture:happy-path", {
+    title: "Demo: classification on gpt-4o", reason: "Cheap task type running on a premium model.",
+    requestCount: 60, currentCost: 0.72, projectedCost: 0.05, projectedSavings: 0.67,
+    replayableCount: 60, status: "pending", evalStatus: "not_started", demoFixtureOutcome: "pass",
+  });
+
+  // Rec 2 — the failing candidate: same shape, synthesizes to FAIL when "Run eval" is clicked.
+  await seedTraffic("demo-fixture-failing", 60);
+  await upsertRec("demo-fixture:failing-candidate", {
+    title: "Demo: classification on gpt-4o (candidate fails quality gate)",
+    reason: "Cheap task type running on a premium model.",
+    requestCount: 60, currentCost: 0.72, projectedCost: 0.05, projectedSavings: 0.67,
+    replayableCount: 60, status: "pending", evalStatus: "not_started", demoFixtureOutcome: "fail",
+  });
+
+  // Rec 3 — pre-baked at canary_running with a genuine guardrail breach, for a live MANUAL
+  // rollback demo (no live provider needed for that route either).
+  const rec3 = await upsertRec("demo-fixture:rollback-scenario", {
+    title: "Demo: classification on gpt-4o (canary in progress, breaching)",
+    reason: "Cheap task type running on a premium model.",
+    requestCount: 60, currentCost: 0.72, projectedCost: 0.05, projectedSavings: 0.67,
+    replayableCount: 60, status: "accepted", acceptedVia: "passed", evalStatus: "passed",
+  });
+  if (!rec3.evalDatasetId) {
+    const dataset = await EvalDataset.create({
+      name: "demo rollback dataset", recommendationId: rec3._id,
+      scope: { application: APPLICATION, taskType: TASK_TYPE, currentModel: CURRENT_MODEL },
+      baselineModel: CURRENT_MODEL, candidateModel: SUGGESTED_MODEL,
+      riskTier: "low", piiMode: "masked", itemCount: 200, status: "ready",
+      isDemoFixture: true,
+    });
+    // synthesizeRun() sets rec.evalStatus/qualitySummary/evalRunId and saves; evalDatasetId is
+    // this route's own responsibility (mirrors create-eval-dataset's split of duties).
+    const run = await demoFixture.synthesizeRun({ rec: rec3, dataset, outcome: "pass" });
+    rec3.evalDatasetId = dataset._id;
+
+    const rule = await Rule.create({
+      condition: { taskType: TASK_TYPE, application: APPLICATION },
+      target: { provider: "openai", model: SUGGESTED_MODEL },
+      enabled: false, sourceRecommendation: rec3._id, qualityGate: "passed",
+      note: rec3.title, isDemoFixture: true,
+    });
+
+    const experiment = await RoutingExperiment.create({
+      evalRunId: run._id, recommendationId: rec3._id,
+      scope: { application: APPLICATION, taskType: TASK_TYPE },
+      baselineModel: CURRENT_MODEL, candidateModel: SUGGESTED_MODEL, candidateProvider: "openai",
+      rolloutPct: 20, status: "active", metricsWindowMinutes: 60,
+      guardrails: { maxErrorRateIncrease: 0.02, maxLatencyRegressionPct: 0.25, maxWorseRate: 0.1, minCostSavingPct: 0.1 },
+      lastMonitoredAt: new Date(),
+      lastMetrics: { candTotal: 30, candErrorRate: 0.35, baseErrorRate: 0.02, latencyRegressionPct: 0.4, costSavingPct: 0.9, worseRate: null },
+      isDemoFixture: true,
+    });
+    rec3.experimentId = experiment._id;
+    await rec3.save();
+    await demoFixture.synthesizeCanaryBreach({ rec: rec3, experiment });
+    void rule; // created for the dashboard's disabled-rule linkage; not read further here
+  }
+
+  console.log("Demo fixture seeded:");
+  console.log("  - demo-fixture:happy-path        (opportunity — walk it live to a passing eval + canary)");
+  console.log("  - demo-fixture:failing-candidate (opportunity — walk it live to a failing eval)");
+  console.log("  - demo-fixture:rollback-scenario (canary_running, guardrail already breached — click Roll back)");
+  console.log("Reset with: node server/scripts/demo-fixture.js reset");
+}
+
+async function reset() {
+  const [rr, rec, ds, run, res, exp, rule] = await Promise.all([
+    RequestRecord.deleteMany({ isDemoFixture: true }),
+    Recommendation.deleteMany({ isDemoFixture: true }),
+    EvalDataset.deleteMany({ isDemoFixture: true }),
+    EvalRun.deleteMany({ isDemoFixture: true }),
+    EvalResult.deleteMany({ isDemoFixture: true }),
+    RoutingExperiment.deleteMany({ isDemoFixture: true }),
+    Rule.deleteMany({ isDemoFixture: true }),
+  ]);
+  console.log("Demo fixture reset — deleted:", {
+    requestRecords: rr.deletedCount, recommendations: rec.deletedCount, evalDatasets: ds.deletedCount,
+    evalRuns: run.deletedCount, evalResults: res.deletedCount, routingExperiments: exp.deletedCount, rules: rule.deletedCount,
+  });
+}
+
+async function main() {
+  const mode = process.argv[2];
+  if (mode !== "seed" && mode !== "reset") {
+    console.error("Usage: node server/scripts/demo-fixture.js seed|reset");
+    process.exit(1);
+  }
+  await mongoose.connect(config.mongoUri);
+  if (mode === "seed") await seed();
+  else await reset();
+  await mongoose.disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/server/src/api/routes/experiments.js
+++ b/server/src/api/routes/experiments.js
@@ -99,6 +99,7 @@ router.post("/recommendations/:id/create-canary", requireRole("operator"), async
       guardrails: sanitizeGuardrails(b.guardrails),
       metricsWindowMinutes: b.metricsWindowMinutes != null ? Math.max(5, Number(b.metricsWindowMinutes)) : 60,
       status: "active", createdBy: "console", approvedBy: req.user.email,
+      isDemoFixture: rec.isDemoFixture || false, // F-06: propagate fixture ownership forward
     });
     rec.experimentId = exp._id;
     await rec.save();

--- a/server/src/api/routes/recommendations.js
+++ b/server/src/api/routes/recommendations.js
@@ -16,6 +16,8 @@ const { tierForTask } = require("../../classify/classifier");
 const stageBatch = require("../../recommend/stageBatch");
 const outcome = require("../../recommend/outcome");
 const evidenceReport = require("../../recommend/evidenceReport");
+const demoFixture = require("../../eval/demoFixture");
+const connections = require("../../providers/connections");
 
 const router = express.Router();
 
@@ -112,6 +114,7 @@ router.post("/recommendations/:id/accept", requireRole("operator"), async (req, 
       sourceRecommendation: rec._id,
       qualityGate,
       note: rec.title,
+      isDemoFixture: rec.isDemoFixture || false, // F-06: propagate fixture ownership forward
     });
     rec.status = "accepted";
     rec.acceptedVia = qualityGate;
@@ -136,6 +139,10 @@ router.post("/recommendations/:id/create-eval-dataset", requireRole("operator"),
       rec.evalDatasetId = dataset._id;
       if (rec.evalStatus === "not_started") rec.evalStatus = "dataset_ready";
       await rec.save();
+      if (rec.isDemoFixture) { // F-06: propagate fixture ownership forward
+        dataset.isDemoFixture = true;
+        await dataset.save();
+      }
     }
     setImmediate(() => logAction("eval.dataset.create", "evalDataset", String(dataset._id), { recommendationId: String(rec._id), itemCount: dataset.itemCount, status: dataset.status }, req.user));
     if (dataset.status === "failed") {
@@ -160,6 +167,16 @@ router.post("/recommendations/:id/run-eval", requireRole("operator"), async (req
     if (!dataset || dataset.status !== "ready") {
       return res.status(409).json({ error: "no_dataset", message: "Create a ready eval dataset first (POST .../create-eval-dataset)." });
     }
+
+    // F-06 demo fixture: no live provider is configured, and this dataset is fixture-owned —
+    // synthesize a result with the same pure aggregate()/evaluateRun() functions production
+    // uses, instead of calling the live replay pipeline (which would 503). See eval/demoFixture.js.
+    if (dataset.isDemoFixture && (await connections.effective()).demoMode) {
+      const run = await demoFixture.synthesizeRun({ rec, dataset, outcome: rec.demoFixtureOutcome || "pass" });
+      setImmediate(() => logAction("eval.run.start", "evalRun", String(run._id), { recommendationId: String(rec._id), candidateModel: dataset.candidateModel, demoFixture: true }, req.user));
+      return res.status(run.status === "failed" ? 422 : 202).json(run);
+    }
+
     if (dataset.piiMode === "metadata_only") {
       return res.status(422).json({ error: "not_replayable", message: "A metadata_only dataset has no prompts to replay. Use a masked dataset." });
     }

--- a/server/src/eval/demoFixture.js
+++ b/server/src/eval/demoFixture.js
@@ -1,0 +1,128 @@
+// F-06: design-partner demo fixture support. `eval/replay.js`'s executeRun() and
+// `eval/shadow.js`'s maybeShadowEval() both hard-call a live provider with no existing mock
+// seam (confirmed by reading every call site — no env var, no Settings flag, no injected
+// client). Rather than build a fixture-provider adapter, this module synthesizes a candidate
+// eval run WITHOUT ever calling startRun/executeRun/judgeItem: it generates synthetic per-item
+// entries and feeds them through the SAME pure, tested functions production uses —
+// replay.js's aggregate() and thresholds.js's evaluateRun() — so the demo's pass/fail outcome
+// is genuinely computed by production gating logic, not hand-faked numbers.
+const EvalRun = require("../models/EvalRun");
+const EvalResult = require("../models/EvalResult");
+const RequestRecord = require("../models/RequestRecord");
+const { aggregate } = require("./replay");
+const { riskForTier, targetCountForRisk, defaultThresholds, evaluateRun } = require("./thresholds");
+const { tierForTask } = require("../classify/classifier");
+
+// A fresh, deterministic PRNG per call (not a shared module-level counter) — two calls with
+// the same seed always produce the same sequence, regardless of what else has run in-process.
+// Same LCG shape as seed/seed.js's `rnd()`.
+function makeRng(seed) {
+  let s = seed;
+  return () => {
+    s = (s * 1103515245 + 12345) & 0x7fffffff;
+    return s / 0x7fffffff;
+  };
+}
+
+// Builds `count` synthetic per-item entries shaped for replay.js's aggregate(). `outcome`
+// controls the bias: "pass" clears every risk-tiered threshold; "fail" breaches worse-rate and
+// critical-fail-rate specifically (thresholds.js's defaultThresholds always requires BOTH to
+// hold, so this is enough to fail regardless of the other stats).
+function syntheticEntries(count, outcome, seed = 42) {
+  const rnd = makeRng(seed);
+  const entries = [];
+  for (let i = 0; i < count; i++) {
+    const productionCost = 0.01 + rnd() * 0.002;
+    const productionLatencyMs = 400 + rnd() * 100;
+    let verdict, criticalFailure, formatPass, candidateCost, candidateLatencyMs;
+    if (outcome === "fail") {
+      verdict = rnd() < 0.4 ? "worse" : rnd() < 0.7 ? "equal" : "better";
+      criticalFailure = rnd() < 0.05;
+      formatPass = rnd() > 0.1;
+      candidateCost = productionCost * (0.5 + rnd() * 0.3);
+      candidateLatencyMs = productionLatencyMs * (0.9 + rnd() * 0.3);
+    } else {
+      verdict = rnd() < 0.003 ? "worse" : rnd() < 0.5 ? "equal" : "better";
+      criticalFailure = false;
+      formatPass = true;
+      candidateCost = productionCost * (0.2 + rnd() * 0.1);
+      candidateLatencyMs = productionLatencyMs * (0.7 + rnd() * 0.1);
+    }
+    entries.push({
+      verdict, criticalFailure, formatPass, candidateCost, candidateLatencyMs,
+      productionCost, productionLatencyMs, errored: false,
+    });
+  }
+  return entries;
+}
+
+// Synthesizes a complete, internally-consistent EvalRun + matching EvalResult batch for a
+// demo-fixture recommendation, without ever calling a live provider. `outcome`: "pass"|"fail".
+async function synthesizeRun({ rec, dataset, outcome }) {
+  const risk = riskForTier(tierForTask(rec.taskType)) || "medium";
+  const count = targetCountForRisk(risk);
+  const entries = syntheticEntries(count, outcome);
+  const summary = aggregate(entries);
+  const thresholds = defaultThresholds(risk);
+  const { passed, failures } = evaluateRun(summary, thresholds);
+
+  const run = await EvalRun.create({
+    recommendationId: rec._id, datasetId: dataset._id,
+    application: rec.application, workflow: rec.workflow, taskType: rec.taskType,
+    baselineModel: rec.currentModel, candidateModel: rec.suggestedModel,
+    riskTier: risk, fidelity: "high",
+    status: passed ? "passed" : "failed",
+    thresholds, summary, failures,
+    isDemoFixture: true,
+  });
+
+  await EvalResult.insertMany(entries.map((e, i) => ({
+    evalRunId: run._id, requestId: `demo-${rec._id}-${i}`,
+    baselineModel: rec.currentModel, candidateModel: rec.suggestedModel,
+    candidateResponse: null, // never real text — this is a synthetic demo item
+    candidateCost: e.candidateCost, candidateLatencyMs: e.candidateLatencyMs,
+    judgeVerdict: e.verdict, criticalFailure: e.criticalFailure, formatPass: e.formatPass,
+    judgeRationale: "Synthetic demo item — no live judge call was made.",
+    isDemoFixture: true,
+  })));
+
+  // Mirror eval/replay.js's finish() side effect on the recommendation exactly, so the
+  // dashboard/accept-gate see the same terminal state a real (async) run would leave behind.
+  rec.evalStatus = run.status;
+  rec.qualitySummary = summary;
+  rec.evalRunId = run._id;
+  await rec.save();
+
+  return run;
+}
+
+// Writes real RequestRecord traffic tagged routingDecision:"canary" (and a matching baseline
+// batch) with a deliberately elevated candidate failure rate, so canaryMonitor.js's real
+// metricsFor() aggregation would independently reach the same breach conclusion if it ever
+// runs against this data — not a disconnected fabricated lastMetrics number.
+async function synthesizeCanaryBreach({ rec, experiment, count = 30 }) {
+  const rnd = makeRng(99);
+  const now = Date.now();
+  const windowMs = (experiment.metricsWindowMinutes || 60) * 60 * 1000;
+  const rows = [];
+  for (let i = 0; i < count; i++) {
+    const ts = new Date(now - rnd() * windowMs * 0.8);
+    rows.push({
+      requestId: `demo-canary-${rec._id}-${i}`, application: rec.application, taskType: rec.taskType,
+      provider: rec.suggestedProvider, model: rec.suggestedModel, modelRequested: rec.currentModel,
+      status: rnd() < 0.35 ? "failure" : "success", // well above a healthy baseline error rate
+      latencyMs: 600 + rnd() * 400, routingDecision: "canary", timestamp: ts,
+      totalCost: 0.003 + rnd() * 0.001, isDemoFixture: true,
+    });
+    rows.push({
+      requestId: `demo-baseline-${rec._id}-${i}`, application: rec.application, taskType: rec.taskType,
+      provider: rec.currentProvider, model: rec.currentModel, modelRequested: rec.currentModel,
+      status: rnd() < 0.02 ? "failure" : "success", // normal baseline error rate
+      latencyMs: 400 + rnd() * 100, routingDecision: "auto", timestamp: ts,
+      totalCost: 0.01 + rnd() * 0.002, isDemoFixture: true,
+    });
+  }
+  await RequestRecord.insertMany(rows);
+}
+
+module.exports = { synthesizeRun, synthesizeCanaryBreach, syntheticEntries };

--- a/server/src/models/EvalDataset.js
+++ b/server/src/models/EvalDataset.js
@@ -36,6 +36,9 @@ const evalDatasetSchema = new mongoose.Schema(
     status: { type: String, enum: ["creating", "ready", "failed"], default: "creating", index: true },
     error: { type: String, default: null },
     createdBy: { type: String, default: "console" },
+    // F-06: propagated from a fixture-owned Recommendation at create-eval-dataset time. Lets
+    // the run-eval demo short-circuit recognize this dataset, and `npm run demo:reset` clean it up.
+    isDemoFixture: { type: Boolean, default: false, index: true },
   },
   { collection: "eval_datasets", timestamps: true }
 );

--- a/server/src/models/EvalResult.js
+++ b/server/src/models/EvalResult.js
@@ -34,6 +34,10 @@ const evalResultSchema = new mongoose.Schema(
     abFlipped: { type: Boolean, default: false }, // candidate was placed in slot A this item
     judgeRationale: { type: String, default: null },
     error: { type: String, default: null }, // candidate/judge call error, if any
+
+    // F-06: true for synthetic per-item rows generated alongside a demo-fixture EvalRun.
+    // candidateResponse/judgeRationale are never real text for these — see eval/demoFixture.js.
+    isDemoFixture: { type: Boolean, default: false, index: true },
   },
   { collection: "eval_results", timestamps: true }
 );

--- a/server/src/models/EvalRun.js
+++ b/server/src/models/EvalRun.js
@@ -45,6 +45,11 @@ const evalRunSchema = new mongoose.Schema(
     createdBy: { type: String, default: "console" },
     startedAt: { type: Date, default: null },
     completedAt: { type: Date, default: null },
+
+    // F-06: true only for runs synthesized by the demo-fixture's run-eval short-circuit
+    // (eval/demoFixture.js) — summary/failures are genuinely computed by the real aggregate()/
+    // evaluateRun() pure functions from synthetic entries, never a live replay.
+    isDemoFixture: { type: Boolean, default: false, index: true },
   },
   { collection: "eval_runs", timestamps: true }
 );

--- a/server/src/models/Recommendation.js
+++ b/server/src/models/Recommendation.js
@@ -64,6 +64,15 @@ const recommendationSchema = new mongoose.Schema(
 
     // Stable key so re-running the engine updates instead of duplicating.
     dedupeKey: { type: String, unique: true, index: true },
+
+    // F-06 design-partner demo fixture. isDemoFixture marks this rec (and its RequestRecord
+    // traffic) as fixture-owned, so `npm run demo:reset` can find and delete it safely.
+    // demoFixtureOutcome is the seed-time intent read by the run-eval route's demo
+    // short-circuit (server/src/eval/demoFixture.js) — "pass"/"fail" decide which deterministic
+    // eval outcome to synthesize when this rec's dataset is eval'd with no live provider
+    // configured. null for every real recommendation; never read outside the fixture path.
+    isDemoFixture: { type: Boolean, default: false, index: true },
+    demoFixtureOutcome: { type: String, enum: ["pass", "fail", null], default: null },
   },
   { collection: "recommendations", timestamps: true }
 );

--- a/server/src/models/RequestRecord.js
+++ b/server/src/models/RequestRecord.js
@@ -84,6 +84,12 @@ const requestRecordSchema = new mongoose.Schema(
     // (see server/src/api/routes/ingest.js) so two integrations can't collide.
     externalRequestId: { type: String, default: null },
 
+    // true = written by the design-partner demo fixture (F-06), never real traffic. Lets
+    // `npm run demo:reset` find and delete every fixture-owned document with one scoped
+    // query, without touching anything real. Default false = today's behavior for every
+    // existing and future non-fixture record; no backfill needed.
+    isDemoFixture: { type: Boolean, default: false, index: true },
+
     // performance + outcome
     latencyMs: { type: Number, default: 0 },
     // Time-to-first-token in ms (streaming proxy path only; null for non-streaming or LangChain path).

--- a/server/src/models/RoutingExperiment.js
+++ b/server/src/models/RoutingExperiment.js
@@ -38,6 +38,9 @@ const routingExperimentSchema = new mongoose.Schema(
     rollbackReason: { type: String, default: null },
     lastMonitoredAt: { type: Date, default: null },
     lastMetrics: { type: mongoose.Schema.Types.Mixed, default: null },
+
+    // F-06: propagated from a fixture-owned Recommendation at create-canary time.
+    isDemoFixture: { type: Boolean, default: false, index: true },
   },
   { collection: "routing_experiments", timestamps: true }
 );

--- a/server/src/models/Rule.js
+++ b/server/src/models/Rule.js
@@ -28,6 +28,8 @@ const ruleSchema = new mongoose.Schema(
       index: true,
     },
     note: { type: String, default: "" },
+    // F-06: propagated from a fixture-owned Recommendation at accept time.
+    isDemoFixture: { type: Boolean, default: false, index: true },
   },
   { collection: "rules", timestamps: true }
 );

--- a/server/test/integration/demoFixture.test.js
+++ b/server/test/integration/demoFixture.test.js
@@ -1,0 +1,157 @@
+"use strict";
+// F-06 (design-partner demo fixture): the run-eval demo short-circuit, and the seed/reset
+// script's idempotency + scoped-deletion guarantees.
+process.env.ARBR_ADMIN_KEY = "";
+
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+const mongoose = require("mongoose");
+const express = require("express");
+const supertest = require("supertest");
+
+const Recommendation = require("../../src/models/Recommendation");
+const EvalDataset = require("../../src/models/EvalDataset");
+const EvalRun = require("../../src/models/EvalRun");
+const EvalResult = require("../../src/models/EvalResult");
+const RoutingExperiment = require("../../src/models/RoutingExperiment");
+const Rule = require("../../src/models/Rule");
+const RequestRecord = require("../../src/models/RequestRecord");
+const apiRoutes = require("../../src/api/routes");
+
+let mongod, agent;
+const stubAdmin = (req, _res, next) => { req.user = { id: "test", email: "test-admin@test", role: "administrator" }; next(); };
+const buildApp = () => { const a = express(); a.use(express.json()); a.use(stubAdmin); a.use("/api", apiRoutes); return a; };
+
+const makeRec = (over = {}) => Recommendation.create({
+  title: "t", reason: "r", taskType: "classification", currentModel: "gpt-4o",
+  suggestedModel: "gpt-4o-mini", suggestedProvider: "openai", dedupeKey: `k-${Math.random()}`,
+  ...over,
+});
+
+before(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  agent = supertest(buildApp());
+});
+after(async () => { await mongoose.disconnect(); await mongod.stop(); });
+beforeEach(async () => {
+  await Promise.all([
+    Recommendation.deleteMany({}), EvalDataset.deleteMany({}), EvalRun.deleteMany({}),
+    EvalResult.deleteMany({}), RoutingExperiment.deleteMany({}), Rule.deleteMany({}),
+    RequestRecord.deleteMany({}),
+  ]);
+});
+
+test("run-eval short-circuits for a demo-fixture dataset with no live provider, never reaching the real replay pipeline", async () => {
+  const rec = await makeRec({ isDemoFixture: true, demoFixtureOutcome: "pass" });
+  const dataset = await EvalDataset.create({
+    recommendationId: rec._id, status: "ready", riskTier: "low", isDemoFixture: true,
+  });
+  rec.evalDatasetId = dataset._id;
+  await rec.save();
+
+  const res = await agent.post(`/api/recommendations/${rec._id}/run-eval`);
+
+  assert.equal(res.status, 202);
+  assert.equal(res.body.status, "passed");
+  // isDemoFixture:true on the returned run is proof the short-circuit fired: the real replay
+  // pipeline (eval/replay.js's startRun) never sets this field, and it hard-requires a live
+  // provider it doesn't have here — it cannot produce this response at all, let alone this one.
+  assert.equal(res.body.isDemoFixture, true);
+
+  const updated = await Recommendation.findById(rec._id).lean();
+  assert.equal(updated.evalStatus, "passed");
+  assert.ok(updated.qualitySummary);
+  assert.equal(String(updated.evalRunId), String(res.body._id));
+});
+
+test("run-eval short-circuit produces a failing run when demoFixtureOutcome is 'fail', with real gate reasons", async () => {
+  const rec = await makeRec({ isDemoFixture: true, demoFixtureOutcome: "fail" });
+  const dataset = await EvalDataset.create({
+    recommendationId: rec._id, status: "ready", riskTier: "low", isDemoFixture: true,
+  });
+  rec.evalDatasetId = dataset._id;
+  await rec.save();
+
+  const res = await agent.post(`/api/recommendations/${rec._id}/run-eval`);
+  assert.equal(res.status, 422);
+  assert.equal(res.body.status, "failed");
+  assert.ok(res.body.failures.length > 0);
+
+  const results = await EvalResult.find({ evalRunId: res.body._id }).lean();
+  assert.equal(results.length, res.body.summary.total);
+  assert.ok(results.every((r) => r.isDemoFixture === true));
+});
+
+test("a non-fixture dataset is unaffected by the short-circuit (falls through, still requires a real dataset gate)", async () => {
+  const rec = await makeRec(); // isDemoFixture defaults to false
+  // No dataset at all — should hit the existing "create a dataset first" gate, not the fixture path.
+  const res = await agent.post(`/api/recommendations/${rec._id}/run-eval`);
+  assert.equal(res.status, 409);
+  assert.equal(res.body.error, "no_dataset");
+});
+
+test("accept propagates isDemoFixture onto the created Rule", async () => {
+  const rec = await makeRec({ isDemoFixture: true });
+  const dataset = await EvalDataset.create({ recommendationId: rec._id, status: "ready", riskTier: "low", isDemoFixture: true });
+  rec.evalDatasetId = dataset._id;
+  await rec.save();
+  await agent.post(`/api/recommendations/${rec._id}/run-eval`);
+
+  const res = await agent.post(`/api/recommendations/${rec._id}/accept`);
+  assert.equal(res.status, 200);
+  assert.equal(res.body.rule.isDemoFixture, true);
+});
+
+test("create-canary propagates isDemoFixture onto the created RoutingExperiment", async () => {
+  const rec = await makeRec({ isDemoFixture: true, application: "app-1" });
+  const dataset = await EvalDataset.create({ recommendationId: rec._id, status: "ready", riskTier: "low", isDemoFixture: true });
+  rec.evalDatasetId = dataset._id;
+  await rec.save();
+  await agent.post(`/api/recommendations/${rec._id}/run-eval`);
+
+  const res = await agent.post(`/api/recommendations/${rec._id}/create-canary`).send({ application: "app-1" });
+  assert.equal(res.status, 201);
+  assert.equal(res.body.isDemoFixture, true);
+});
+
+test("reset (scoped deleteMany) removes every isDemoFixture:true document across all 7 models and leaves real data untouched", async () => {
+  const realRec = await makeRec({ title: "real, not a fixture" });
+  const realRequest = await RequestRecord.create({ requestId: "real-1", model: "gpt-4o", isDemoFixture: false });
+
+  const fixtureRec = await makeRec({ isDemoFixture: true });
+  const fixtureDataset = await EvalDataset.create({ recommendationId: fixtureRec._id, status: "ready", isDemoFixture: true });
+  const fixtureRun = await EvalRun.create({ recommendationId: fixtureRec._id, datasetId: fixtureDataset._id, isDemoFixture: true });
+  const fixtureResult = await EvalResult.create({ evalRunId: fixtureRun._id, isDemoFixture: true });
+  const fixtureExp = await RoutingExperiment.create({
+    recommendationId: fixtureRec._id, baselineModel: "gpt-4o", candidateModel: "gpt-4o-mini", isDemoFixture: true,
+  });
+  const fixtureRule = await Rule.create({
+    target: { provider: "openai", model: "gpt-4o-mini" }, sourceRecommendation: fixtureRec._id, isDemoFixture: true,
+  });
+  const fixtureRequest = await RequestRecord.create({ requestId: "fixture-1", model: "gpt-4o", isDemoFixture: true });
+
+  // Run the same scoped-delete logic the CLI script uses.
+  await Promise.all([
+    RequestRecord.deleteMany({ isDemoFixture: true }),
+    Recommendation.deleteMany({ isDemoFixture: true }),
+    EvalDataset.deleteMany({ isDemoFixture: true }),
+    EvalRun.deleteMany({ isDemoFixture: true }),
+    EvalResult.deleteMany({ isDemoFixture: true }),
+    RoutingExperiment.deleteMany({ isDemoFixture: true }),
+    Rule.deleteMany({ isDemoFixture: true }),
+  ]);
+
+  assert.equal(await Recommendation.findById(fixtureRec._id), null);
+  assert.equal(await EvalDataset.findById(fixtureDataset._id), null);
+  assert.equal(await EvalRun.findById(fixtureRun._id), null);
+  assert.equal(await EvalResult.findById(fixtureResult._id), null);
+  assert.equal(await RoutingExperiment.findById(fixtureExp._id), null);
+  assert.equal(await Rule.findById(fixtureRule._id), null);
+  assert.equal(await RequestRecord.findById(fixtureRequest._id), null);
+
+  // Real, non-fixture documents survive untouched.
+  assert.ok(await Recommendation.findById(realRec._id));
+  assert.ok(await RequestRecord.findById(realRequest._id));
+});

--- a/server/test/unit/demoFixture.test.js
+++ b/server/test/unit/demoFixture.test.js
@@ -1,0 +1,56 @@
+"use strict";
+// Pure-logic coverage for the demo-fixture synthesizer (F-06). synthesizeRun() itself writes
+// to Mongo, so it's covered in server/test/integration/demoFixture.test.js — this file covers
+// only syntheticEntries(), the pure generator, composed with the SAME real, exported
+// aggregate()/evaluateRun() production uses (no DB needed for either).
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { syntheticEntries } = require("../../src/eval/demoFixture");
+const { aggregate } = require("../../src/eval/replay");
+const { targetCountForRisk, defaultThresholds, evaluateRun } = require("../../src/eval/thresholds");
+
+test("syntheticEntries is deterministic: same count/outcome produces byte-identical output", () => {
+  const a = syntheticEntries(50, "pass");
+  const b = syntheticEntries(50, "pass");
+  assert.deepEqual(a, b);
+});
+
+test("pass and fail outcomes diverge (not the same sequence reused)", () => {
+  const pass = syntheticEntries(50, "pass");
+  const fail = syntheticEntries(50, "fail");
+  assert.notDeepEqual(pass, fail);
+});
+
+for (const risk of ["low", "medium", "high"]) {
+  test(`outcome:"pass" genuinely clears every ${risk}-risk threshold via the real evaluateRun gate`, () => {
+    const count = targetCountForRisk(risk);
+    const entries = syntheticEntries(count, "pass");
+    const summary = aggregate(entries);
+    const { passed, failures } = evaluateRun(summary, defaultThresholds(risk));
+    assert.equal(passed, true, `expected a pass, got failures: ${failures.join("; ")}`);
+    assert.deepEqual(failures, []);
+  });
+
+  test(`outcome:"fail" genuinely breaches the real evaluateRun gate for ${risk} risk, with non-empty reasons`, () => {
+    const count = targetCountForRisk(risk);
+    const entries = syntheticEntries(count, "fail");
+    const summary = aggregate(entries);
+    const { passed, failures } = evaluateRun(summary, defaultThresholds(risk));
+    assert.equal(passed, false);
+    assert.ok(failures.length > 0);
+  });
+}
+
+test("every generated entry has the exact shape aggregate() expects", () => {
+  const entries = syntheticEntries(10, "pass");
+  for (const e of entries) {
+    assert.equal(typeof e.verdict, "string");
+    assert.equal(typeof e.criticalFailure, "boolean");
+    assert.equal(typeof e.formatPass, "boolean");
+    assert.equal(typeof e.candidateCost, "number");
+    assert.equal(typeof e.candidateLatencyMs, "number");
+    assert.equal(typeof e.productionCost, "number");
+    assert.equal(typeof e.productionLatencyMs, "number");
+    assert.equal(e.errored, false);
+  }
+});


### PR DESCRIPTION
## Summary

**Stacked on #180 (F-03) and #181 (F-05) — base branch is `feat/evidence-report`, not `main`.** Reuses `recommend/stage.js`'s `deriveStage()`, `recommend/outcome.js`'s `computeOutcome()`, and `recommend/evidenceReport.js`, none of which exist on `main` yet. Merge #180 and #181 first.

Second P1 item, unblocked by F-03. Gives design partners a deterministic, ~10-minute, live walkthrough of the full optimization lifecycle with zero provider keys.

**The central problem:** eval replay (`eval/replay.js`) and shadow campaigns (`eval/shadow.js`) hard-call a live provider with no existing seam anywhere in the codebase — confirmed by reading every call site (no mock adapter, no env var, no Settings flag). Building a fixture-provider adapter wired into `getRouter()` would have been invasive for a Medium-effort item.

**The approach:** never call the real replay pipeline for fixture data. Instead, `server/src/eval/demoFixture.js`'s `synthesizeRun()` generates synthetic per-item entries and feeds them through the **exact same pure, tested functions production uses** — `eval/replay.js`'s exported `aggregate()` and `eval/thresholds.js`'s `evaluateRun()` — so the demo's pass/fail outcome is genuinely computed by production gating logic, not hand-faked numbers. A small short-circuit inside the real `POST /recommendations/:id/run-eval` route detects a demo-fixture dataset with no live provider configured and calls this instead of `evalReplay.startRun`. The facilitator clicks the real button in the real UI and gets a real state transition in seconds.

- Seeds 3 recommendations: a **happy path** (opportunity → live eval pass → canary → promote → outcome), a **failing candidate** (live eval fail, quality gate genuinely blocks it), and a **pre-seeded breaching canary** (for a live manual rollback demo — no live provider needed for that route either).
- A new `isDemoFixture: Boolean` field (7 models — confirmed by research that no such marker existed anywhere, making "reset never touches non-demo data" previously unsatisfiable) propagates forward through `create-eval-dataset`/`accept`/`create-canary`, so `npm run demo:reset` can delete exactly what it seeded.
- **Found and fixed a real bug during manual verification**: the short-circuit initially only created the `EvalRun`/`EvalResult` docs but never updated `Recommendation.evalStatus`/`qualitySummary`/`evalRunId` — the side effect the real pipeline's `finish()` performs. Without it, `POST .../accept` failed with `409 eval_required` even after a "passed" eval. Fixed by mirroring `finish()`'s exact side effect inside `synthesizeRun()`.

## Test plan

- [x] 9 new unit tests (`syntheticEntries` composed with the real `aggregate()`/`evaluateRun()`) — deterministic, pass clears every risk tier's gate, fail breaches it with real reasons, correct entry shape
- [x] 6 new integration tests — short-circuit fires for a fixture dataset (proven by `isDemoFixture:true` on the response, not a flaky timing check — an earlier version of this test used a wall-clock assertion that turned out flaky under full-suite load and was removed in favor of a real correctness check), fail-outcome path, non-fixture datasets fall through untouched, `isDemoFixture` propagation through accept/create-canary, and the scoped-reset test (seeds real + fixture data together, confirms reset deletes only the fixture rows)
- [x] `MONGOMS_VERSION=7.0.14 npm run test:server` — 345/345 pass
- [x] `npm run lint` — clean
- [x] `npm --prefix web run build` — clean (no frontend changes)
- [x] Manual, full walkthrough against a real zero-provider-key boot: `npm run demo:seed` → build dataset → run eval (passed, in ~100ms) → accept → create-canary → promote → outcome panel → evidence report (.md) for the happy path; run eval (failed, real reasons) for the failing candidate; manual rollback for the pre-seeded breaching canary. Then `npm run demo:reset`, confirmed idempotent (ran seed twice, same document counts, no duplicates) and scoped (real data alongside the fixture survives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)