### PR TITLE
feat(security): cloud-agnostic secret-manager integration (F-07)

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -64,6 +64,7 @@ export default defineConfig({
           { text: 'Model registry', link: '/models' },
           { text: 'Budgets & governance', link: '/budgets' },
           { text: 'Accountable admin access', link: '/auth' },
+          { text: 'Cloud secret-manager integration', link: '/secret-manager' },
           { text: 'Design-partner demo fixture', link: '/demo-fixture' },
         ]
       },

--- a/docs/secret-manager.md
+++ b/docs/secret-manager.md
@@ -1,0 +1,75 @@
+# Cloud secret-manager integration
+
+Environment variables and encrypted-MongoDB credentials work well for a pilot, but a partner's
+production environment commonly requires a managed secret store with rotation — no secret value
+ever committed to a `.env` file, and no restart needed when a key is rotated.
+
+Any credential-shaped environment variable — a provider API key (`OPENAI_API_KEY`,
+`ANTHROPIC_API_KEY`, ...), `ARBR_ADMIN_KEY`, or `ARBR_ENCRYPTION_KEY` — can hold either a literal
+value (today's behavior, unchanged) or a reference to a secret in a managed store, resolved
+transparently at boot and on a periodic refresh. There's no new UI and no migration: an existing
+deployment using literal values keeps working exactly as it does today.
+
+## GCP Secret Manager
+
+The one fully-working adapter today. It matches Arbr's own production target — `arbr.gyde.ai`
+runs on a GCE VM — and gets free authentication via the VM's attached service account
+(Application Default Credentials), no extra credential configuration.
+
+**1. Grant access.** The runtime service account needs read access to each secret it will
+resolve:
+
+```sh
+gcloud secrets add-iam-policy-binding openai-key \
+  --member="serviceAccount:YOUR-VM-SERVICE-ACCOUNT@PROJECT.iam.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+```
+
+**2. Point the env var at the secret**, using GCP's own resource-name syntax prefixed with
+`gcp-sm://` — copy-pasteable straight from the GCP Console's "Copy resource name" action:
+
+```sh
+OPENAI_API_KEY=gcp-sm://projects/123456789/secrets/openai-key/versions/latest
+```
+
+That's it — no other configuration. On boot, Arbr resolves every recognized reference before
+connecting to Mongo (fail-closed timing, same as the existing `ARBR_ADMIN_KEY`/
+`ARBR_ENCRYPTION_KEY` production checks): in production, a resolution failure (missing
+permission, wrong secret name, unreachable API) refuses to start with an actionable message; in
+dev, it's logged as a warning and treated as if the variable were unset.
+
+## Rotation
+
+A resolved secret is re-checked automatically every 10 minutes, and immediately via:
+
+```sh
+curl -X POST https://your-arbr-host/api/secrets/refresh \
+  -H "Authorization: Bearer $ARBR_ADMIN_KEY"
+```
+
+(administrator role required). Rotating a secret's value in GCP Console and calling this once is
+enough — no restart, no data migration. `GET /api/connections` reports `source: "secret-manager"`
+for a credential resolved this way, so an operator can see where a credential came from without
+ever seeing the secret or its exact reference.
+
+## Adding another store
+
+The resolver is built against a small, cloud-agnostic interface — one file per store:
+
+```js
+{ scheme: "aws-sm", matches: (uri) => boolean, resolve: (uri) => Promise<string> }
+```
+
+**AWS Secrets Manager** is the natural next adapter: `@aws-sdk/*` is already vendored via
+`@langchain/aws` for the Bedrock provider, so there's no new SDK dependency, and the AWS
+credential chain (IAM role on the instance, or `AWS_*` env vars) already applies. An `aws-sm://`
+scheme against ARNs would follow the exact same shape as `gcp-sm://`.
+
+**Azure Key Vault** would follow the same pattern — an `azure-kv://<vault-name>/<secret-name>`
+scheme, resolved via `@azure/identity` + `@azure/keyvault-secrets` using `DefaultAzureCredential`
+(picks up a managed identity automatically on an Azure VM, mirroring GCP's ADC). Not implemented
+yet; documented here so the shape is settled if/when a partner needs it.
+
+Either adapter is a new file implementing that interface, appended to the resolver's provider
+registry — no changes to `envCredentialFor()`, `secrets.js`, `csrf.js`, `semanticCache.js`,
+`adminAuth.js`, or the boot sequence that reads them.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
+        "@google-cloud/secret-manager": "^6.2.0",
         "@langchain/anthropic": "^1.5.1",
         "@langchain/aws": "^1.4.3",
         "@langchain/core": "^1.2.2",
@@ -1332,6 +1333,18 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@google-cloud/secret-manager": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-6.2.0.tgz",
+      "integrity": "sha512-KjusvEON/HLeS7VelJ1aoY4zUOcNnEYCQ69Vnncf3Fnk5OLl6Dl0QKimgw4ajW3CgR7pCUkNPneiK5HgWSGQOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-gax": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@google/generative-ai": {
       "version": "0.24.1",
       "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
@@ -1339,6 +1352,151 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/@grpc/proto-loader/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1424,12 +1582,79 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
     },
     "node_modules/@langchain/anthropic": {
       "version": "1.5.1",
@@ -1546,6 +1771,73 @@
       "dependencies": {
         "@noble/hashes": "^1.1.5"
       }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.0",
@@ -2143,6 +2435,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2484,7 +2785,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -2537,7 +2837,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2550,7 +2849,6 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2726,6 +3024,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/birpc": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
@@ -2800,6 +3107,12 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -2912,6 +3225,24 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -3082,7 +3413,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3108,6 +3438,15 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3213,6 +3552,33 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -3240,6 +3606,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/entities": {
@@ -3344,7 +3719,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3618,6 +3992,12 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3658,6 +4038,29 @@
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -3780,6 +4183,22 @@
         }
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
@@ -3818,6 +4237,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/formidable": {
@@ -3880,11 +4311,40 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
+      "integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -3940,6 +4400,27 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3951,6 +4432,36 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -3966,6 +4477,93 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^8.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/gaxios": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/gcp-metadata": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.3.tgz",
+      "integrity": "sha512-ziTrzUhhpL9Zk5k0HHzgP/KIpWDJT0VMBC/ynt/QIBvTW+UUcSivQRl6VlwTf/EilDxtSWklHoRsKy1c4k+59w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "7.1.3",
+        "google-logging-utils": "1.1.3",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.7.tgz",
+      "integrity": "sha512-EhiqaWWJ+9h7sCcKJTsoo6tMcjokVHhWsbSuWCnZJT4vIBP3y4mAoFLnt9SzgkVZeq24ZsFaArr06nnYYku2yA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.12.6",
+        "@grpc/proto-loader": "^0.8.0",
+        "duplexify": "^4.1.3",
+        "google-auth-library": "10.5.0",
+        "google-logging-utils": "1.1.3",
+        "node-fetch": "^3.3.2",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "3.0.4",
+        "protobufjs": "^7.5.4",
+        "retry-request": "^8.0.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax/node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3976,6 +4574,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/has-symbols": {
@@ -4094,11 +4705,23 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -4178,6 +4801,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -4214,8 +4846,22 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jose": {
       "version": "6.2.3",
@@ -4233,6 +4879,15 @@
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.5.1"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -4268,6 +4923,27 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/kareem": {
       "version": "3.3.0",
@@ -4350,6 +5026,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -4622,6 +5310,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/minisearch": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
@@ -4835,6 +5532,44 @@
       },
       "engines": {
         "node": ">=12.22.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/object-assign": {
@@ -5060,6 +5795,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -5083,11 +5824,32 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
@@ -5250,6 +6012,41 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/proto3-json-serializer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
+      "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "protobufjs": "^7.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -5316,6 +6113,20 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
@@ -5343,12 +6154,49 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/retry-request": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.3.tgz",
+      "integrity": "sha512-qqoc4kkGgP9cmQDWELlOpAmfgJOg0Yi7MT82ZjiPWu451ayju4itwomjM4/dBEliify8C1b3tSaeCOldugtwPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/rfdc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/rollup": {
       "version": "4.62.0",
@@ -5420,6 +6268,26 @@
       "dependencies": {
         "tslib": "^2.1.0"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -5503,7 +6371,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5516,7 +6383,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5630,6 +6496,18 @@
       "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
       "license": "MIT"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5689,6 +6567,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "license": "MIT",
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
     "node_modules/streamx": {
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
@@ -5699,6 +6592,15 @@
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -5717,6 +6619,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/stringify-entities": {
@@ -5738,7 +6682,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -5749,6 +6692,34 @@
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "license": "MIT"
     },
     "node_modules/superagent": {
       "version": "10.3.0",
@@ -5830,6 +6801,21 @@
         "bare-fs": "^4.5.5",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teeny-request": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.3.tgz",
+      "integrity": "sha512-5yDliI1uWkYPo7W+Zvrxg6YmoWuj5iC5EydewqrRTvc68nyMTZhlPPlLg6cptUGfbQAb+N9XDPDPzF6N081lug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/teex": {
@@ -5950,6 +6936,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
@@ -6041,6 +7033,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "14.0.1",
@@ -6218,6 +7216,15 @@
         }
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -6244,7 +7251,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6284,6 +7290,80 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -6315,7 +7395,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "bench:latency:stream": "node server/scripts/latency-bench.js --stream"
   },
   "dependencies": {
+    "@google-cloud/secret-manager": "^6.2.0",
     "@langchain/anthropic": "^1.5.1",
     "@langchain/aws": "^1.4.3",
     "@langchain/core": "^1.2.2",

--- a/server/src/api/adminAuth.js
+++ b/server/src/api/adminAuth.js
@@ -21,12 +21,24 @@
 const { config } = require("../config");
 const { timingSafeEqual, bearerOf } = require("./authUtil");
 const identity = require("./identity");
+const secretResolver = require("../security/secretResolver");
 
 const MASTER_USER = { id: "master-key", email: "master-key", role: "administrator", isMasterKey: true };
 
+// Live read so a rotated ARBR_ADMIN_KEY (via a secret-manager reference)
+// takes effect on the next periodic refresh / manual refresh call, with no
+// restart. Returns undefined (never a still-unresolved ref string) when
+// resolution hasn't happened or failed — config.adminKey (the raw env
+// value) is used only to detect "was anything configured at all", below,
+// never as a fallback credential here.
+function effectiveAdminKey() {
+  return secretResolver.resolvedOrLiteral("ARBR_ADMIN_KEY");
+}
+
 function isAdminRequest(req) {
   const token = bearerOf(req);
-  return !!(token && config.adminKey && timingSafeEqual(token, config.adminKey));
+  const adminKey = effectiveAdminKey();
+  return !!(token && adminKey && timingSafeEqual(token, adminKey));
 }
 
 async function middleware(req, res, next) {

--- a/server/src/api/csrf.js
+++ b/server/src/api/csrf.js
@@ -8,14 +8,19 @@ const crypto = require("crypto");
 const { doubleCsrf } = require("csrf-csrf");
 const { config } = require("../config");
 const { SESSION_COOKIE } = require("./identity");
+const secretResolver = require("../security/secretResolver");
 
 // Falls back to a per-boot random secret when ARBR_ENCRYPTION_KEY is unset —
 // harmless since this only matters once ARBR_AUTH_MODE=oidc is configured
 // (adminkey mode, the default, never sets a session cookie to begin with).
-const secret = process.env.ARBR_ENCRYPTION_KEY || crypto.randomBytes(32).toString("hex");
+// Stable for the process lifetime; read live (not a cached const) so a
+// gcp-sm:// reference resolves to the real value instead of being used
+// literally as the CSRF secret.
+const randomFallback = crypto.randomBytes(32).toString("hex");
+const secret = () => secretResolver.resolvedOrLiteral("ARBR_ENCRYPTION_KEY") ?? randomFallback;
 
 const { generateCsrfToken, doubleCsrfProtection } = doubleCsrf({
-  getSecret: () => secret,
+  getSecret: () => secret(),
   getSessionIdentifier: (req) => (req.cookies && req.cookies[SESSION_COOKIE]) || "no-session",
   cookieName: "arbr_csrf",
   cookieOptions: { httpOnly: true, sameSite: "lax", secure: config.isProduction, path: "/" },

--- a/server/src/api/routes/connections.js
+++ b/server/src/api/routes/connections.js
@@ -5,6 +5,8 @@ const { requireRole } = require("../rbac");
 const { createRouter } = require("../../providers/llm-router");
 const { toRouterConfig, getRouter } = require("../../providers/router");
 const { internalComplete } = require("../../internal/complete");
+const secretResolver = require("../../security/secretResolver");
+const { PROVIDERS } = require("../../config");
 
 const router = express.Router();
 
@@ -69,5 +71,19 @@ router.post("/connections/:provider/test", requireRole("administrator"), async (
   }
 });
 
+
+// Re-resolve every credential-shaped env var (picks up a rotated
+// secret-manager value with no restart) and invalidate the connections
+// cache so the next request reflects it. Never returns a value — matches
+// the statuses() masking convention exactly.
+router.post("/secrets/refresh", requireRole("administrator"), async (_req, res, next) => {
+  try {
+    const envVarNames = ["ARBR_ADMIN_KEY", "ARBR_ENCRYPTION_KEY",
+      ...Object.values(PROVIDERS).flatMap((p) => Object.values(p.env))];
+    const { resolved, failures } = await secretResolver.refreshAll(envVarNames);
+    connections.invalidate();
+    res.json({ resolved: resolved.length, failures });
+  } catch (e) { next(e); }
+});
 
 module.exports = router;

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -6,6 +6,7 @@
 //   - aws providers (bedrock-nova / Amazon Nova): accessKeyId + secretAccessKey + region
 // The registry below captures that so the rest of the system stays generic.
 require("dotenv").config();
+const secretResolver = require("./security/secretResolver");
 
 const PROVIDERS = {
   openai: {
@@ -110,7 +111,7 @@ function envCredentialFor(id) {
   const required = spec.required || spec.fields;
   const cred = {};
   for (const field of spec.fields) {
-    const val = process.env[spec.env[field]];
+    const val = secretResolver.resolvedOrLiteral(spec.env[field]);
     if (val && val.trim()) cred[field] = val.trim();
   }
   if (spec.authType === "aws" && !cred.region) cred.region = spec.regionDefault;

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -6,7 +6,8 @@ const express = require("express");
 const cors = require("cors");
 const cookieParser = require("cookie-parser");
 const mongoose = require("mongoose");
-const { config, describe, assertProductionReady } = require("./config");
+const { config, describe, assertProductionReady, PROVIDERS } = require("./config");
+const secretResolver = require("./security/secretResolver");
 const registry = require("./pricing/registry");
 const { TASK_CATALOG } = require("./classify/classifier");
 const { handleChat } = require("./gateway/handler");
@@ -35,6 +36,17 @@ const WEB_DIST = path.resolve(__dirname, "../../web/dist");
 async function start() {
   // Fail closed before any network bind when running as production.
   assertProductionReady();
+
+  // Resolve any credential-shaped env var that holds a secret-manager
+  // reference (gcp-sm://...) instead of a literal — before Mongo connects
+  // or anything else reads a credential, same fail-closed timing as
+  // assertProductionReady() above. A no-op when every value is a literal
+  // (every existing deployment, forever, unless it opts into a reference).
+  const secretEnvVarNames = ["ARBR_ADMIN_KEY", "ARBR_ENCRYPTION_KEY",
+    ...Object.values(PROVIDERS).flatMap((p) => Object.values(p.env))];
+  const { failures } = await secretResolver.refreshAll(secretEnvVarNames);
+  secretResolver.assertResolvedOrThrow(failures, config.isProduction);
+  secretResolver.startPeriodicRefresh(secretEnvVarNames);
 
   await mongoose.connect(config.mongoUri);
   await registry.init(); // seed ModelEntry if empty + warm in-memory cache

--- a/server/src/providers/connections.js
+++ b/server/src/providers/connections.js
@@ -14,6 +14,7 @@ const ProviderCredential = require("../models/ProviderCredential");
 const CustomProvider = require("../models/CustomProvider");
 const Settings = require("../models/Settings");
 const secrets = require("../security/secrets");
+const secretResolver = require("../security/secretResolver");
 const pricing = require("../pricing/registry");
 
 const TTL_MS = 3000;
@@ -116,6 +117,9 @@ async function statuses() {
       const envCred = envCredentialFor(id);
       last4 = (envCred?.[primaryField(id)] || "").slice(-4);
       region = envCred?.region || null;
+      // Surface that this credential came from a managed secret store —
+      // never the reference itself, just the boolean.
+      if (secretResolver.wasSecretRef(spec.env[primaryField(id)])) source = "secret-manager";
     } else if (source === "stored") {
       last4 = storedDocs[id]?.last4 || "";
       region = storedDocs[id]?.region || null;

--- a/server/src/routing/semanticCache.js
+++ b/server/src/routing/semanticCache.js
@@ -12,6 +12,7 @@
 //   _textFromMessages(messages)           → string (exported for tests)
 
 const { OpenAIEmbeddings } = require("@langchain/openai");
+const secretResolver = require("../security/secretResolver");
 
 const MAX_ENTRIES = 1000;
 const _store = new Map(); // key → { embedding: number[], value, expiresAt }
@@ -20,7 +21,7 @@ let _embedder = null;
 let _embedderInitKey = null;
 
 function _initEmbedder() {
-  const key = process.env.OPENAI_API_KEY;
+  const key = secretResolver.resolvedOrLiteral("OPENAI_API_KEY");
   if (!key) return null;
   if (_embedder && _embedderInitKey === key) return _embedder;
   _embedder = new OpenAIEmbeddings({
@@ -134,4 +135,4 @@ async function set(messages, value, ttlMinutes) {
 function clear() { _store.clear(); }
 function size()  { return _store.size; }
 
-module.exports = { get, set, clear, size, cosineSimilarity, invalidate, _textFromMessages };
+module.exports = { get, set, clear, size, cosineSimilarity, invalidate, _textFromMessages, _initEmbedder };

--- a/server/src/security/secretProviders/gcpSecretManager.js
+++ b/server/src/security/secretProviders/gcpSecretManager.js
@@ -1,0 +1,52 @@
+// GCP Secret Manager SecretProvider. Resource strings are GCP's own
+// resource-name syntax (as they appear after the "gcp-sm://" prefix is
+// stripped by secretRef.js), e.g. "projects/123/secrets/openai-key/versions/latest".
+// Authenticates via Application Default Credentials — free on a GCE VM with
+// an attached service account, no extra credential config.
+const { parseSecretRef } = require("../secretRef");
+
+let client = null;
+function getClient() {
+  // Constructed lazily so requiring this module never requires GCP
+  // reachability in environments that don't use the gcp-sm:// scheme.
+  if (!client) {
+    const { SecretManagerServiceClient } = require("@google-cloud/secret-manager");
+    client = new SecretManagerServiceClient();
+  }
+  return client;
+}
+
+// Maps a GCP client error to an actionable message. Never includes the
+// attempted secret's value — there is none to include, only the resource
+// name, which is safe to surface (it names the secret, not its value).
+function actionableMessage(resource, err) {
+  const code = err && err.code;
+  if (code === 7) { // PERMISSION_DENIED
+    return `permission denied reading "${resource}" — grant the runtime service account ` +
+      "roles/secretmanager.secretAccessor on this secret";
+  }
+  if (code === 5) { // NOT_FOUND
+    return `secret not found: "${resource}" — check the secret name and version`;
+  }
+  return (err && err.message) || `failed to resolve "${resource}"`;
+}
+
+// `client` is injectable (tests pass a fake, never touching the real SDK or
+// network); production call sites never pass one, so this always lazily
+// constructs the real singleton.
+async function resolve(resource, client = getClient()) {
+  try {
+    const [version] = await client.accessSecretVersion({ name: resource });
+    return version.payload.data.toString("utf8");
+  } catch (err) {
+    throw new Error(actionableMessage(resource, err));
+  }
+}
+
+module.exports = {
+  scheme: "gcp-sm",
+  matches: (uri) => parseSecretRef(uri)?.scheme === "gcp-sm",
+  resolve: (uri) => resolve(parseSecretRef(uri).resource),
+  _resolveResource: resolve, // test-only: accepts an injected fake client
+  _actionableMessage: actionableMessage, // test-only
+};

--- a/server/src/security/secretRef.js
+++ b/server/src/security/secretRef.js
@@ -1,0 +1,18 @@
+// Parses a credential-shaped env var's raw string value into a secret-manager
+// reference, if it looks like one — a generic `scheme://resource` shape,
+// anchored at the start of the string. NOT tied to a hardcoded scheme
+// allowlist: which schemes are actually usable is entirely a function of
+// which providers are registered in secretResolver.js's PROVIDERS_REGISTRY,
+// so adding a new cloud (aws-sm://, azure-kv://) never requires touching
+// this file. A real credential literal (API key, admin key, etc.) never
+// takes this shape in practice, so this can't misidentify one.
+const SCHEME_PATTERN = /^([a-z][a-z0-9+.-]*):\/\/(.+)$/i;
+
+// value -> { scheme, resource } | null
+function parseSecretRef(value) {
+  if (typeof value !== "string") return null;
+  const m = SCHEME_PATTERN.exec(value);
+  return m ? { scheme: m[1], resource: m[2] } : null;
+}
+
+module.exports = { parseSecretRef };

--- a/server/src/security/secretResolver.js
+++ b/server/src/security/secretResolver.js
@@ -1,0 +1,119 @@
+// Resolves credential-shaped env var values that may hold a secret-manager
+// reference instead of a literal. A no-op for every existing deployment: a
+// literal value is returned unchanged. Cloud-agnostic — PROVIDERS_REGISTRY
+// holds one entry per backing store; adding AWS/Azure later means writing
+// one file implementing the same { matches, resolve } shape and appending it
+// here, with zero changes to anything below.
+const { parseSecretRef } = require("./secretRef");
+const gcpSecretManager = require("./secretProviders/gcpSecretManager");
+
+const PROVIDERS_REGISTRY = [gcpSecretManager];
+
+const DEFAULT_INTERVAL_MS = 10 * 60 * 1000; // secret rotation isn't hot-path
+
+// envVarName -> { value, ref } | undefined. Resolved values only ever live
+// here — never logged, never serialized in any API response.
+const _cache = new Map();
+let _timer = null;
+
+function findProvider(rawValue) {
+  return PROVIDERS_REGISTRY.find((p) => p.matches(rawValue));
+}
+
+// Resolves one env var's raw value. Literal values pass through untouched
+// (the common case). Returns the resolved value; throws on a ref that fails
+// to resolve — callers decide whether that's fatal.
+async function resolveOne(envVarName, rawValue) {
+  const ref = parseSecretRef(rawValue);
+  if (!ref) {
+    _cache.delete(envVarName); // a literal never counts as "was a secret ref"
+    return rawValue;
+  }
+  const provider = findProvider(rawValue);
+  if (!provider) throw new Error(`[secrets] no provider registered for scheme "${ref.scheme}"`);
+  const value = await provider.resolve(rawValue);
+  _cache.set(envVarName, { value, ref: rawValue });
+  return value;
+}
+
+// Resolves every name in the list (reading process.env fresh). Collects
+// failures instead of throwing per-item — the caller (production boot vs.
+// dev warn) decides what a failure means.
+async function refreshAll(envVarNames) {
+  const resolved = [];
+  const failures = [];
+  for (const name of envVarNames) {
+    const raw = process.env[name];
+    if (raw === undefined) continue; // unset — nothing to resolve, existing behavior
+    try {
+      await resolveOne(name, raw);
+      resolved.push(name);
+    } catch (err) {
+      failures.push({ name, error: err.message });
+    }
+  }
+  return { resolved, failures };
+}
+
+// Sync cache read — the hot-path accessor every credential reader calls on
+// every request. Returns undefined when there's nothing resolved (literal
+// value, unset var, or a failed resolve), so callers fall through to
+// process.env[name] exactly as they do today.
+function getResolved(envVarName) {
+  return _cache.get(envVarName)?.value;
+}
+
+// True if the cached entry for this name came from a resolved secret-manager
+// reference (for the Connections UI's source label) — never exposes the ref
+// itself, just the boolean.
+function wasSecretRef(envVarName) {
+  return _cache.has(envVarName);
+}
+
+// The value every credential reader should actually use: the resolved
+// value if there is one, else the raw env var IF it's a genuine literal —
+// but never the raw ref string itself when resolution hasn't happened yet
+// or failed (e.g. dev mode, where a failure only warns rather than refusing
+// to start). Without this, a still-unresolved "gcp-sm://..." string would
+// be silently accepted as if it were the credential itself.
+function resolvedOrLiteral(envVarName) {
+  const resolved = getResolved(envVarName);
+  if (resolved !== undefined) return resolved;
+  const raw = process.env[envVarName];
+  return parseSecretRef(raw) ? undefined : raw;
+}
+
+function startPeriodicRefresh(envVarNames, intervalMs = DEFAULT_INTERVAL_MS) {
+  if (_timer) return;
+  const connections = require("../providers/connections"); // lazy: avoid a require-time cycle
+  _timer = setInterval(async () => {
+    await refreshAll(envVarNames);
+    connections.invalidate();
+  }, intervalMs);
+  if (_timer.unref) _timer.unref();
+}
+
+function stopPeriodicRefresh() {
+  if (_timer) { clearInterval(_timer); _timer = null; }
+}
+
+// Boot-time fail-closed check (pure, sync — easy to unit-test in isolation
+// from the rest of index.js's start() sequence, which also connects Mongo
+// and binds the HTTP port). In production, any resolution failure refuses
+// to start; outside production, a failure is just a warning, matching
+// today's existing behavior for a missing/blank var.
+function assertResolvedOrThrow(failures, isProduction) {
+  if (isProduction && failures.length) {
+    throw new Error("[secrets] Refusing to start — could not resolve:\n  - " +
+      failures.map((f) => `${f.name}: ${f.error}`).join("\n  - "));
+  }
+  for (const f of failures) {
+    console.warn(`[secrets] could not resolve ${f.name}: ${f.error} — treating as unset.`);
+  }
+}
+
+module.exports = {
+  resolveOne, refreshAll, getResolved, wasSecretRef, resolvedOrLiteral,
+  startPeriodicRefresh, stopPeriodicRefresh, assertResolvedOrThrow,
+  PROVIDERS_REGISTRY,
+};

--- a/server/src/security/secrets.js
+++ b/server/src/security/secrets.js
@@ -8,13 +8,14 @@
 // it would make them trivially decryptable by anyone. Set ARBR_ENCRYPTION_KEY (any
 // strong string) in real deployments.
 const crypto = require("crypto");
+const secretResolver = require("./secretResolver");
 
 // Public, intentionally-insecure constant: safe to ship only because it is refused in production.
 const DEV_FALLBACK = "arbr-dev-insecure-encryption-key-change-me";
 let warned = false;
 
 function secret() {
-  const s = process.env.ARBR_ENCRYPTION_KEY;
+  const s = secretResolver.resolvedOrLiteral("ARBR_ENCRYPTION_KEY");
   if (s && s.trim()) return s.trim();
 
   // Never silently fall back to the public dev key in production — fail loud and early.

--- a/server/test/integration/secretsRefresh.test.js
+++ b/server/test/integration/secretsRefresh.test.js
@@ -1,0 +1,81 @@
+"use strict";
+// F-07 (cloud secret-manager integration): POST /api/secrets/refresh.
+process.env.ARBR_ADMIN_KEY = "";
+
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+const mongoose = require("mongoose");
+const express = require("express");
+const supertest = require("supertest");
+
+const apiRoutes = require("../../src/api/routes");
+const secretResolver = require("../../src/security/secretResolver");
+
+let mongod, agent;
+let currentTestUser = { id: "admin-1", email: "admin@test", role: "administrator" };
+const stubUser = (req, _res, next) => { req.user = currentTestUser; next(); };
+const buildApp = () => {
+  const a = express();
+  a.use(express.json());
+  a.use(stubUser);
+  a.use("/api", apiRoutes);
+  return a;
+};
+
+const fakeProvider = {
+  scheme: "fake",
+  matches: (uri) => typeof uri === "string" && uri.startsWith("fake://"),
+  resolve: async (uri) => {
+    if (uri.includes("fail")) throw new Error("injected fake-secret failure for test XYZ-do-not-leak");
+    return "injected-fake-secret-value-should-never-appear-in-response";
+  },
+};
+
+before(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  agent = supertest(buildApp());
+  secretResolver.PROVIDERS_REGISTRY.push(fakeProvider);
+});
+after(async () => {
+  const i = secretResolver.PROVIDERS_REGISTRY.indexOf(fakeProvider);
+  if (i >= 0) secretResolver.PROVIDERS_REGISTRY.splice(i, 1);
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+beforeEach(() => {
+  currentTestUser = { id: "admin-1", email: "admin@test", role: "administrator" };
+  delete process.env.OPENAI_API_KEY;
+});
+
+test("requires administrator role — 403 for operator", async () => {
+  currentTestUser = { id: "o-1", email: "operator@test", role: "operator" };
+  const res = await agent.post("/api/secrets/refresh");
+  assert.equal(res.status, 403);
+});
+
+test("administrator: resolves configured refs, returns counts and failures — never a value", async () => {
+  process.env.OPENAI_API_KEY = "fake://openai-key";
+  const res = await agent.post("/api/secrets/refresh");
+  delete process.env.OPENAI_API_KEY;
+
+  assert.equal(res.status, 200);
+  assert.equal(typeof res.body.resolved, "number");
+  assert.ok(res.body.resolved >= 1);
+  assert.deepEqual(res.body.failures, []);
+
+  const serialized = JSON.stringify(res.body);
+  assert.ok(!serialized.includes("injected-fake-secret-value-should-never-appear-in-response"));
+});
+
+test("administrator: a failing ref is reported in failures, response still has no value or leaked detail beyond the error field", async () => {
+  process.env.OPENAI_API_KEY = "fake://please-fail";
+  const res = await agent.post("/api/secrets/refresh");
+  delete process.env.OPENAI_API_KEY;
+
+  assert.equal(res.status, 200);
+  assert.equal(res.body.failures.length, 1);
+  assert.equal(res.body.failures[0].name, "OPENAI_API_KEY");
+  assert.match(res.body.failures[0].error, /injected fake-secret failure for test XYZ-do-not-leak/);
+});

--- a/server/test/unit/gcpSecretManager.test.js
+++ b/server/test/unit/gcpSecretManager.test.js
@@ -1,0 +1,72 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const gcpSecretManager = require("../../src/security/secretProviders/gcpSecretManager");
+
+const RESOURCE = "projects/123/secrets/openai-key/versions/latest";
+const URI = `gcp-sm://${RESOURCE}`;
+
+test("matches() only accepts gcp-sm:// references", () => {
+  assert.equal(gcpSecretManager.matches(URI), true);
+  assert.equal(gcpSecretManager.matches("sk-a-literal-key"), false);
+  assert.equal(gcpSecretManager.matches("aws-sm://arn:..."), false);
+});
+
+test("_resolveResource returns the secret payload as utf8, via an injected fake client", async () => {
+  const fakeClient = {
+    accessSecretVersion: async ({ name }) => {
+      assert.equal(name, RESOURCE);
+      return [{ payload: { data: Buffer.from("super-secret-value", "utf8") } }];
+    },
+  };
+  const value = await gcpSecretManager._resolveResource(RESOURCE, fakeClient);
+  assert.equal(value, "super-secret-value");
+});
+
+test("PERMISSION_DENIED maps to an actionable message naming the IAM role, never a value", async () => {
+  const err = new Error("original grpc message with no secret in it");
+  err.code = 7; // PERMISSION_DENIED
+  const fakeClient = { accessSecretVersion: async () => { throw err; } };
+  await assert.rejects(
+    () => gcpSecretManager._resolveResource(RESOURCE, fakeClient),
+    (thrown) => {
+      assert.match(thrown.message, /secretAccessor/);
+      assert.match(thrown.message, new RegExp(RESOURCE.replace(/\//g, "\\/")));
+      return true;
+    }
+  );
+});
+
+test("NOT_FOUND maps to an actionable message", async () => {
+  const err = new Error("not found");
+  err.code = 5; // NOT_FOUND
+  const fakeClient = { accessSecretVersion: async () => { throw err; } };
+  await assert.rejects(
+    () => gcpSecretManager._resolveResource(RESOURCE, fakeClient),
+    /check the secret name and version/
+  );
+});
+
+test("an unmapped error code falls back to the raw error message", async () => {
+  const err = new Error("some other transient failure");
+  err.code = 14; // UNAVAILABLE, not specially handled
+  const fakeClient = { accessSecretVersion: async () => { throw err; } };
+  await assert.rejects(
+    () => gcpSecretManager._resolveResource(RESOURCE, fakeClient),
+    /some other transient failure/
+  );
+});
+
+test("no attempted secret value ever appears in a thrown error's message", async () => {
+  // There is nothing to leak here (only the resource name is passed in), but
+  // assert the invariant explicitly so a future refactor can't regress it.
+  const err = new Error("boom");
+  err.code = 7;
+  const fakeClient = { accessSecretVersion: async () => { throw err; } };
+  try {
+    await gcpSecretManager._resolveResource(RESOURCE, fakeClient);
+    assert.fail("expected a rejection");
+  } catch (thrown) {
+    assert.ok(!thrown.message.includes("payload"));
+  }
+});

--- a/server/test/unit/secretRef.test.js
+++ b/server/test/unit/secretRef.test.js
@@ -1,0 +1,34 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { parseSecretRef } = require("../../src/security/secretRef");
+
+test("parses a gcp-sm:// reference into scheme + resource", () => {
+  const ref = parseSecretRef("gcp-sm://projects/123/secrets/openai-key/versions/latest");
+  assert.deepEqual(ref, { scheme: "gcp-sm", resource: "projects/123/secrets/openai-key/versions/latest" });
+});
+
+test("a plain literal API key is never misidentified as a ref", () => {
+  assert.equal(parseSecretRef("sk-abc123def456"), null);
+  assert.equal(parseSecretRef(""), null);
+  assert.equal(parseSecretRef(undefined), null);
+  assert.equal(parseSecretRef(null), null);
+});
+
+test("'gcp-sm://' with no resource after the prefix is not a valid ref", () => {
+  assert.equal(parseSecretRef("gcp-sm://"), null);
+});
+
+test("parseSecretRef recognizes ANY scheme://resource shape, not a hardcoded allowlist", () => {
+  // Deliberate: which schemes are actually usable is the registry's job
+  // (secretResolver.js's PROVIDERS_REGISTRY), not this file's — otherwise
+  // adding a cloud adapter would require editing two places instead of one.
+  // No credential this codebase reads (API keys, ARBR_ADMIN_KEY, etc.) is
+  // ever shaped like a URL, so this can't misidentify a real literal.
+  assert.deepEqual(parseSecretRef("aws-sm://arn:aws:secretsmanager:..."), {
+    scheme: "aws-sm", resource: "arn:aws:secretsmanager:...",
+  });
+  assert.deepEqual(parseSecretRef("azure-kv://myvault/mysecret"), {
+    scheme: "azure-kv", resource: "myvault/mysecret",
+  });
+});

--- a/server/test/unit/secretResolver.test.js
+++ b/server/test/unit/secretResolver.test.js
@@ -1,0 +1,122 @@
+"use strict";
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+const secretResolver = require("../../src/security/secretResolver");
+
+// A fake SecretProvider — no real GCP calls, no network. Injected directly
+// into the live registry array (append/splice), the same array
+// secretResolver dispatches through.
+const fakeProvider = {
+  scheme: "fake",
+  matches: (uri) => typeof uri === "string" && uri.startsWith("fake://"),
+  resolve: async (uri) => {
+    if (uri.includes("fail")) throw new Error("fake provider failure");
+    return `resolved:${uri.slice("fake://".length)}`;
+  },
+};
+
+before(() => { secretResolver.PROVIDERS_REGISTRY.push(fakeProvider); });
+after(() => {
+  const i = secretResolver.PROVIDERS_REGISTRY.indexOf(fakeProvider);
+  if (i >= 0) secretResolver.PROVIDERS_REGISTRY.splice(i, 1);
+});
+
+const ENV = "TEST_FAKE_SECRET";
+beforeEach(async () => {
+  // Clear any cache entry from a prior test by resolving a literal.
+  await secretResolver.resolveOne(ENV, "reset-to-literal");
+});
+
+test("a literal value passes through unchanged and is never marked as a secret ref", async () => {
+  const value = await secretResolver.resolveOne(ENV, "sk-literal-value");
+  assert.equal(value, "sk-literal-value");
+  assert.equal(secretResolver.getResolved(ENV), undefined); // literal never cached
+  assert.equal(secretResolver.wasSecretRef(ENV), false);
+});
+
+test("a matching ref resolves and caches the resolved value", async () => {
+  const value = await secretResolver.resolveOne(ENV, "fake://my-secret");
+  assert.equal(value, "resolved:my-secret");
+  assert.equal(secretResolver.getResolved(ENV), "resolved:my-secret");
+  assert.equal(secretResolver.wasSecretRef(ENV), true);
+});
+
+test("resolveOne throws for an unrecognized scheme", async () => {
+  await assert.rejects(
+    () => secretResolver.resolveOne(ENV, "unregistered-scheme://x"),
+    /no provider registered/
+  );
+});
+
+test("refreshAll collects a failing resolve instead of throwing", async () => {
+  process.env[ENV] = "fake://please-fail";
+  const { resolved, failures } = await secretResolver.refreshAll([ENV]);
+  delete process.env[ENV];
+  assert.deepEqual(resolved, []);
+  assert.equal(failures.length, 1);
+  assert.equal(failures[0].name, ENV);
+  assert.match(failures[0].error, /fake provider failure/);
+});
+
+test("resolvedOrLiteral: a plain literal env var passes through unchanged", () => {
+  process.env[ENV] = "sk-a-plain-literal-key";
+  assert.equal(secretResolver.resolvedOrLiteral(ENV), "sk-a-plain-literal-key");
+  delete process.env[ENV];
+});
+
+test("resolvedOrLiteral: returns the resolved value once a ref has been resolved", async () => {
+  process.env[ENV] = "fake://real-value";
+  await secretResolver.refreshAll([ENV]);
+  assert.equal(secretResolver.resolvedOrLiteral(ENV), "resolved:real-value");
+  delete process.env[ENV];
+});
+
+test("resolvedOrLiteral: an UNRESOLVED ref never falls through as if it were the literal credential", () => {
+  // The exact gap a manual boot smoke test caught: without this, a
+  // gcp-sm://... string that failed to resolve (or was never refreshed)
+  // would be silently accepted as a usable credential value.
+  process.env[ENV] = "fake://never-refreshed";
+  assert.equal(secretResolver.resolvedOrLiteral(ENV), undefined);
+  delete process.env[ENV];
+});
+
+test("resolvedOrLiteral: unset env var returns undefined", () => {
+  delete process.env[ENV];
+  assert.equal(secretResolver.resolvedOrLiteral(ENV), undefined);
+});
+
+test("refreshAll resolves a successful ref and overwrites the cache on a subsequent refresh", async () => {
+  process.env[ENV] = "fake://first-value";
+  let result = await secretResolver.refreshAll([ENV]);
+  assert.deepEqual(result.resolved, [ENV]);
+  assert.equal(secretResolver.getResolved(ENV), "resolved:first-value");
+
+  process.env[ENV] = "fake://second-value";
+  result = await secretResolver.refreshAll([ENV]);
+  assert.deepEqual(result.resolved, [ENV]);
+  assert.equal(secretResolver.getResolved(ENV), "resolved:second-value");
+
+  delete process.env[ENV];
+});
+
+test("refreshAll skips an unset env var without error", async () => {
+  delete process.env[ENV];
+  const { resolved, failures } = await secretResolver.refreshAll([ENV]);
+  assert.deepEqual(resolved, []);
+  assert.deepEqual(failures, []);
+});
+
+test("assertResolvedOrThrow: production + failures -> throws with an actionable message", () => {
+  assert.throws(
+    () => secretResolver.assertResolvedOrThrow([{ name: "X", error: "boom" }], true),
+    /Refusing to start.*X: boom/s
+  );
+});
+
+test("assertResolvedOrThrow: production + no failures -> does not throw", () => {
+  assert.doesNotThrow(() => secretResolver.assertResolvedOrThrow([], true));
+});
+
+test("assertResolvedOrThrow: non-production + failures -> warns, does not throw", () => {
+  assert.doesNotThrow(() => secretResolver.assertResolvedOrThrow([{ name: "X", error: "boom" }], false));
+});

--- a/server/test/unit/secretResolverCallSites.test.js
+++ b/server/test/unit/secretResolverCallSites.test.js
@@ -1,0 +1,124 @@
+"use strict";
+// Regression coverage for every Phase 4 call site the F-07 secret-manager
+// resolver was wired into: proves literal-value behavior is byte-identical
+// before/after (not just that the resolver's own unit works in isolation),
+// plus the one case a plan review found broken in an earlier draft —
+// adminAuth.js reading a *resolved* ARBR_ADMIN_KEY, not a boot-time snapshot.
+const { test, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const secretResolver = require("../../src/security/secretResolver");
+
+const ORIG_ENV = { ...process.env };
+afterEach(() => {
+  for (const k of Object.keys(process.env)) if (!(k in ORIG_ENV)) delete process.env[k];
+  for (const [k, v] of Object.entries(ORIG_ENV)) process.env[k] = v;
+});
+
+// config.js and adminAuth.js both read env vars at require-time (config.js's
+// envLive snapshot, adminAuth's captured `config` reference) — re-require
+// fresh after mutating env, same pattern as assertProductionReady.test.js.
+function freshRequire(relPath) {
+  delete require.cache[require.resolve(relPath)];
+  return require(relPath);
+}
+
+beforeEach(async () => {
+  // Clear any leftover resolver cache entries from other test files.
+  await secretResolver.resolveOne("OPENAI_API_KEY", "reset");
+  await secretResolver.resolveOne("ARBR_ADMIN_KEY", "reset");
+  await secretResolver.resolveOne("ARBR_ENCRYPTION_KEY", "reset");
+});
+
+test("config.js envCredentialFor(): a literal OPENAI_API_KEY resolves exactly as before", () => {
+  process.env.OPENAI_API_KEY = "sk-literal-openai-key";
+  const { envCredentialFor } = freshRequire("../../src/config");
+  assert.deepEqual(envCredentialFor("openai"), { apiKey: "sk-literal-openai-key" });
+});
+
+test("secrets.js secret(): a literal ARBR_ENCRYPTION_KEY derives the same key bytes as before", () => {
+  process.env.ARBR_ENCRYPTION_KEY = "literal-encryption-key";
+  const secrets = freshRequire("../../src/security/secrets");
+  const a = secrets.encrypt("hello");
+  // Re-require again (same literal) — decrypting with a fresh module instance
+  // must still work, proving secret() derives identically each time.
+  const secrets2 = freshRequire("../../src/security/secrets");
+  assert.equal(secrets2.decrypt(a), "hello");
+});
+
+test("semanticCache._initEmbedder(): a literal OPENAI_API_KEY still initializes the embedder as before", () => {
+  const semanticCache = require("../../src/routing/semanticCache");
+  semanticCache.invalidate(); // discard any embedder cached by another test file
+  process.env.OPENAI_API_KEY = "sk-literal-for-embedder";
+  const embedder = semanticCache._initEmbedder();
+  assert.ok(embedder, "expected an embedder to be constructed for a literal key");
+  semanticCache.invalidate();
+});
+
+test("semanticCache._initEmbedder(): no key at all still returns null as before", () => {
+  const semanticCache = require("../../src/routing/semanticCache");
+  semanticCache.invalidate();
+  delete process.env.OPENAI_API_KEY;
+  assert.equal(semanticCache._initEmbedder(), null);
+});
+
+test("semanticCache._initEmbedder(): a resolved secret-manager value is preferred over the raw ref literal", async () => {
+  const semanticCache = require("../../src/routing/semanticCache");
+  semanticCache.invalidate();
+  process.env.OPENAI_API_KEY = "fake://openai-key-ref";
+
+  const fakeProvider = {
+    scheme: "fake",
+    matches: (uri) => typeof uri === "string" && uri.startsWith("fake://"),
+    resolve: async () => "sk-resolved-from-secret-manager",
+  };
+  secretResolver.PROVIDERS_REGISTRY.push(fakeProvider);
+  try {
+    await secretResolver.refreshAll(["OPENAI_API_KEY"]);
+    const embedder = semanticCache._initEmbedder();
+    assert.ok(embedder, "expected an embedder to be constructed from the resolved value");
+  } finally {
+    const i = secretResolver.PROVIDERS_REGISTRY.indexOf(fakeProvider);
+    if (i >= 0) secretResolver.PROVIDERS_REGISTRY.splice(i, 1);
+    semanticCache.invalidate();
+  }
+});
+
+test("adminAuth.isAdminRequest(): a literal ARBR_ADMIN_KEY with no resolver cache populated still authenticates", () => {
+  process.env.ARBR_ADMIN_KEY = "literal-admin-key";
+  freshRequire("../../src/config");
+  const adminAuth = freshRequire("../../src/api/adminAuth");
+  const req = { headers: { authorization: "Bearer literal-admin-key" } };
+  assert.equal(adminAuth.isAdminRequest(req), true);
+  assert.equal(adminAuth.isAdminRequest({ headers: { authorization: "Bearer wrong-key" } }), false);
+});
+
+test("adminAuth.isAdminRequest(): a rotated (resolved) admin key takes effect without re-requiring anything", async () => {
+  // The exact case the plan review found broken in the original "mutate
+  // config.adminKey once at boot" design: populate the resolver cache for
+  // ARBR_ADMIN_KEY (as refreshAll() would after a rotation + refresh call)
+  // and confirm the *resolved* value authenticates while the raw ref does not.
+  process.env.ARBR_ADMIN_KEY = "fake://admin-key-ref";
+  freshRequire("../../src/config");
+  const adminAuth = freshRequire("../../src/api/adminAuth");
+
+  const fakeProvider = {
+    scheme: "fake",
+    matches: (uri) => typeof uri === "string" && uri.startsWith("fake://"),
+    resolve: async () => "rotated-admin-key-value",
+  };
+  secretResolver.PROVIDERS_REGISTRY.push(fakeProvider);
+  try {
+    await secretResolver.refreshAll(["ARBR_ADMIN_KEY"]);
+    assert.equal(
+      adminAuth.isAdminRequest({ headers: { authorization: "Bearer rotated-admin-key-value" } }),
+      true
+    );
+    assert.equal(
+      adminAuth.isAdminRequest({ headers: { authorization: "Bearer fake://admin-key-ref" } }),
+      false
+    );
+  } finally {
+    const i = secretResolver.PROVIDERS_REGISTRY.indexOf(fakeProvider);
+    if (i >= 0) secretResolver.PROVIDERS_REGISTRY.splice(i, 1);
+  }
+});


### PR DESCRIPTION
## Summary
- Any credential-shaped env var (provider API keys, `ARBR_ADMIN_KEY`, `ARBR_ENCRYPTION_KEY`) can now hold a `gcp-sm://projects/P/secrets/S/versions/V` reference instead of a literal, resolved transparently at boot and on a 10-minute refresh, or immediately via `POST /api/secrets/refresh`. Zero behavior change for literal values.
- Cloud-agnostic by design: `secretResolver.js` dispatches by URI scheme through a small `SecretProvider` registry. GCP Secret Manager is the one working adapter (matches `arbr.gyde.ai`'s actual GCE deployment — free auth via the attached service account). AWS/Azure are documented in `docs/secret-manager.md`, addable later as one file each with zero changes elsewhere.
- Wires into every direct env-var read this codebase has: `config.js`, `secrets.js`, `csrf.js`, `semanticCache.js`, and `adminAuth.js` — the last fixed to read live rather than a boot-time snapshot, so a rotated admin key takes effect without a restart.
- Production fails closed (before Mongo connects / port binds) on a resolution failure; dev logs a warning and treats it as unset — never silently accepts an unresolved `gcp-sm://...` string as if it were a real credential.

## Test plan
- [x] `npm run lint` clean (0 errors)
- [x] `MONGOMS_VERSION=7.0.14 npm run test:server` — 392/392 pass
- [x] `npm --prefix web run build` succeeds
- [x] Manual boot check: no keys → demo mode unchanged; literal `OPENAI_API_KEY` → live, `source: "env"`, byte-identical to before; `gcp-sm://...` that fails to resolve → dev warns + demo mode (not falsely "live" with a garbage key); same case in production → refuses to start with an actionable error before binding a port