### PR TITLE
fix(web): keep sidebar footer links on one row

### DIFF
--- a/web/src/components/Layout.jsx
+++ b/web/src/components/Layout.jsx
@@ -209,19 +209,31 @@ export default function Layout({ status, user, onSignOut, children }) {
               <div className="text-[10.5px] uppercase tracking-widest text-gray-400">{user.role}</div>
             </div>
           )}
-          <NavLink to={FOOTER_LINK.to} className={navClass}>
-            {FOOTER_LINK.icon}
-            {FOOTER_LINK.label}
-          </NavLink>
-          <a
-            href={PROJECT_LINK.href}
-            target="_blank"
-            rel="noreferrer"
-            className="mx-1 my-0.5 flex items-center gap-2.5 rounded-lg px-3 py-2 text-[13px] font-medium text-gray-600 transition-colors hover:bg-gray-50 hover:text-gray-900"
-          >
-            {PROJECT_LINK.icon}
-            {PROJECT_LINK.label}
-          </a>
+          <div className="mx-1 my-0.5 flex items-stretch gap-1">
+            <NavLink
+              to={FOOTER_LINK.to}
+              className={({ isActive }) =>
+                `flex flex-none items-center gap-1.5 whitespace-nowrap rounded-lg px-2 py-2 text-[13px] font-medium transition-colors ${
+                  isActive
+                    ? "bg-arbr-accent-50 text-arbr-charcoal font-semibold"
+                    : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+                }`
+              }
+            >
+              {FOOTER_LINK.icon}
+              {FOOTER_LINK.label}
+            </NavLink>
+            <a
+              href={PROJECT_LINK.href}
+              target="_blank"
+              rel="noreferrer"
+              title={PROJECT_LINK.href}
+              className="flex min-w-0 flex-1 items-center gap-1.5 rounded-lg px-2 py-2 text-[13px] font-medium text-gray-600 transition-colors hover:bg-gray-50 hover:text-gray-900"
+            >
+              {PROJECT_LINK.icon}
+              <span className="truncate">{PROJECT_LINK.label}</span>
+            </a>
+          </div>
           {(getAdminToken() || user) && onSignOut && (
             <button
               onClick={onSignOut}


### PR DESCRIPTION
## Summary
- Follow-up to #186. Stacking "Docs" and "projectarbr.org" as two footer rows grew the fixed footer's height, which shrank the scrollable nav area above it — on typical viewport heights, "Users" (last Govern item) now needed a scroll it didn't before.
- Puts both links in a single row instead: "Docs" sized to its content, "projectarbr.org" taking the remaining width (truncates with a `title` tooltip if the sidebar is ever narrower).

## Test plan
- [x] `npm --prefix web run build` succeeds
- [x] Screenshot verification: footer is back to its original single-row height, "Users" visible without scrolling, both links render legibly