### PR TITLE
feat(ops): operational readiness package (F-08)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,15 @@
 # Brings up MongoDB + the control plane (dashboard + API + gateway on one port).
 # This file is the DEMO/EVAL profile: it seeds synthetic data on boot. For a
 # production deployment (no seeding, admin auth, reverse proxy) see DEPLOYMENT.md.
+# Bounds each container's stdout log growth. Docker's default json-file driver has
+# no size cap; a long-running host can otherwise fill its disk from logs alone
+# (see docs/operational-readiness.md's log-rotation section).
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "20m"
+    max-file: "5"
+
 services:
   mongo:
     image: mongo:7
@@ -17,6 +26,7 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
+    logging: *default-logging
     # Not published to the host by default; the app talks to it over the compose network.
 
   app:
@@ -25,6 +35,7 @@ services:
     depends_on:
       mongo:
         condition: service_healthy
+    logging: *default-logging
     environment:
       PORT: 4100
       MONGO_URI: mongodb://mongo:27017/arbr-control-plane

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -83,6 +83,7 @@ export default defineConfig({
           { text: 'Data privacy & retention', link: '/privacy' },
           { text: 'Deployment', link: '/deployment' },
           { text: 'Deploy on GCP', link: '/deployment-gcp' },
+          { text: 'Operational readiness', link: '/operational-readiness' },
         ]
       },
     ],

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -25,10 +25,25 @@ Returns gateway health and current settings. Accepted by both the admin key and 
 
 ### `GET /health`
 
-Liveness endpoint. Public — no auth required.
+Liveness endpoint. Public — no auth required. Always 200 if the process is up — never depends
+on Mongo being reachable, so it must not be used as a readiness probe.
 
 ```json
 { "ok": true, "demoMode": false }
+```
+
+### `GET /health/ready`
+
+Readiness endpoint. Public — no auth required. Returns `503` while draining after SIGTERM/SIGINT
+or while Mongo is disconnected — a load balancer or orchestrator should stop routing new traffic
+here on `503`, without treating the instance as dead. See
+[Operational readiness](/operational-readiness) for the liveness-vs-readiness distinction.
+
+```json
+{ "ok": true, "ready": true, "reason": null }
+```
+```json
+{ "ok": false, "ready": false, "reason": "shutting_down" }
 ```
 
 ---

--- a/docs/deployment-gcp.md
+++ b/docs/deployment-gcp.md
@@ -171,9 +171,11 @@ docker compose logs -f app
 docker compose restart app
 
 # Backup MongoDB
-docker compose exec mongo mongodump --out /tmp/backup
-docker cp $(docker compose ps -q mongo):/tmp/backup ./backup-$(date +%F)
+bash ops/backup.sh
 ```
+
+See [Operational readiness](/operational-readiness) for restore, disaster recovery, and a
+post-restore verification checklist.
 
 ## Deploying a new version (gated, image-based)
 

--- a/docs/operational-readiness.md
+++ b/docs/operational-readiness.md
@@ -1,0 +1,129 @@
+# Operational readiness
+
+A supportable runbook for self-hosted partners: liveness vs. readiness, backup/restore,
+disaster recovery, capacity guidance, log rotation, disk alerts, and support-bundle generation.
+Upgrade and rollback are covered in [Deploy on GCP](/deployment-gcp#deploying-a-new-version-gated-image-based)
+— not repeated here.
+
+## Liveness vs. readiness
+
+- `GET /health` — **liveness**. Always `200` if the process is up; never depends on Mongo. This
+  is what `ops/deploy.sh` polls to gate a deploy — don't point an orchestrator's liveness/restart
+  probe anywhere else.
+- `GET /health/ready` — **readiness**. Returns `503` while draining after SIGTERM/SIGINT (a
+  3-second grace window before the server stops accepting new connections, so a
+  readiness-polling load balancer has time to notice and stop routing here first) or while Mongo
+  is disconnected. Point a load balancer's or orchestrator's readiness probe here — it should
+  remove an unhealthy instance from rotation without restarting it. Today's single-VM deployment
+  has no managed instance group polling this; it's provided for Cloud Run, a future Kubernetes
+  deployment, or any other orchestrator that wants real drain-aware readiness.
+
+```sh
+curl -s localhost:4100/health         # {"ok":true,"demoMode":false}
+curl -s localhost:4100/health/ready   # {"ok":true,"ready":true,"reason":null}
+```
+
+## Backup
+
+```sh
+bash ops/backup.sh [output-dir]   # defaults to ./backups
+```
+
+Runs `mongodump` inside the `mongo` container (Mongo's data lives on a named Docker volume, not
+a bind mount, so this is the supported way to get it out) and writes a single gzipped archive.
+Run it before every deploy that touches data, and on a schedule (cron `bash ops/backup.sh` on the
+VM, rotated off-box — this script doesn't manage retention itself).
+
+## Restore
+
+```sh
+bash ops/restore.sh <backup-file>
+```
+
+**Destructive** — drops every existing collection in the target database before restoring.
+Prompts for confirmation, restarts the app container afterward, and health-gates the restart the
+same way `ops/deploy.sh` does.
+
+### Post-restore verification checklist
+
+Run all of these after any restore — a restore that doesn't pass this isn't done:
+
+- [ ] `curl -s localhost:4100/health` → `{"ok":true,...}`
+- [ ] `curl -s localhost:4100/health/ready` → `{"ok":true,"ready":true,"reason":null}`
+- [ ] `curl -s -H "Authorization: Bearer $ARBR_ADMIN_KEY" localhost:4100/api/status` → `200`, sane
+      `liveProviders`/`routingMode`
+- [ ] A known Settings value from before the restore reads back correctly (e.g. `retentionDays`
+      via `GET /api/governance`)
+- [ ] Row counts look right for at least one collection you can sanity-check (e.g. `Rule` count
+      via `GET /api/ops/export`)
+
+## Disaster recovery
+
+Scenario: the VM is lost entirely (deleted, corrupted, region outage).
+
+1. Provision a new VM and follow [Deploy on GCP](/deployment-gcp) from scratch — same firewall
+   rules, same `.env`/`docker-compose.gcp.yml` overrides (these are gitignored/untracked, so they
+   must be restored from wherever they're kept outside the repo — a secrets manager or a secure
+   copy, not committed).
+2. Bring the stack up once with `SEED_ON_BOOT=false` so it doesn't seed demo data over a restore.
+3. `bash ops/restore.sh <latest-backup>`.
+4. Run the post-restore verification checklist above.
+
+## Capacity guidance
+
+Rough sizing for a single-VM deployment (no HA — see the roadmap's P2 "Horizontal scale" item
+for multi-replica):
+
+| Signal | Guidance |
+|---|---|
+| Disk | Mongo data grows with `RequestRecord` volume × `retentionDays` (auto-purged daily past that window — see [Data privacy & retention](/privacy)). Budget headroom for a `mongodump` archive too — `ops/deploy.sh` now refuses to pull a new image past 90% disk usage. |
+| RAM | Mongo + Node both fit comfortably in 2GB for pilot traffic; the model registry (~1500+ entries) and semantic-cache embeddings (if enabled) are the main in-memory growth points. |
+| CPU | Routing/classification calls to a provider add latency, not CPU load on this box — the gateway itself is I/O-bound. |
+
+## Log rotation
+
+The app logs only to stdout — there's no in-container log file to rotate. The base
+`docker-compose.yml` bounds Docker's own `json-file` driver instead (`max-size: 20m`,
+`max-file: 5` — capped at ~100MB per container, applied to both `app` and `mongo` via a shared
+`x-logging` anchor), which is what actually needed fixing: the default driver has **no** size
+cap, and this VM's 20G root disk has hit 100% from unbounded growth before.
+
+## Disk alerts
+
+`ops/deploy.sh` reclaims dangling images before every pull and now refuses to proceed if usage is
+still above 90% afterward, with a message pointing at `ops/backup.sh` + cleanup. There's no
+continuous background disk monitor — check `df -h` when running `ops/backup.sh` if you want a
+manual read outside a deploy.
+
+## Configuration/policy export & import
+
+```sh
+curl -s -H "Authorization: Bearer $ARBR_ADMIN_KEY" localhost:4100/api/ops/export > config.json
+curl -s -X POST -H "Authorization: Bearer $ARBR_ADMIN_KEY" -H "Content-Type: application/json" \
+  --data-binary @config.json localhost:4100/api/ops/import
+```
+
+Exports `Settings`, `Rule`, and `Cap` (budgets) — the human-authored policy surface. Deliberately
+**excludes** provider credentials (never touches that collection at all — administrator role
+required either way), and excludes `RoutingExperiment`/`Recommendation`/eval data, which are
+operational history, not config. Import creates fresh documents (new IDs, not an ID-preserving
+merge) and forces `isDemoFixture: false` on every imported `Rule`/`Cap`, so a real config restore
+is never silently deleted by an unrelated instance's demo-reset. `Rule.sourceRecommendation` may
+point at a recommendation that doesn't exist on the target instance after an import — harmless
+(reads back as unset), not solved here.
+
+Note: `Settings.webhookUrl` is effectively a bearer token and is included in the export — this
+isn't a new exposure, `GET /api/governance` already returns it unmasked to any administrator.
+
+## Support bundle
+
+```sh
+curl -s -X POST -H "Authorization: Bearer $ARBR_ADMIN_KEY" localhost:4100/api/ops/support-bundle
+```
+
+Returns one JSON object: version/runtime info, the masked config summary, current `Settings`,
+disk usage, 24h request/error-rate counts, and the last 50 audit-log entries (projected to
+`timestamp`/`action`/`entity`/`entityId`/`actor` only — the audit log's free-form `changes` field
+is dropped entirely, not trusted). It never queries provider credentials or raw request records,
+so there's no captured prompt/response text or secret to accidentally include — safe to attach
+directly to a support request.

--- a/ops/backup.sh
+++ b/ops/backup.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Mongo backup for arbr's control-plane database, via mongodump run inside the mongo
+# container. Mongo runs on a named Docker volume (arbr_mongo_data), not a bind mount —
+# this is the supported way to get data out without stopping the container.
+# Companion: ops/restore.sh.
+#
+# Usage:  bash ops/backup.sh [output-dir]     output-dir defaults to ./backups
+set -euo pipefail
+
+REPO="$HOME/arbr-ai-control-plane"
+COMPOSE_FILES="-f docker-compose.yml -f docker-compose.gcp.yml -f docker-compose.deploy.yml"
+COMPOSE="sudo docker compose $COMPOSE_FILES"
+OUT_DIR="${1:-$REPO/backups}"
+
+cd "$REPO"
+mkdir -p "$OUT_DIR"
+
+# Read the real database name from the running app container rather than hardcode it —
+# MONGO_URI is mongodb://mongo:27017/<db>[?options].
+DB="$($COMPOSE exec -T app printenv MONGO_URI 2>/dev/null | tr -d '\r' | sed -n 's#.*/\([^/?]*\)\(?.*\)\{0,1\}$#\1#p')"
+DB="${DB:-arbr-control-plane}"
+
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT_FILE="$OUT_DIR/arbr-${DB}-${TS}.archive.gz"
+
+echo "==> Backing up database '${DB}' to ${OUT_FILE}…"
+$COMPOSE exec -T mongo mongodump --archive --gzip --db="$DB" > "$OUT_FILE"
+
+SIZE="$(du -h "$OUT_FILE" | cut -f1)"
+echo "==> Done. ${OUT_FILE} (${SIZE})"
+echo "    Restore with: bash ops/restore.sh ${OUT_FILE}"

--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -62,6 +62,16 @@ df -h / | awk 'NR==2{printf "    disk before: %s used, %s free\n",$5,$4}'
 sudo docker image prune -f >/dev/null 2>&1 || echo "!! prune skipped (non-fatal)"
 df -h / | awk 'NR==2{printf "    disk after:  %s used, %s free\n",$5,$4}'
 
+# 1.6 DISK PRE-FLIGHT. Checked AFTER pruning, not before — pruning might already fix a
+# high reading, and checking first could abort a deploy that didn't need to be. A pull
+# dying mid-way with "no space left on device" is a worse failure mode than refusing to
+# start; this catches it early with an actionable message instead.
+DISK_PCT="$(df -h / | awk 'NR==2{print $5}' | tr -d '%')"
+if [ "$DISK_PCT" -gt 90 ] 2>/dev/null; then
+  echo "!! Disk at ${DISK_PCT}% after prune — refusing to pull. Run ops/backup.sh then free space (old backups, docker system prune), or extend the disk."
+  exit 1
+fi
+
 # 2. DEPLOY.
 deploy "$TAG"
 

--- a/ops/restore.sh
+++ b/ops/restore.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Restore a backup produced by ops/backup.sh. DESTRUCTIVE: --drop replaces every
+# collection in the target database with the backup's contents.
+#
+# Usage:  bash ops/restore.sh <backup-file>
+set -euo pipefail
+
+REPO="$HOME/arbr-ai-control-plane"
+COMPOSE_FILES="-f docker-compose.yml -f docker-compose.gcp.yml -f docker-compose.deploy.yml"
+COMPOSE="sudo docker compose $COMPOSE_FILES"
+HEALTH="http://localhost:4100/health"
+FILE="${1:-}"
+
+if [ -z "$FILE" ] || [ ! -f "$FILE" ]; then
+  echo "!! Usage: bash ops/restore.sh <backup-file>"
+  exit 1
+fi
+
+cd "$REPO"
+
+echo "==> Restoring ${FILE} — this DROPS existing collections in the target database."
+read -r -p "    Type 'yes' to continue: " CONFIRM
+if [ "$CONFIRM" != "yes" ]; then
+  echo "!! Aborted — nothing changed."
+  exit 1
+fi
+
+$COMPOSE exec -T mongo mongorestore --archive --gzip --drop < "$FILE"
+
+echo "==> Restore complete. Restarting app to pick up the restored data…"
+$COMPOSE restart app
+
+# Health gate, same pattern as ops/deploy.sh.
+ok=0
+for _ in $(seq 1 20); do
+  sleep 3
+  if curl -fsS "$HEALTH" >/dev/null 2>&1; then ok=1; break; fi
+done
+
+if [ "$ok" != "1" ]; then
+  echo "!! App did not become healthy after restore — check: sudo docker compose $COMPOSE_FILES logs app"
+  exit 1
+fi
+
+echo "==> Done. App is healthy post-restore."
+echo "    Now run the verification checklist in docs/operational-readiness.md."

--- a/server/src/api/routes/index.js
+++ b/server/src/api/routes/index.js
@@ -25,5 +25,6 @@ router.use(require("./providerHealth.js"));
 router.use(require("./appConfigs.js"));
 router.use(require("./shadow.js"));
 router.use(require("./users.js"));
+router.use(require("./ops.js"));
 
 module.exports = router;

--- a/server/src/api/routes/ops.js
+++ b/server/src/api/routes/ops.js
@@ -1,0 +1,145 @@
+// Admin API routes — operational readiness (F-08): config export/import and a
+// support-diagnostics bundle. Every route here is deliberately scoped to never
+// query ProviderCredential/CustomProvider (secrets) or raw RequestRecord
+// documents (captured prompt/response text) — exclusion by construction, not a
+// redaction pass that could miss a field. See docs/operational-readiness.md.
+const express = require("express");
+const { requireRole } = require("../rbac");
+const { describe } = require("../../config");
+const Settings = require("../../models/Settings");
+const Rule = require("../../models/Rule");
+const Cap = require("../../models/Cap");
+const AuditLog = require("../../models/AuditLog");
+const RequestRecord = require("../../models/RequestRecord");
+
+const router = express.Router();
+const EXPORT_VERSION = 1;
+
+// Strip mongoose/internal fields so a re-import creates fresh documents
+// rather than attempting to overwrite by a possibly-foreign _id.
+function stripInternal({ _id, __v, ...rest }) {
+  return rest;
+}
+
+// ── config/policy export + import ──
+router.get("/ops/export", requireRole("administrator"), async (_req, res, next) => {
+  try {
+    const [settings, rules, caps] = await Promise.all([
+      Settings.get(),
+      Rule.find().lean(),
+      Cap.find().lean(),
+    ]);
+    res.json({
+      exportVersion: EXPORT_VERSION,
+      exportedAt: new Date().toISOString(),
+      settings: stripInternal(settings.toObject ? settings.toObject() : settings),
+      rules: rules.map(stripInternal),
+      caps: caps.map(stripInternal),
+    });
+  } catch (e) { next(e); }
+});
+
+router.post("/ops/import", requireRole("administrator"), async (req, res, _next) => {
+  try {
+    const body = req.body || {};
+    if (body.exportVersion !== EXPORT_VERSION) {
+      return res.status(400).json({
+        error: "unsupported_export_version",
+        message: `Expected exportVersion ${EXPORT_VERSION}, got ${body.exportVersion}.`,
+      });
+    }
+
+    if (body.settings && typeof body.settings === "object") {
+      await Settings.updateOne(
+        { key: "global" },
+        { $set: { ...stripInternal(body.settings), key: "global" } },
+        { upsert: true }
+      );
+      Settings.invalidateCache();
+    }
+
+    let rulesImported = 0, capsImported = 0;
+    if (Array.isArray(body.rules)) {
+      // New _ids — this is a config restore, not an ID-preserving merge.
+      // isDemoFixture is forced false: a real config restore must never be
+      // silently deletable by an unrelated instance's demo:reset cleanup.
+      const docs = body.rules.map((r) => ({ ...stripInternal(r), isDemoFixture: false }));
+      if (docs.length) await Rule.insertMany(docs);
+      rulesImported = docs.length;
+    }
+    if (Array.isArray(body.caps)) {
+      const docs = body.caps.map((c) => stripInternal(c));
+      if (docs.length) await Cap.insertMany(docs);
+      capsImported = docs.length;
+    }
+
+    res.json({ ok: true, rulesImported, capsImported });
+  } catch (e) {
+    res.status(400).json({ error: "import_failed", message: String(e.message || e) });
+  }
+});
+
+// ── support bundle ──
+router.post("/ops/support-bundle", requireRole("administrator"), async (_req, res, next) => {
+  try {
+    let pkg = {};
+    try { pkg = require("../../../../package.json"); } catch { /* version unknown */ }
+
+    const [settings, disk, requestStats, recentAudit] = await Promise.all([
+      Settings.get(),
+      diskUsage(),
+      requestStats24h(),
+      recentAuditEntries(),
+    ]);
+
+    res.json({
+      generatedAt: new Date().toISOString(),
+      about: { version: pkg.version, name: pkg.name, nodeVersion: process.version },
+      config: describe(),
+      settings: stripInternal(settings.toObject ? settings.toObject() : settings),
+      disk,
+      requestStats,
+      recentAudit,
+    });
+  } catch (e) { next(e); }
+});
+
+async function diskUsage() {
+  try {
+    const stats = await require("fs").promises.statfs("/");
+    const totalBytes = stats.blocks * stats.bsize;
+    const freeBytes = stats.bfree * stats.bsize;
+    return { totalBytes, freeBytes, usedPct: Math.round(((totalBytes - freeBytes) / totalBytes) * 1000) / 10 };
+  } catch (e) {
+    return { error: String(e.message || e) }; // statfs is POSIX-only; degrade, don't fail the bundle
+  }
+}
+
+// Counts/rates only — never .find() on raw RequestRecord documents, so there's
+// no captured messages/responseText field to accidentally include.
+async function requestStats24h() {
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const [row] = await RequestRecord.aggregate([
+    { $match: { timestamp: { $gte: since } } },
+    { $group: {
+        _id: null,
+        total: { $sum: 1 },
+        failures: { $sum: { $cond: [{ $eq: ["$status", "failure"] }, 1, 0] } },
+    } },
+  ]);
+  const total = row?.total || 0;
+  const failures = row?.failures || 0;
+  return { total, failures, errorRatePct: total ? Math.round((failures / total) * 1000) / 10 : 0 };
+}
+
+// Projected fields only — `changes` (unenforced Mixed) is dropped entirely,
+// not trusted to never hold something sensitive.
+async function recentAuditEntries() {
+  return AuditLog.find()
+    .sort({ timestamp: -1 })
+    .limit(50)
+    .select("timestamp action entity entityId actor")
+    .lean();
+}
+
+module.exports = router;

--- a/server/src/api/routes/ops.js
+++ b/server/src/api/routes/ops.js
@@ -21,6 +21,31 @@ function stripInternal({ _id, __v, ...rest }) {
   return rest;
 }
 
+// Copies only real Settings schema fields out of an imported object, derived
+// from the schema itself (not a hand-maintained list, so it can't drift).
+// Values are still whatever the caller sent — that's the point of import —
+// but the KEY SET reaching Mongo's $set is fixed by code, never by the
+// request body, so an imported object can't inject an operator-shaped key
+// ($where, $rename, a dotted path, __proto__, ...) into the update.
+// schema.paths has one entry PER LEAF, so a subdocument field like
+// maintenanceMode appears as "maintenanceMode.enabled"/"maintenanceMode.message"
+// rather than a single "maintenanceMode" key — take only the top-level
+// segment (deduped) so nested groups are copied as whole objects, matching
+// both what export produces and what $set expects.
+const SETTINGS_FIELDS = [...new Set(
+  Object.keys(Settings.schema.paths)
+    .map((p) => p.split(".")[0])
+    .filter((k) => !["_id", "__v", "key"].includes(k))
+)];
+function pickSettingsFields(obj) {
+  const out = {};
+  if (!obj || typeof obj !== "object") return out;
+  for (const k of SETTINGS_FIELDS) {
+    if (Object.prototype.hasOwnProperty.call(obj, k)) out[k] = obj[k];
+  }
+  return out;
+}
+
 // ── config/policy export + import ──
 router.get("/ops/export", requireRole("administrator"), async (_req, res, next) => {
   try {
@@ -52,7 +77,7 @@ router.post("/ops/import", requireRole("administrator"), async (req, res, _next)
     if (body.settings && typeof body.settings === "object") {
       await Settings.updateOne(
         { key: "global" },
-        { $set: { ...stripInternal(body.settings), key: "global" } },
+        { $set: { ...pickSettingsFields(body.settings), key: "global" } },
         { upsert: true }
       );
       Settings.invalidateCache();

--- a/server/src/health/readiness.js
+++ b/server/src/health/readiness.js
@@ -1,0 +1,11 @@
+// Pure readiness decision, separate from index.js's boot/shutdown wiring so
+// it's directly unit-testable with plain values — no app boot required.
+// mongoReadyState is mongoose.connection.readyState (0 disconnected,
+// 1 connected, 2 connecting, 3 disconnecting).
+function computeReadiness({ isShuttingDown, mongoReadyState }) {
+  if (isShuttingDown) return { ready: false, reason: "shutting_down" };
+  if (mongoReadyState !== 1) return { ready: false, reason: "mongo_disconnected" };
+  return { ready: true, reason: null };
+}
+
+module.exports = { computeReadiness };

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -28,10 +28,16 @@ const csrf = require("./api/csrf");
 const apiRoutes = require("./api/routes");
 const authRoutes = require("./api/routes/auth");
 const connections = require("./providers/connections");
+const { computeReadiness } = require("./health/readiness");
 
 // Built dashboard (created by `npm --prefix web run build`). When present, the
 // server serves it on the same port — single-port production / Docker.
 const WEB_DIST = path.resolve(__dirname, "../../web/dist");
+
+// Set by installShutdownHandlers on the first SIGTERM/SIGINT; read by
+// GET /health/ready so readiness (unlike liveness) can correctly reflect a
+// server that's draining in-flight requests before exit.
+let isShuttingDown = false;
 
 async function start() {
   // Fail closed before any network bind when running as production.
@@ -95,6 +101,17 @@ async function start() {
     let demoMode = config.demoMode;
     try { demoMode = (await connections.effective()).demoMode; } catch { /* keep boot-time fallback */ }
     res.json({ ok: true, demoMode });
+  });
+
+  // Readiness (distinct from liveness above): can legitimately fail — a
+  // load balancer/orchestrator should stop routing new traffic here without
+  // treating the instance as dead. Draining during shutdown or a
+  // disconnected Mongo both fail this; neither means the process is unhealthy.
+  app.get("/health/ready", (_req, res) => {
+    const { ready, reason } = computeReadiness({
+      isShuttingDown, mongoReadyState: mongoose.connection.readyState,
+    });
+    res.status(ready ? 200 : 503).json({ ok: ready, ready, reason });
   });
 
   // The unified AI gateway — one endpoint for all AI requests.
@@ -238,6 +255,11 @@ async function start() {
 // served. Draining briefly after server.close() is what makes those writes land.
 const SHUTDOWN_DRAIN_MS = 250;
 const SHUTDOWN_FORCE_MS = 15_000; // under Kubernetes' 30s default grace period
+// server.close() stops accepting new connections immediately — a readiness
+// probe reporting "not ready" is only useful to an orchestrator if there's a
+// window where the server still accepts traffic while reporting that,
+// giving a load balancer time to notice and stop routing here first.
+const READINESS_GRACE_MS = 3_000;
 
 // The daily purge interval is deliberately not cleared: this always ends in
 // process.exit(0), and a 24h timer cannot fire inside the drain window.
@@ -247,6 +269,7 @@ function installShutdownHandlers({ server }) {
   async function shutdown(signal) {
     if (shuttingDown) return; // a second Ctrl-C shouldn't re-enter
     shuttingDown = true;
+    isShuttingDown = true; // module-level: read by GET /health/ready
     console.log(`\n[shutdown] ${signal} received — draining…`);
 
     const force = setTimeout(() => {
@@ -256,22 +279,27 @@ function installShutdownHandlers({ server }) {
     if (force.unref) force.unref();
 
     try {
-      // 1 · Stop accepting connections; let in-flight responses finish.
+      // 1 · Report not-ready while STILL accepting traffic, so a
+      //     readiness-polling load balancer can drain us before we actually
+      //     stop listening (see READINESS_GRACE_MS above).
+      await new Promise((resolve) => setTimeout(resolve, READINESS_GRACE_MS));
+
+      // 2 · Stop accepting connections; let in-flight responses finish.
       await new Promise((resolve) => server.close(resolve));
 
-      // 2 · server.close() leaves established WebSockets open — end them explicitly.
+      // 3 · server.close() leaves established WebSockets open — end them explicitly.
       const closed = closeRealtimeSessions();
       if (closed > 0) console.log(`[shutdown] closed ${closed} realtime session(s)`);
 
-      // 3 · Let the detached logger.write callbacks for those responses run.
+      // 4 · Let the detached logger.write callbacks for those responses run.
       await new Promise((resolve) => setTimeout(resolve, SHUTDOWN_DRAIN_MS));
 
-      // 4 · Stop background work before tearing down its dependencies.
+      // 5 · Stop background work before tearing down its dependencies.
       errorAlertMonitor.stop();
       canaryMonitor.stop();
       evalWorker.stop();
 
-      // 5 · Mongo last — the drained writes above need it alive.
+      // 6 · Mongo last — the drained writes above need it alive.
       await mongoose.disconnect();
       console.log("[shutdown] clean");
     } catch (err) {

--- a/server/test/integration/ops.test.js
+++ b/server/test/integration/ops.test.js
@@ -1,0 +1,158 @@
+"use strict";
+// F-08 (operational readiness): GET/POST /api/ops/{export,import,support-bundle}.
+process.env.ARBR_ADMIN_KEY = "";
+
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+const mongoose = require("mongoose");
+const express = require("express");
+const supertest = require("supertest");
+
+const apiRoutes = require("../../src/api/routes");
+const Rule = require("../../src/models/Rule");
+const Cap = require("../../src/models/Cap");
+const ProviderCredential = require("../../src/models/ProviderCredential");
+const RequestRecord = require("../../src/models/RequestRecord");
+const AuditLog = require("../../src/models/AuditLog");
+
+let mongod, agent;
+let currentTestUser = { id: "admin-1", email: "admin@test", role: "administrator" };
+const stubUser = (req, _res, next) => { req.user = currentTestUser; next(); };
+const buildApp = () => {
+  const a = express();
+  a.use(express.json());
+  a.use(stubUser);
+  a.use("/api", apiRoutes);
+  return a;
+};
+
+const FAKE_SECRET = "injected-fake-provider-secret-must-never-leak-XYZ123";
+const FAKE_PAYLOAD = "injected-fake-captured-prompt-text-must-never-leak-XYZ456";
+const FAKE_AUDIT_CHANGE = "injected-fake-audit-changes-payload-must-never-leak-XYZ789";
+
+before(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  agent = supertest(buildApp());
+});
+after(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+beforeEach(async () => {
+  currentTestUser = { id: "admin-1", email: "admin@test", role: "administrator" };
+  await Promise.all([
+    Rule.deleteMany({}), Cap.deleteMany({}), ProviderCredential.deleteMany({}),
+    RequestRecord.deleteMany({}), AuditLog.deleteMany({}),
+  ]);
+});
+
+test("export requires administrator role — 403 for operator", async () => {
+  currentTestUser = { id: "o-1", email: "operator@test", role: "operator" };
+  const res = await agent.get("/api/ops/export");
+  assert.equal(res.status, 403);
+});
+
+test("import requires administrator role — 403 for operator", async () => {
+  currentTestUser = { id: "o-1", email: "operator@test", role: "operator" };
+  const res = await agent.post("/api/ops/import").send({ exportVersion: 1 });
+  assert.equal(res.status, 403);
+});
+
+test("support-bundle requires administrator role — 403 for operator", async () => {
+  currentTestUser = { id: "o-1", email: "operator@test", role: "operator" };
+  const res = await agent.post("/api/ops/support-bundle");
+  assert.equal(res.status, 403);
+});
+
+test("export never includes a provider credential, even though one exists", async () => {
+  await ProviderCredential.create({
+    provider: "openai", ciphertext: FAKE_SECRET, iv: "iv", tag: "tag", last4: "abcd",
+  });
+  const res = await agent.get("/api/ops/export");
+  assert.equal(res.status, 200);
+  assert.ok(!JSON.stringify(res.body).includes(FAKE_SECRET));
+});
+
+test("export/import round-trip: rules and caps survive, with fresh ids and isDemoFixture forced false", async () => {
+  const rule = await Rule.create({
+    target: { provider: "openai", model: "gpt-4o-mini" }, note: "roundtrip-test", isDemoFixture: true,
+  });
+  const cap = await Cap.create({ limit: 500, action: "alert" });
+
+  const exported = await agent.get("/api/ops/export");
+  assert.equal(exported.status, 200);
+  assert.equal(exported.body.exportVersion, 1);
+  assert.equal(exported.body.rules.length, 1);
+  assert.equal(exported.body.caps.length, 1);
+
+  await Rule.deleteMany({});
+  await Cap.deleteMany({});
+
+  const imported = await agent.post("/api/ops/import").send(exported.body);
+  assert.equal(imported.status, 200);
+  assert.equal(imported.body.rulesImported, 1);
+  assert.equal(imported.body.capsImported, 1);
+
+  const rules = await Rule.find().lean();
+  assert.equal(rules.length, 1);
+  assert.equal(rules[0].note, "roundtrip-test");
+  assert.equal(rules[0].isDemoFixture, false); // forced, even though the export carried true
+  assert.notEqual(String(rules[0]._id), String(rule._id)); // fresh id, not an overwrite
+
+  const caps = await Cap.find().lean();
+  assert.equal(caps.length, 1);
+  assert.equal(caps[0].limit, 500);
+  assert.notEqual(String(caps[0]._id), String(cap._id));
+});
+
+test("import rejects an unsupported exportVersion", async () => {
+  const res = await agent.post("/api/ops/import").send({ exportVersion: 99 });
+  assert.equal(res.status, 400);
+  assert.equal(res.body.error, "unsupported_export_version");
+});
+
+test("import restores Settings fields from the export", async () => {
+  const exported = await agent.get("/api/ops/export");
+  const settingsPatch = { ...exported.body.settings, retentionDays: 42 };
+  const res = await agent.post("/api/ops/import").send({ exportVersion: 1, settings: settingsPatch });
+  assert.equal(res.status, 200);
+
+  const gov = await agent.get("/api/governance");
+  assert.equal(gov.body.retentionDays, 42);
+});
+
+test("support-bundle never includes a captured request payload, even though one is stored", async () => {
+  await RequestRecord.create({
+    requestId: "ops-bundle-payload-probe",
+    application: "test-app", provider: "openai", model: "gpt-4o-mini",
+    promptTokens: 10, completionTokens: 5, latencyMs: 42, status: "success",
+    messages: [{ role: "user", content: FAKE_PAYLOAD }],
+    responseText: FAKE_PAYLOAD,
+  });
+  const res = await agent.post("/api/ops/support-bundle");
+  assert.equal(res.status, 200);
+  assert.ok(!JSON.stringify(res.body).includes(FAKE_PAYLOAD));
+  assert.equal(res.body.requestStats.total, 1); // counted, just not the payload text
+});
+
+test("support-bundle drops AuditLog.changes entirely, even though one holds something sensitive", async () => {
+  await AuditLog.create({
+    action: "rule.create", entity: "rule", entityId: "abc",
+    changes: { note: FAKE_AUDIT_CHANGE }, actor: { id: "admin-1", email: "admin@test", role: "administrator" },
+  });
+  const res = await agent.post("/api/ops/support-bundle");
+  assert.equal(res.status, 200);
+  assert.ok(!JSON.stringify(res.body).includes(FAKE_AUDIT_CHANGE));
+  assert.equal(res.body.recentAudit.length, 1);
+  assert.equal(res.body.recentAudit[0].action, "rule.create");
+  assert.equal(res.body.recentAudit[0].changes, undefined);
+});
+
+test("support-bundle includes disk usage and masked config, no crash if statfs is unavailable", async () => {
+  const res = await agent.post("/api/ops/support-bundle");
+  assert.equal(res.status, 200);
+  assert.ok(res.body.disk); // either real numbers or a degraded {error} shape — never throws
+  assert.equal(typeof res.body.config, "string"); // config.describe()'s boot-banner text
+});

--- a/server/test/integration/ops.test.js
+++ b/server/test/integration/ops.test.js
@@ -123,6 +123,39 @@ test("import restores Settings fields from the export", async () => {
   assert.equal(gov.body.retentionDays, 42);
 });
 
+test("import restores nested Settings groups (maintenanceMode), not just flat fields", async () => {
+  // Regression for the fix that replaced a raw object spread with a
+  // schema-derived key allowlist (CodeQL js/sql-injection on the $set
+  // payload) — schema.paths reports subdocuments as dotted leaves
+  // ("maintenanceMode.enabled"), which must still be copied as a whole
+  // top-level object, not silently dropped.
+  const settingsPatch = {
+    maintenanceMode: { enabled: true, message: "nested-group-survives-import" },
+  };
+  const res = await agent.post("/api/ops/import").send({ exportVersion: 1, settings: settingsPatch });
+  assert.equal(res.status, 200);
+
+  const gov = await agent.get("/api/governance");
+  assert.equal(gov.body.maintenanceMode.enabled, true);
+  assert.equal(gov.body.maintenanceMode.message, "nested-group-survives-import");
+});
+
+test("import ignores operator-shaped keys in the settings payload instead of passing them to Mongo", async () => {
+  // The CodeQL finding itself: a raw spread of req.body.settings into $set
+  // would let a caller's object keys reach Mongo's update operator directly.
+  const res = await agent.post("/api/ops/import").send({
+    exportVersion: 1,
+    settings: { retentionDays: 7, $rename: { retentionDays: "hacked" }, "__proto__.polluted": true },
+  });
+  assert.equal(res.status, 200);
+
+  const gov = await agent.get("/api/governance");
+  assert.equal(gov.body.retentionDays, 7); // the legitimate field still applied
+  // Nothing to assert "hacked" against — the point is this didn't throw or
+  // corrupt the document; retentionDays alone proves only the allowlisted
+  // key was ever written.
+});
+
 test("support-bundle never includes a captured request payload, even though one is stored", async () => {
   await RequestRecord.create({
     requestId: "ops-bundle-payload-probe",

--- a/server/test/integration/shutdown.test.js
+++ b/server/test/integration/shutdown.test.js
@@ -13,6 +13,7 @@ const logger = require("../../src/logging/logger");
 
 const ENTRY = path.resolve(__dirname, "../../src/index.js");
 const PORT = 4397;
+const READY_PORT = 4398;
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 let mongod;
@@ -58,6 +59,46 @@ test("SIGTERM drains and exits cleanly", async () => {
     assert.doesNotMatch(out, /forcing exit/);
     // Should be roughly the drain, not the 15s force timer.
     assert.ok(elapsed < 10_000, `shutdown took ${elapsed}ms`);
+  } finally {
+    if (proc.exitCode === null) proc.kill("SIGKILL");
+  }
+});
+
+test("GET /health/ready reflects readiness across a real SIGTERM (F-08)", async () => {
+  // server.close() stops accepting NEW connections immediately — so this can
+  // only be observed within the READINESS_GRACE_MS window BEFORE that happens,
+  // not after. That's the whole point: a load balancer polling readiness gets
+  // a chance to notice and drain traffic here before the listener closes.
+  const proc = spawn(process.execPath, [ENTRY], {
+    cwd: path.resolve(__dirname, "../../.."),
+    env: { ...process.env, MONGO_URI: uri, PORT: String(READY_PORT), ARBR_ADMIN_KEY: "", SEED_ON_BOOT: "false" },
+  });
+
+  let out = "";
+  proc.stdout.on("data", (d) => { out += d.toString(); });
+  proc.stderr.on("data", (d) => { out += d.toString(); });
+  const exited = new Promise((resolve) => proc.on("exit", (code) => resolve(code)));
+
+  try {
+    for (let i = 0; i < 80 && !out.includes("ready:"); i++) await sleep(250);
+    assert.ok(out.includes("ready:"), `server did not boot:\n${out}`);
+
+    const before = await fetch(`http://localhost:${READY_PORT}/health/ready`).then((r) => ({ status: r.status, body: r.json() }));
+    assert.equal(before.status, 200);
+    assert.deepEqual(await before.body, { ok: true, ready: true, reason: null });
+
+    proc.kill("SIGTERM");
+    await sleep(300); // well inside READINESS_GRACE_MS, well before server.close()
+
+    const during = await fetch(`http://localhost:${READY_PORT}/health/ready`);
+    assert.equal(during.status, 503);
+    assert.deepEqual(await during.json(), { ok: false, ready: false, reason: "shutting_down" });
+
+    const code = await Promise.race([exited, sleep(20_000).then(() => "TIMEOUT")]);
+    assert.equal(code, 0, `expected clean exit, got ${code}:\n${out}`);
+
+    // Once the process has actually exited, the port is no longer listening at all.
+    await assert.rejects(() => fetch(`http://localhost:${READY_PORT}/health/ready`));
   } finally {
     if (proc.exitCode === null) proc.kill("SIGKILL");
   }

--- a/server/test/unit/readiness.test.js
+++ b/server/test/unit/readiness.test.js
@@ -1,0 +1,49 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { computeReadiness } = require("../../src/health/readiness");
+
+test("ready when not shutting down and Mongo is connected (readyState 1)", () => {
+  assert.deepEqual(
+    computeReadiness({ isShuttingDown: false, mongoReadyState: 1 }),
+    { ready: true, reason: null }
+  );
+});
+
+test("not ready while shutting down, even if Mongo is connected", () => {
+  assert.deepEqual(
+    computeReadiness({ isShuttingDown: true, mongoReadyState: 1 }),
+    { ready: false, reason: "shutting_down" }
+  );
+});
+
+test("not ready when Mongo is disconnected (readyState 0)", () => {
+  assert.deepEqual(
+    computeReadiness({ isShuttingDown: false, mongoReadyState: 0 }),
+    { ready: false, reason: "mongo_disconnected" }
+  );
+});
+
+test("not ready when Mongo is still connecting (readyState 2)", () => {
+  assert.deepEqual(
+    computeReadiness({ isShuttingDown: false, mongoReadyState: 2 }),
+    { ready: false, reason: "mongo_disconnected" }
+  );
+});
+
+test("not ready when Mongo is disconnecting (readyState 3)", () => {
+  assert.deepEqual(
+    computeReadiness({ isShuttingDown: false, mongoReadyState: 3 }),
+    { ready: false, reason: "mongo_disconnected" }
+  );
+});
+
+test("shutting_down takes precedence over a Mongo-disconnected reason", () => {
+  // Order matters: during shutdown, Mongo is disconnected LAST (index.js's
+  // shutdown() drains, then disconnects Mongo) — the reason reported should
+  // be the actual cause (draining), not the Mongo state that follows from it.
+  assert.deepEqual(
+    computeReadiness({ isShuttingDown: true, mongoReadyState: 0 }),
+    { ready: false, reason: "shutting_down" }
+  );
+});


### PR DESCRIPTION
## Summary
- **Liveness/readiness split**: `GET /health` unchanged (still `ops/deploy.sh`'s health gate); new `GET /health/ready` reflects Mongo connectivity + a 3s drain-aware grace window on SIGTERM before the server actually stops accepting connections, so a readiness-polling LB can notice and drain first. Decision logic is a pure, unit-tested `server/src/health/readiness.js`.
- **Backup/restore**: `ops/backup.sh` / `ops/restore.sh` (mongodump/mongorestore via the mongo container), plus a documented restore-verification checklist and DR runbook in `docs/operational-readiness.md`.
- **Config/policy export + import**: `GET/POST /api/ops/{export,import}` for Settings/Rule/Cap (administrator-gated), never touches provider credentials. Import forces `isDemoFixture:false` so a real restore can't be swept up by an unrelated instance's demo-reset.
- **Support bundle**: `POST /api/ops/support-bundle` — no credentials or captured payloads *by construction* (never queries `ProviderCredential`/`CustomProvider` or raw `RequestRecord`; projects `AuditLog` to a fixed field list, dropping the unenforced `changes` field entirely).
- `ops/deploy.sh` now refuses to pull past 90% disk usage (checked after the existing prune, not before). Base `docker-compose.yml` (not the gitignored GCP override, which can't ship via git) bounds container log growth via a shared `x-logging` anchor.

## Test plan
- [x] `npm run lint` clean (0 errors, matches baseline)
- [x] `MONGOMS_VERSION=7.0.14 npm run test:server` — 409/409 pass (26 new)
- [x] `npm --prefix web run build` succeeds
- [x] `docker compose config` validated for both the base stack and the full deploy stack (base + gcp + deploy overlays)
- [x] Manual: booted locally, confirmed `/health` unchanged and `/health/ready` 200→503(`shutting_down`)→connection-refused across a real SIGTERM, with the 503 actually observable within the grace window (not just in theory)
- [x] Manual: full export→wipe→import round-trip on real Rule/Cap docs, confirmed restored with fresh IDs and `isDemoFixture` forced false
- [x] Manual: support-bundle response grepped for zero occurrences of a seeded fake credential/payload/audit-changes string
- [ ] Not verified: `ops/backup.sh`/`ops/restore.sh` against a real Docker stack — Docker wasn't running locally this session. Scripts match `ops/deploy.sh`'s proven conventions exactly (same `COMPOSE_FILES`, same health-gate loop) but haven't been executed for real; worth a manual run before or during first use on the VM.