### PR TITLE
feat(internal): route every internal LLM call through one accounting wrapper

### DIFF
--- a/server/src/api/routes/connections.js
+++ b/server/src/api/routes/connections.js
@@ -4,6 +4,7 @@ const connections = require("../../providers/connections");
 const { requireRole } = require("../rbac");
 const { createRouter } = require("../../providers/llm-router");
 const { toRouterConfig, getRouter } = require("../../providers/router");
+const { internalComplete } = require("../../internal/complete");
 
 const router = express.Router();
 
@@ -57,7 +58,11 @@ router.post("/connections/:provider/test", requireRole("administrator"), async (
       defaultProvider: provider,
     });
     // Generous budget so "thinking" models (e.g. Gemini 2.5) have room to answer.
-    const out = await r.complete({ messages: [{ role: "user", content: "Reply with: ok" }], maxTokens: 256 });
+    const out = await internalComplete({
+      kind: "connection-test", router: r,
+      messages: [{ role: "user", content: "Reply with: ok" }], maxTokens: 256,
+      context: { provider },
+    });
     res.json({ ok: true, model: out.modelId, sample: (out.text || "").slice(0, 40) });
   } catch (e) {
     res.json({ ok: false, message: String(e.message || e) });

--- a/server/src/api/routes/models.js
+++ b/server/src/api/routes/models.js
@@ -7,6 +7,7 @@ const { toRouterConfig, getRouter } = require("../../providers/router");
 const pricing = require("../../pricing/registry");
 const ModelEntry = require("../../models/ModelEntry");
 const { requireRole } = require("../rbac");
+const { internalComplete } = require("../../internal/complete");
 
 const router = express.Router();
 
@@ -41,7 +42,11 @@ router.post("/models/:id/test", requireRole("administrator"), async (req, res) =
     const start = Date.now();
     const cfg = { ...toRouterConfig(model.provider, p), model: model.id };
     const r = createRouter({ providers: { [model.provider]: cfg }, defaultProvider: model.provider });
-    const out = await r.complete({ messages: [{ role: "user", content: message }], maxTokens: 512 });
+    const out = await internalComplete({
+      kind: "model-test", router: r,
+      messages: [{ role: "user", content: message }], maxTokens: 512,
+      context: { model: model.id },
+    });
     res.json({
       ok: true,
       text: out.text || "",

--- a/server/src/classify/classifier.js
+++ b/server/src/classify/classifier.js
@@ -6,6 +6,7 @@
 // without paying for classification on every request.
 
 const crypto = require("crypto");
+const { internalComplete } = require("../internal/complete");
 
 // 30 built-in task types grouped by complexity tier.
 // tier: "light" = fast & cheap, "mid" = balanced, "premium" = deep reasoning.
@@ -236,7 +237,7 @@ function normalizeLabel(text) {
 }
 
 // One LLM call on a CHEAP model → { taskType, difficulty, confidence } from TASK_TYPES, or null.
-async function classifyWithLLM({ messages, router, eff }) {
+async function classifyWithLLM({ messages, router, eff, application = null }) {
   if (!router || !eff || !eff.defaultProvider) return null;
   const text = lastUserText(messages).slice(0, 800);
   const prompt =
@@ -246,12 +247,18 @@ async function classifyWithLLM({ messages, router, eff }) {
     `Return ONLY a JSON object: {"taskType": "...", "difficulty": <1-10>, "confidence": <0-1>}\n\n` +
     `Request:\n"""${text}"""`;
   const m = pickClassifierModel(eff);
-  const result = await router.complete({
+  // Accounted here rather than by the gateway. This call is made on both /v1/chat and
+  // /v1/chat/completions; when the two gateways each logged it themselves, the
+  // OpenAI-compatible path silently didn't, so its classifier spend was invisible.
+  const result = await internalComplete({
+    kind: "classifier",
+    router,
     messages: [{ role: "user", content: prompt }],
-    providerOverride: m.provider,
-    modelOverride: m.model,
+    provider: m.provider,
+    model: m.model,
     temperature: 0,
     maxTokens: 256, // headroom for "thinking" models (e.g. Gemini 2.5)
+    context: { application: application || null },
   });
   const parsed = parseJsonBlock(result.text || "");
   let label = parsed ? normalizeLabel(parsed.taskType) : null;
@@ -278,7 +285,7 @@ async function classifyWithLLM({ messages, router, eff }) {
 // A provided taskType is always trusted. Otherwise: when useLLM, the AI classifier
 // is primary (default model, cached) and keyword is only the fallback; when useLLM
 // is off, the keyword heuristic decides.
-async function classifyTask({ taskType, messages, router, eff, useLLM }) {
+async function classifyTask({ taskType, messages, router, eff, useLLM, application = null }) {
   if (taskType && String(taskType).trim()) {
     return { taskType: String(taskType).trim().toLowerCase(), method: "provided", confidence: 1.0, difficulty: null, difficultyScore: null, llm: null };
   }
@@ -287,7 +294,7 @@ async function classifyTask({ taskType, messages, router, eff, useLLM }) {
     const hit = _llmCache.get(key);
     if (hit) return { taskType: hit.taskType, method: "ai", confidence: hit.confidence ?? 0.8, difficulty: hit.difficulty || null, difficultyScore: hit.difficultyScore ?? null, llm: null };
     try {
-      const r = await classifyWithLLM({ messages, router, eff });
+      const r = await classifyWithLLM({ messages, router, eff, application });
       if (r && r.label) {
         const entry = { taskType: r.label, difficulty: r.difficulty || null, difficultyScore: r.difficultyScore ?? null, confidence: r.confidence };
         if (_llmCache.size >= LLM_CACHE_MAX) _llmCache.delete(_llmCache.keys().next().value);

--- a/server/src/eval/judge.js
+++ b/server/src/eval/judge.js
@@ -3,6 +3,7 @@
 // perspective, or null when no judge model is available. Used by shadow-eval.
 const pricing = require("../pricing/registry");
 const { parseVerdict } = require("./logic");
+const { internalComplete } = require("../internal/complete");
 
 function lastUserText(messages) {
   if (typeof messages === "string") return messages;
@@ -35,8 +36,9 @@ async function judge({ router, eff, judgeModel, messages, prodText, candidateTex
     'Reply with ONLY JSON: {"winner": "A" | "B" | "tie", "reason": "<one short sentence>"}',
   ].join("\n");
   try {
-    const res = await router.complete({
-      messages: [{ role: "user", content: prompt }], providerOverride: jm.provider, modelOverride: judgeModel, temperature: 0,
+    const res = await internalComplete({
+      kind: "shadow-judge", router,
+      messages: [{ role: "user", content: prompt }], provider: jm.provider, model: judgeModel, temperature: 0,
     });
     return parseVerdict(res.text || "");
   } catch {

--- a/server/src/eval/replay.js
+++ b/server/src/eval/replay.js
@@ -11,6 +11,7 @@ const Recommendation = require("../models/Recommendation");
 const { clampText, maskPii } = require("../logging/piiFilter");
 const { judgeItem, disproveWorse, runValidators, lastUserText } = require("./rubricJudge");
 const { evaluateRun } = require("./thresholds");
+const { internalComplete } = require("../internal/complete");
 
 // Curation weights for the severity-weighted worse-rate. "normal" = 1 so uncurated benchmarks are
 // unchanged; a critical regression counts 3x, a trivial one 0.3x.
@@ -175,10 +176,13 @@ async function executeRun(runId) {
       if (fresh && fresh.status === "cancelled") { cancelled = true; break; }
     }
     try {
-      const candidate = await router.complete({
-        messages: item.messages, providerOverride: cm.provider, modelOverride: run.candidateModel,
+      const candidate = await internalComplete({
+        kind: "eval-replay", router,
+        messages: item.messages, provider: cm.provider, model: run.candidateModel,
+        context: { runId: String(run._id) },
       });
-      const candCost = pricing.costFor(run.candidateModel, candidate.usage?.inputTokens || 0, candidate.usage?.outputTokens || 0).totalCost;
+      // From the wrapper, so the EvalRun ledger and the RequestRecord ledger agree.
+      const candCost = candidate.costUsd;
       actualCost += candCost;
       const { formatPass, results } = runValidators(candidate.text, item.validators);
       const flip = Math.random() < 0.5; // A/B position de-bias

--- a/server/src/eval/rubricJudge.js
+++ b/server/src/eval/rubricJudge.js
@@ -7,6 +7,7 @@
 //      high-risk tasks (self-preference). `sameFamily()` is exported for that check.
 const pricing = require("../pricing/registry");
 const { lastUserText } = require("./judge");
+const { internalComplete } = require("../internal/complete");
 
 const RUBRIC_DIMS = ["correctness", "completeness", "instruction_following", "format", "safety"];
 
@@ -135,8 +136,9 @@ async function judgeItem({ router, eff, judgeModel, userText, baselineText, cand
   // On failure return { error } (not null) so the run can explain WHY 0 items were judged.
   // null is reserved for "no judge configured / not live" (an intentional capture-only run).
   try {
-    const res = await router.complete({
-      messages: [{ role: "user", content: prompt }], providerOverride: jm.provider, modelOverride: judgeModel, temperature: 0,
+    const res = await internalComplete({
+      kind: "eval-judge", router,
+      messages: [{ role: "user", content: prompt }], provider: jm.provider, model: judgeModel, temperature: 0,
     });
     const parsed = parseRubricVerdict(res.text || "");
     if (!parsed) return { error: `judge "${judgeModel}" did not return a valid A/B/tie JSON verdict` };
@@ -175,8 +177,9 @@ async function disproveWorse({ router, eff, judgeModel, userText, baselineText, 
     'Set "worse_verdict_holds": false ONLY when the "worse" verdict is clearly wrong.',
   ].join("\n");
   try {
-    const res = await router.complete({
-      messages: [{ role: "user", content: prompt }], providerOverride: jm.provider, modelOverride: judgeModel, temperature: 0,
+    const res = await internalComplete({
+      kind: "eval-disprove", router,
+      messages: [{ role: "user", content: prompt }], provider: jm.provider, model: judgeModel, temperature: 0,
     });
     const m = String(res.text || "").match(/\{[\s\S]*\}/);
     if (!m) return { overturned: false };

--- a/server/src/eval/shadow.js
+++ b/server/src/eval/shadow.js
@@ -9,6 +9,7 @@ const pricing = require("../pricing/registry");
 const { maskMessages, maskPii, clampText } = require("../logging/piiFilter");
 const { judge } = require("./judge");
 const { isSingleShot, shouldSample, withinWindow, campaignMatches } = require("./logic");
+const { internalComplete } = require("../internal/complete");
 
 function shadowPayload({ messages, prodText, candidateText }, settings) {
   if (settings?.captureRequestPayloads === false) {
@@ -106,8 +107,10 @@ async function maybeShadowEval({ application, workflow, taskType, messages, hasT
     // Daily shadow budget: stop mirroring once today's candidate spend hits the cap.
     if (campaign.maxDailyShadowBudgetUsd != null && await spentTodayUsd(campaign._id) >= campaign.maxDailyShadowBudgetUsd) return;
 
-    const candidate = await router.complete({
-      messages, providerOverride: cm.provider, modelOverride: campaign.candidateModel,
+    const candidate = await internalComplete({
+      kind: "shadow-candidate", router,
+      messages, provider: cm.provider, model: campaign.candidateModel,
+      context: { campaignId: String(campaign._id), application, requestId },
     }).catch(() => null);
     if (!candidate) { await recordCandidateError(campaign); return; }
 
@@ -118,7 +121,9 @@ async function maybeShadowEval({ application, workflow, taskType, messages, hasT
       prodModel: prod.model, prodProvider: prod.provider, prodCost: costOf(prod.model, prod.usage),
       prodLatencyMs: prod.latencyMs, prodResponse: stored.prodResponse,
       candidateModel: campaign.candidateModel, candidateProvider: cm.provider,
-      candidateCost: costOf(campaign.candidateModel, candidate.usage), candidateLatencyMs: candidate.latencyMs,
+      // From the wrapper, so the EvalPair ledger and the RequestRecord ledger price the
+      // same call identically (costOf ignores prompt-cache discounts; the wrapper doesn't).
+      candidateCost: candidate.costUsd, candidateLatencyMs: candidate.latencyMs,
       candidateResponse: stored.candidateResponse,
       judgeModel: campaign.judgeModel || null,
       messages: stored.messages,

--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -121,7 +121,9 @@ async function invokeWithFallback(router, eff, { provider, model, messages, temp
 }
 
 // Shared routing resolution: classify task + decide served {provider, model}.
-// Returns { served, routingDecision, taskType, classifiedBy, cls }.
+// Returns { served, routingDecision, taskType, classifiedBy }. The classifier's own
+// spend is accounted inside classify/classifier.js, so callers don't have to remember
+// to log it — the OpenAI-compatible gateway used to forget, and its cost vanished.
 // Callers are responsible for budget enforcement (it may short-circuit the response).
 async function resolveRoute(body, { router, eff, application, workflow, userId = null, appConfig = {}, appDbConfig = null }) {
   const routingMode = await ruleEngine.getRoutingMode();
@@ -134,6 +136,9 @@ async function resolveRoute(body, { router, eff, application, workflow, userId =
     messages: body.messages,
     router, eff,
     useLLM: routingMode === "ai" && autoMode && !providedTaskType,
+    // Provenance only — recorded on internalContext so the overhead view can show
+    // which app's traffic triggered a classification. Never a queryable dimension.
+    application,
   });
   const taskType = cls.taskType;
   const classifiedBy = cls.method;
@@ -266,7 +271,7 @@ async function resolveRoute(body, { router, eff, application, workflow, userId =
   }
 
   return {
-    served, routingDecision, taskType, classifiedBy, cls,
+    served, routingDecision, taskType, classifiedBy,
     difficulty, difficultyScore, confidence, explain, qualityGate,
   };
 }
@@ -344,9 +349,9 @@ async function handleChat(req, res) {
     allowedModels: req.apiKey?.allowedModels || [],
     defaultModel: req.apiKey?.defaultModel || null,
   };
-  let served, routingDecision, taskType, classifiedBy, cls, difficulty, difficultyScore, confidence, explain, qualityGate;
+  let served, routingDecision, taskType, classifiedBy, difficulty, difficultyScore, confidence, explain, qualityGate;
   try {
-    ({ served, routingDecision, taskType, classifiedBy, cls, difficulty, difficultyScore, confidence, explain, qualityGate } =
+    ({ served, routingDecision, taskType, classifiedBy, difficulty, difficultyScore, confidence, explain, qualityGate } =
       await resolveRoute(body, { router, eff, application: meta.application, workflow: meta.workflow, userId: meta.userId, appConfig, appDbConfig: appCfg }));
   } catch (err) {
     if (err.code === "model_not_allowed") {
@@ -355,22 +360,9 @@ async function handleChat(req, res) {
     throw err;
   }
 
-  if (cls.llm) {
-    setImmediate(() =>
-      logger.write({
-        requestId: uuidv4(), timestamp: new Date(),
-        application: "arbr-internal", workflow: "auto-classifier",
-        userId: null, department: "arbr",
-        provider: cls.llm.provider, model: cls.llm.model, modelRequested: cls.llm.model,
-        taskType: "classification",
-        promptTokens: cls.llm.usage?.inputTokens || 0,
-        completionTokens: cls.llm.usage?.outputTokens || 0,
-        totalTokens: cls.llm.usage?.totalTokens || 0,
-        latencyMs: cls.llm.latencyMs || 0, status: "success",
-        routingDecision: "passthrough", cacheHit: false,
-      })
-    );
-  }
+  // The classifier's own spend is recorded by classify/classifier.js via
+  // internal/complete.js — not here. It used to be logged at this call site, which meant
+  // the OpenAI-compatible gateway (which shares resolveRoute) never logged it at all.
 
   // Budget enforcement — a breached enforcing cap outranks everything, including
   // explicit pins (that is the point of enforcement). block → 429; downgrade →

--- a/server/src/internal/complete.js
+++ b/server/src/internal/complete.js
@@ -1,0 +1,132 @@
+// Every LLM call Arbr makes FOR ITSELF goes through here.
+//
+// Arbr is a cost-control product, so it has to be honest about the cost it creates.
+// Historically each internal call site was responsible for logging its own spend, and
+// nine of ten forgot — the router never logs, only callers do. This wrapper moves that
+// responsibility to one choke point: call it and your spend is priced, attributed and
+// recorded, whether or not you remembered to think about it.
+//
+// Records are written with `internalKind` set and every customer dimension left null,
+// so analytics counts the money in headline totals while never attributing it to a
+// customer application. See ARCHITECTURE.md → "Arbr's own AI spend".
+const RequestRecord = require("../models/RequestRecord");
+const { costFor } = require("../pricing/registry");
+const logger = require("../logging/logger");
+const { v4: uuidv4 } = require("uuid");
+
+const INTERNAL_KINDS = RequestRecord.INTERNAL_KINDS;
+
+// In-flight write promises, so tests can await the fire-and-forget logging without a
+// mocking library or arbitrary sleeps.
+const _pending = new Set();
+
+function _record(fields) {
+  const p = Promise.resolve()
+    .then(() => logger.write(fields))
+    .catch(() => { /* logger already swallows; belt and braces */ })
+    .finally(() => _pending.delete(p));
+  _pending.add(p);
+}
+
+/**
+ * Run an internal LLM call and account for it.
+ *
+ * @param {object}   o
+ * @param {string}   o.kind      one of RequestRecord.INTERNAL_KINDS
+ * @param {object}   o.router    a router from providers/router.js getRouter(), or a
+ *                               one-off createRouter (the admin test endpoints use these)
+ * @param {Array}    o.messages  chat messages
+ * @param {string}  [o.provider] providerOverride
+ * @param {string}  [o.model]    modelOverride
+ * @param {number}  [o.temperature]
+ * @param {number}  [o.maxTokens]
+ * @param {object}  [o.context]  provenance ({ application, requestId, campaignId, runId })
+ *                               stored on internalContext — never a queryable dimension
+ * @returns {Promise<{text,providerId,modelId,latencyMs,usage,costUsd}>}
+ *
+ * Provider errors propagate unchanged (every call site already handles them), but a
+ * failure record is written first — so failed internal calls are visible too.
+ */
+async function internalComplete({
+  kind, router, messages, provider, model, temperature, maxTokens, context = null,
+}) {
+  if (!INTERNAL_KINDS.includes(kind)) {
+    throw new Error(`internalComplete: unknown kind "${kind}". Known: ${INTERNAL_KINDS.join(", ")}`);
+  }
+  if (!router) throw new Error("internalComplete: router is required");
+
+  const startedAt = new Date();
+  try {
+    const res = await router.complete({
+      messages,
+      providerOverride: provider,
+      modelOverride: model,
+      temperature,
+      maxTokens,
+    });
+
+    const usage = res.usage || {};
+    const promptTokens = usage.inputTokens || 0;
+    const completionTokens = usage.outputTokens || 0;
+    const { totalCost } = costFor(res.modelId, promptTokens, completionTokens, {
+      cachedReadTokens: usage.cachedReadTokens || 0,
+      cacheWriteTokens: usage.cacheWriteTokens || 0,
+    });
+
+    _record({
+      ...baseFields(kind, startedAt, context),
+      provider: res.providerId,
+      model: res.modelId,
+      modelRequested: model || res.modelId,
+      promptTokens,
+      completionTokens,
+      totalTokens: usage.totalTokens || promptTokens + completionTokens,
+      cachedReadTokens: usage.cachedReadTokens || 0,
+      cacheWriteTokens: usage.cacheWriteTokens || 0,
+      latencyMs: res.latencyMs || 0,
+      status: "success",
+    });
+
+    return { ...res, costUsd: totalCost };
+  } catch (err) {
+    _record({
+      ...baseFields(kind, startedAt, context),
+      provider: provider || null,
+      model: model || null,
+      modelRequested: model || null,
+      latencyMs: Date.now() - startedAt.getTime(),
+      status: "failure",
+      errorMessage: String(err && err.message ? err.message : err).slice(0, 500),
+    });
+    throw err;
+  }
+}
+
+// Customer dimensions are deliberately null: defence in depth, so a query that forgets
+// to exclude internal records yields an unattributed bucket rather than a fake app.
+// messages/responseText are deliberately never captured — Arbr's own prompts are not
+// customer data, and omitting them also makes internal records fail eval-dataset
+// eligibility (which requires both) even if a query filter is ever missed.
+function baseFields(kind, timestamp, context) {
+  return {
+    requestId: uuidv4(),
+    timestamp,
+    internalKind: kind,
+    internalContext: context || null,
+    application: null,
+    workflow: null,
+    department: null,
+    userId: null,
+    taskType: null,
+    routingDecision: "passthrough",
+    classifiedBy: "provided",
+    cacheHit: false,
+  };
+}
+
+// Test helper: await all in-flight internal log writes.
+function _flushForTests() {
+  return Promise.all([..._pending]);
+}
+
+module.exports = { internalComplete, _flushForTests, INTERNAL_KINDS };

--- a/server/src/routing/aiPolicy.js
+++ b/server/src/routing/aiPolicy.js
@@ -6,6 +6,7 @@ const RequestRecord = require("../models/RequestRecord");
 const pricing = require("../pricing/registry");
 const { TASK_TYPES, TASK_CATALOG } = require("../classify/classifier");
 const { projectImpact } = require("./policySim");
+const { internalComplete } = require("../internal/complete");
 
 // Increment when MODEL_CAPABILITIES or TASK_CAPABILITIES change.
 // GET /api/ai-policy auto-regenerates if the stored version is behind.
@@ -309,10 +310,12 @@ async function _computeAssignments({ router, eff, excludeModels = [], goal = "ba
       `Return ONLY a valid JSON object mapping each task ID to one model ID. Example:\n` +
       `{"faq":"model-a","coding":"model-b","translation":"model-c"}`;
 
-    const resp = await router.complete({
+    const resp = await internalComplete({
+      kind: "policy-generation",
+      router,
       messages: [{ role: "user", content: prompt }],
-      providerOverride: generatorModel.provider,
-      modelOverride:    generatorModel.id,
+      provider: generatorModel.provider,
+      model:    generatorModel.id,
       temperature: 0.2,
       maxTokens:   1200,
     });

--- a/server/test/unit/classifierAccounting.test.js
+++ b/server/test/unit/classifierAccounting.test.js
@@ -1,0 +1,83 @@
+"use strict";
+// The classifier's spend must be accounted by the classifier itself, not by whichever
+// gateway happened to call it.
+//
+// Regression: resolveRoute is shared by /v1/chat and /v1/chat/completions, but only the
+// native handler destructured `cls` and logged the classification call. The
+// OpenAI-compatible gateway — LibreChat, OpenCode, any OpenAI SDK client — made the same
+// billable call and logged nothing. Accounting now lives inside classifyTask, so neither
+// gateway can forget.
+const { test, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const logger = require("../../src/logging/logger");
+const { classifyTask } = require("../../src/classify/classifier");
+const { _flushForTests } = require("../../src/internal/complete");
+
+const realWrite = logger.write;
+let written;
+beforeEach(() => { written = []; logger.write = async (r) => { written.push(r); }; });
+afterEach(() => { logger.write = realWrite; });
+
+// The classifier caches by prompt hash, so vary the text per test to force a real call.
+let n = 0;
+const uniqueMessages = () => [{ role: "user", content: `please summarise this unique document ${n++}` }];
+
+function fakeRouter() {
+  return {
+    async complete() {
+      return {
+        text: '{"taskType":"summarisation","difficulty":3,"confidence":0.9}',
+        providerId: "openai", modelId: "gpt-4o-mini", latencyMs: 12,
+        usage: { inputTokens: 80, outputTokens: 12, totalTokens: 92 },
+      };
+    },
+  };
+}
+const eff = { defaultProvider: "openai", defaultModel: "gpt-4o-mini", liveIds: ["openai"] };
+
+test("classifying records the call's own spend", async () => {
+  const cls = await classifyTask({
+    messages: uniqueMessages(), router: fakeRouter(), eff, useLLM: true, application: "checkout",
+  });
+  await _flushForTests();
+
+  assert.equal(cls.method, "ai", "the LLM classifier should have run");
+  assert.equal(written.length, 1, "the classification call must be accounted exactly once");
+  assert.equal(written[0].internalKind, "classifier");
+  assert.equal(written[0].promptTokens, 80);
+  assert.equal(written[0].application, null, "never attributed to the triggering app");
+  assert.deepEqual(written[0].internalContext, { application: "checkout" },
+    "but the triggering app is kept as provenance");
+});
+
+test("a provided taskType makes no billable call", async () => {
+  await classifyTask({ taskType: "coding", messages: uniqueMessages(), router: fakeRouter(), eff, useLLM: true });
+  await _flushForTests();
+  assert.equal(written.length, 0, "trusting the caller's taskType must cost nothing");
+});
+
+test("keyword-only mode makes no billable call", async () => {
+  await classifyTask({ messages: uniqueMessages(), router: fakeRouter(), eff, useLLM: false });
+  await _flushForTests();
+  assert.equal(written.length, 0);
+});
+
+// Structural guard: the old sentinel-writing block must not come back in either gateway.
+// Both paths share resolveRoute, so a call-site log in one of them is a bug by construction.
+test("neither gateway writes classifier records itself", () => {
+  const gateway = path.resolve(__dirname, "../../src/gateway");
+  for (const file of ["handler.js", "openaiCompat.js"]) {
+    const src = fs.readFileSync(path.join(gateway, file), "utf8");
+    assert.ok(
+      !src.includes("arbr-internal"),
+      `${file} still references the legacy arbr-internal sentinel`
+    );
+    assert.ok(
+      !src.includes("auto-classifier"),
+      `${file} appears to log classifier spend itself; it belongs in classify/classifier.js`
+    );
+  }
+});

--- a/server/test/unit/internalComplete.test.js
+++ b/server/test/unit/internalComplete.test.js
@@ -1,0 +1,145 @@
+"use strict";
+// The wrapper every internal Arbr LLM call goes through. These tests use a hand-written
+// fake router (no mocking library, per the project's testing rules) and stub logger.write
+// so they assert on the exact record that would be persisted, without a DB.
+const { test, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+
+const logger = require("../../src/logging/logger");
+const RequestRecord = require("../../src/models/RequestRecord");
+const { internalComplete, _flushForTests } = require("../../src/internal/complete");
+
+const realWrite = logger.write;
+let written;
+
+beforeEach(() => {
+  written = [];
+  logger.write = async (rec) => { written.push(rec); };
+});
+afterEach(() => { logger.write = realWrite; });
+
+function fakeRouter(over = {}) {
+  return {
+    calls: [],
+    async complete(args) {
+      this.calls.push(args);
+      return {
+        text: "ok",
+        providerId: "openai",
+        modelId: "gpt-4o-mini",
+        latencyMs: 42,
+        usage: { inputTokens: 100, outputTokens: 20, totalTokens: 120 },
+        ...over,
+      };
+    },
+  };
+}
+
+test("records a priced internal call with no customer dimensions", async () => {
+  const router = fakeRouter();
+  const res = await internalComplete({
+    kind: "classifier", router,
+    messages: [{ role: "user", content: "hi" }],
+    provider: "openai", model: "gpt-4o-mini", temperature: 0, maxTokens: 256,
+  });
+  await _flushForTests();
+
+  assert.equal(res.text, "ok");
+  assert.equal(typeof res.costUsd, "number", "callers need costUsd to keep their own ledgers in step");
+
+  assert.equal(written.length, 1);
+  const rec = written[0];
+  assert.equal(rec.internalKind, "classifier");
+  assert.equal(rec.status, "success");
+  assert.equal(rec.provider, "openai");
+  assert.equal(rec.promptTokens, 100);
+  assert.equal(rec.completionTokens, 20);
+  assert.equal(rec.latencyMs, 42);
+
+  // Defence in depth: a query that forgets to exclude internal records must yield an
+  // unattributed bucket, never a fake application.
+  for (const f of ["application", "workflow", "department", "userId", "taskType"]) {
+    assert.equal(rec[f], null, `${f} must be null on an internal record`);
+  }
+});
+
+test("never captures prompt or response text", async () => {
+  await internalComplete({
+    kind: "policy-generation", router: fakeRouter(),
+    messages: [{ role: "user", content: "a secret internal prompt" }],
+  });
+  await _flushForTests();
+
+  const rec = written[0];
+  assert.equal(rec.messages, undefined, "Arbr's own prompts are not customer data");
+  assert.equal(rec.responseText, undefined);
+  // This is also what makes internal records fail eval-dataset eligibility, which
+  // requires both fields — a second barrier if a query filter is ever missed.
+});
+
+test("passes overrides through to the router", async () => {
+  const router = fakeRouter();
+  await internalComplete({
+    kind: "eval-judge", router,
+    messages: [{ role: "user", content: "x" }],
+    provider: "anthropic", model: "claude-haiku-4-5", temperature: 0.2, maxTokens: 999,
+  });
+  assert.deepEqual(router.calls[0], {
+    messages: [{ role: "user", content: "x" }],
+    providerOverride: "anthropic",
+    modelOverride: "claude-haiku-4-5",
+    temperature: 0.2,
+    maxTokens: 999,
+  });
+});
+
+test("records a failure and rethrows so callers keep their own handling", async () => {
+  const router = { complete: async () => { throw new Error("provider exploded"); } };
+  await assert.rejects(
+    () => internalComplete({ kind: "connection-test", router, messages: [{ role: "user", content: "x" }] }),
+    /provider exploded/
+  );
+  await _flushForTests();
+
+  assert.equal(written.length, 1, "a failed internal call must still be visible");
+  assert.equal(written[0].status, "failure");
+  assert.equal(written[0].internalKind, "connection-test");
+  assert.match(written[0].errorMessage, /provider exploded/);
+});
+
+test("a logging failure never reaches the caller", async () => {
+  logger.write = async () => { throw new Error("mongo is down"); };
+  const res = await internalComplete({
+    kind: "model-test", router: fakeRouter(), messages: [{ role: "user", content: "x" }],
+  });
+  await _flushForTests();
+  assert.equal(res.text, "ok", "accounting must never break the thing it is accounting for");
+});
+
+test("stores provenance on internalContext, not as a dimension", async () => {
+  await internalComplete({
+    kind: "shadow-candidate", router: fakeRouter(),
+    messages: [{ role: "user", content: "x" }],
+    context: { campaignId: "c1", application: "checkout" },
+  });
+  await _flushForTests();
+
+  assert.deepEqual(written[0].internalContext, { campaignId: "c1", application: "checkout" });
+  assert.equal(written[0].application, null, "provenance must not leak into the dimension");
+});
+
+test("rejects an unknown kind rather than writing an unclassifiable record", async () => {
+  await assert.rejects(
+    () => internalComplete({ kind: "not-a-kind", router: fakeRouter(), messages: [] }),
+    /unknown kind/
+  );
+  assert.equal(written.length, 0);
+});
+
+test("every kind in the schema enum is accepted", async () => {
+  for (const kind of RequestRecord.INTERNAL_KINDS) {
+    await internalComplete({ kind, router: fakeRouter(), messages: [{ role: "user", content: "x" }] });
+  }
+  await _flushForTests();
+  assert.deepEqual(written.map((r) => r.internalKind), RequestRecord.INTERNAL_KINDS);
+});


### PR DESCRIPTION
## Summary

Arbr makes LLM calls **for itself** in ten places. Before this, **nine of them logged no cost at all** — the router never logs, only callers do, and a new call site always forgets. #167 stopped the one logged site polluting customer analytics; this PR makes the other nine visible, so the overhead number becomes *complete* rather than a fraction.

This is PR 2 of the #158 series (PR 1 = #167, merged).

## The wrapper

New `server/src/internal/complete.js`. Every internal call goes through it: it prices the call, writes a `RequestRecord` tagged with `internalKind`, and returns `costUsd`. All ten sites become one-liners, and a future site can't forget to account for its own spend.

- **Never throws into the caller** beyond what the router already does. Provider errors propagate (every site already handles them), but a **failure record is written first** — so failed internal calls are visible for the first time too.
- **Never captures prompts or responses.** Arbr's own prompts aren't customer data, they'd bloat the collection, and omitting them keeps internal records out of eval datasets (which require both fields) even if a query filter is ever missed.

## The ten sites

| Kind | Site |
|---|---|
| `classifier` | `classify/classifier.js` |
| `policy-generation` | `routing/aiPolicy.js` |
| `shadow-judge` | `eval/judge.js` |
| `eval-judge` / `eval-disprove` | `eval/rubricJudge.js` |
| `shadow-candidate` | `eval/shadow.js` |
| `eval-replay` | `eval/replay.js` |
| `connection-test` / `model-test` | admin routes |

## The classifier fix

The classifier is the one that mattered. It's called by **both** `/v1/chat` and `/v1/chat/completions` through the shared `resolveRoute`, but only the native handler destructured `cls` and logged it — so **every classification on the OpenAI-compatible path was unbilled**. Accounting now lives *inside* the classifier, and `resolveRoute` no longer returns `cls` at all. The footgun that caused the split is deleted, not patched. A structural test asserts neither gateway file can reintroduce call-site logging (`arbr-internal` / `auto-classifier`).

## Ledger consistency

Shadow and eval-replay keep their `EvalPair.candidateCost` / `EvalRun.actualCostUsd` fields but now source them from the wrapper's `costUsd`. Previously they used a local `costOf` that ignored prompt-cache discounts, so the eval ledger and the money ledger could disagree on the same call. Now they can't.

## ⚠️ Expected behaviour change

**Headline `totalCost` will rise once this deploys.** That is nine previously-invisible spend sources becoming real, not new spend. The most likely surprise is `policy-generation`: `GET /api/ai-policy` auto-regenerates on page load using the default (possibly premium) model at 1200 max tokens, so simply leaving the Routing page open has been generating uncounted spend. Worth watching that kind specifically in the breakdown once PR 4 (UI) lands.

## Testing

12 new unit tests, no DB or mocking library (hand-written fake router + stubbed `logger.write`):

- **`internalComplete.test.js`** — priced record with all customer dimensions null; prompts never captured; overrides passed through; failure records + rethrow; a logging failure never reaches the caller; provenance on `internalContext` not as a dimension; unknown kind rejected; every schema enum kind accepted.
- **`classifierAccounting.test.js`** — classification records its own spend attributed to no app; a provided `taskType` and keyword-only mode cost nothing; **structural guard that neither gateway logs classifier spend itself** (the #167 regression).

Full suite: 252 tests. Failures match `main` exactly (all environment-dependent — CI is green). Lint unchanged at 0 errors.

## Follow-ups

- **PR 4** — surface the overhead in the console (Overview tile + per-kind detail page). This is the one that answers "where can I see it".
- **PR 3** — eval `maxRunCostUsd` still excludes judge spend; a run can exceed its stated cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)