### PR TITLE
feat(web): surface Arbr's overhead spend on the console

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -15,6 +15,7 @@ import Budgets from "./pages/Budgets.jsx";
 import Audit from "./pages/Audit.jsx";
 import Governance from "./pages/Governance.jsx";
 import Applications from "./pages/Applications.jsx";
+import InternalSpend from "./pages/InternalSpend.jsx";
 import ApplicationDetail from "./pages/ApplicationDetail.jsx";
 import Users from "./pages/Users.jsx";
 
@@ -66,6 +67,7 @@ export default function App() {
         <Route path="/applications" element={<Applications />} />
         <Route path="/applications/:name" element={<ApplicationDetail />} />
         <Route path="/requests" element={<Requests />} />
+        <Route path="/internal-spend" element={<InternalSpend />} />
         <Route path="/routing" element={<Routing onChange={refreshStatus} />} />
         <Route path="/recommendations" element={<Recommendations />} />
         <Route path="/budgets" element={<Budgets onChange={refreshStatus} />} />

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -81,6 +81,7 @@ export const api = {
   gatewayProviders: () => fetch("/v1/providers", { headers: { "Content-Type": "application/json" } }).then((r) => r.json()),
 
   overview: (filter) => req(`/analytics/overview${qs(filter)}`),
+  internalSpend: (filter) => req(`/analytics/internal-spend${qs(filter)}`),
   timeseries: (filter) => req(`/analytics/timeseries${qs(filter)}`),
   latencyPercentiles: (filter) => req(`/analytics/latency-percentiles${qs(filter)}`),
   providerHealth: () => req("/analytics/provider-health"),

--- a/web/src/pages/InternalSpend.jsx
+++ b/web/src/pages/InternalSpend.jsx
@@ -1,0 +1,109 @@
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { api, fmt } from "../api.js";
+import { Stat, Card, Table, Spinner } from "../components/ui.jsx";
+import RequestsTable from "../components/RequestsTable.jsx";
+
+// Human labels for the internalKind enum — the raw values shouldn't reach users.
+const KIND_LABELS = {
+  classifier: "Task classification",
+  "policy-generation": "Routing policy generation",
+  "shadow-candidate": "Shadow campaign — candidate",
+  "shadow-judge": "Shadow campaign — judge",
+  "eval-replay": "Eval run — candidate replay",
+  "eval-judge": "Eval run — judge",
+  "eval-disprove": "Eval run — disprove pass",
+  "connection-test": "Connection test",
+  "model-test": "Model test",
+};
+const labelFor = (k) => KIND_LABELS[k] || k || "—";
+
+export default function InternalSpend() {
+  const [data, setData] = useState(null);
+  const [err, setErr] = useState(null);
+
+  useEffect(() => {
+    api.internalSpend().then(setData).catch((e) => setErr(e.message));
+  }, []);
+
+  if (err) return <div className="text-sm text-red-600">Failed to load: {err}</div>;
+  if (!data) return <Spinner />;
+
+  const empty = data.totalRequests === 0;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <div className="mb-1 flex items-center gap-2 text-sm text-gray-400">
+          <Link to="/" className="hover:text-gray-600">Overview</Link>
+          <span>/</span>
+          <span className="text-gray-600">Arbr overhead</span>
+        </div>
+        <h1 className="text-xl font-semibold text-gray-900">Arbr overhead</h1>
+        <p className="mt-1 max-w-3xl text-sm text-gray-500">
+          What the control plane spent on <strong>your</strong> provider keys making calls for
+          itself — task classification on the routing path, AI policy generation, eval judging,
+          and connection/model tests. This is real money and is included in your total spend, but
+          it is kept out of every per-application view because it belongs to no application. To cut
+          the largest piece, pin <code className="rounded bg-gray-100 px-1">taskType</code> on your
+          requests so the gateway skips the classifier call.
+        </p>
+      </div>
+
+      {empty ? (
+        <Card>
+          <p className="text-sm text-gray-500">
+            No internal spend recorded yet. Arbr logs overhead when AI routing runs the task
+            classifier, when policies are generated, or when evals run.
+          </p>
+        </Card>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <Stat label="Total overhead" value={fmt.usd(data.totalCost)} />
+            <Stat label="Internal requests" value={fmt.num(data.totalRequests)} />
+            <Stat
+              label="Failed calls"
+              value={fmt.num(data.failures)}
+              sub={data.failures ? "internal calls that errored" : undefined}
+            />
+          </div>
+
+          <Card title="By kind">
+            <Table
+              columns={[
+                { key: "kind", header: "Kind", render: (r) => labelFor(r.key) },
+                { key: "requests", header: "Requests", render: (r) => fmt.num(r.requests) },
+                { key: "cost", header: "Cost", render: (r) => fmt.usd(r.cost) },
+                { key: "avgLatency", header: "Avg latency", render: (r) => fmt.ms(r.avgLatency) },
+                { key: "failures", header: "Failures", render: (r) => fmt.num(r.failures) },
+              ]}
+              rows={data.byKind}
+              empty="No internal spend by kind."
+            />
+          </Card>
+
+          <Card title="By model">
+            <p className="mb-3 text-sm text-gray-500">
+              Where the money went. Policy generation and model tests can hit a premium model, so
+              this is where an expensive surprise shows up.
+            </p>
+            <Table
+              columns={[
+                { key: "model", header: "Model", render: (r) => r.key || "—" },
+                { key: "requests", header: "Requests", render: (r) => fmt.num(r.requests) },
+                { key: "cost", header: "Cost", render: (r) => fmt.usd(r.cost) },
+              ]}
+              rows={data.byModel}
+              empty="No internal spend by model."
+            />
+          </Card>
+
+          <Card title="Recent internal calls">
+            <RequestsTable fixedFilters={{ internalScope: "internal" }} showStats={false} />
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/Overview.jsx
+++ b/web/src/pages/Overview.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { api, fmt } from "../api.js";
 import { Stat, Card, Table, Spinner, Tabs, useTabParam } from "../components/ui.jsx";
 import ByDimension from "./ByDimension.jsx";
@@ -77,10 +78,19 @@ function Summary() {
         </div>
       )}
 
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <div className={`grid grid-cols-1 gap-4 sm:grid-cols-2 ${data.internalCost > 0 ? "lg:grid-cols-4" : "lg:grid-cols-3"}`}>
         <Stat label="Cache hit rate" value={`${((data.cacheHitRate || 0) * 100).toFixed(1)}%`} />
         <Stat label="Cached tokens" value={fmt.num(data.cachedReadTokens)} />
         <Stat label="Cache savings" value={fmt.usd(data.cacheSavingUsd)} />
+        {data.internalCost > 0 && (
+          <Link to="/internal-spend" className="block rounded-lg transition hover:ring-2 hover:ring-arbr-500/30">
+            <Stat
+              label="Arbr overhead"
+              value={fmt.usd(data.internalCost)}
+              sub={`${((data.internalShare || 0) * 100).toFixed(1)}% of total spend · view breakdown`}
+            />
+          </Link>
+        )}
       </div>
 
       <Card title="Latency breakdown">
@@ -107,6 +117,7 @@ function Summary() {
         {latency?.overheadP99 > 500 && (
           <p className="mt-3 text-xs text-gray-400">
             High 99%ile gateway overhead reflects AI task classification — the gateway makes a short LLM call to determine task type when AI routing is on.
+            That call costs money as well as time; see <Link to="/internal-spend" className="text-arbr-600 underline">Arbr overhead</Link>.
             Pin <code className="rounded bg-gray-100 px-1">taskType</code> in your requests to skip it.
           </p>
         )}


### PR DESCRIPTION
## Summary

The final PR in the #158 series — the one that answers "where can I see this spend." #167 stopped internal spend polluting customer views and #183 made all ten internal call sites record their cost; this makes that cost **visible**.

- An **"Arbr overhead" tile** on the Overview summary (rendered only when there is internal spend), showing the cost and its share of total, linking to →
- A new **`/internal-spend` page**: overhead broken down **by kind** (task classification, policy generation, eval judging, connection/model tests) and **by model**, plus a filtered list of recent internal calls.
- Fixes the Overview latency note that framed the classifier call as a *latency* cost only — it now says it costs money and links to the breakdown.

## Why "by model" matters

It's where the surprise shows up. In seeded demo data, **6 policy-generation calls were the single largest line item** — more than the 90 classifier calls — because policy generation runs on `gpt-4o` while classification runs on `gpt-4o-mini`. A handful of premium-model calls can dominate the overhead, and this table is what makes that legible.

## Verified in the real app

Booted the actual server against in-memory Mongo, seeded a realistic mix of customer + internal records, and screenshotted the **built** dashboard (not a mockup). The detail page rendered:

- **Total overhead / Internal requests / Failed calls** stat row ($0.58 / 213 / 1)
- **By kind** — Routing policy generation $0.24 (6 req) at the top, then eval judge, eval replay, task classification, shadow candidate, model test, connection test (showing its 1 seeded failure)
- **By model** — gpt-4o $0.28 (10 req) > gpt-4o-mini $0.19 (163 req) > claude-haiku-4-5 $0.12 (40 req)
- **Recent internal calls** via the existing RequestsTable with `internalScope: "internal"`

And the Overview tile: "ARBR OVERHEAD $0.58 · 40.5% of total spend · view breakdown", clickable through to the page. (The 40% share is a seed artifact — real ratios are much smaller.)

Reuses existing primitives throughout — `Stat`/`Card`/`Table` from `ui.jsx`, and `RequestsTable`'s existing `fixedFilters` prop (no component changes needed). `npm run web:build` passes.

## Dependencies

Needs `GET /api/analytics/internal-spend` from #183. Merge #183 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)