### PR TITLE
feat(telemetry): export OTLP trace spans for gateway requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,30 @@ MONGO_URI=mongodb://localhost:27017/arbr-control-plane
 # none                    — fail the request; no automatic fallback
 # ARBR_FALLBACK_SCOPE=same-provider
 
+# --- OpenTelemetry tracing (optional, off by default) ---
+# Export one OTLP trace span per gateway request, parented to the caller's own
+# distributed trace (via the incoming W3C `traceparent` header). Off unless
+# ARBR_OTEL_ENABLED is true; when off, the OTel SDK is never even loaded.
+#
+# The master switch is ARBR_OTEL_ENABLED, NOT OTEL_ENABLED: that variable also
+# switches @langchain/core into LangSmith-OTel mode, so Arbr never reads it (and
+# warns at boot if it is set). Every OTHER knob falls back to the standard OTEL_*
+# names, so this works with the env a platform team already injects.
+# ARBR_OTEL_ENABLED=true
+#
+# Full traces endpoint. Falls back to OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, then to
+# OTEL_EXPORTER_OTLP_ENDPOINT (base, /v1/traces appended). Default below.
+# ARBR_OTEL_ENDPOINT=http://localhost:4318/v1/traces
+#
+# Exporter headers (e.g. a vendor key): "key1=val1,key2=val2". Falls back to
+# OTEL_EXPORTER_OTLP_HEADERS. Keep these in the environment, not the database.
+# ARBR_OTEL_HEADERS=
+#
+# ARBR_OTEL_SERVICE_NAME=arbr-control-plane   # falls back to OTEL_SERVICE_NAME
+# ARBR_OTEL_SAMPLE_RATIO=1                     # 0..1; failures and sampled-parent traces are always kept
+# ARBR_OTEL_CAPTURE_CONTENT=false             # opt-in prompt/response on spans; also needs payload capture on
+# ARBR_OTEL_CONTENT_MAX_CHARS=8192            # per-attribute clamp (collectors drop oversized spans)
+
 # --- Demo data ---
 # Docker only: SEED_ON_BOOT=true loads the synthetic demo dataset on container
 # start. WARNING: seeding WIPES existing request records — never in production.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -121,6 +121,21 @@ nobody mistakes a demo-grade mechanism for a hardened one. Several of these are 
 single-instance tradeoffs; they matter most if you run multiple replicas or high burst
 traffic.
 
+- **OTel spans are emitted from the post-response log path, not the request path.**
+  When `ARBR_OTEL_ENABLED` is set, `telemetry.emit` is called from `logging/logger.js`
+  inside the same detached `setImmediate` that writes the `RequestRecord`, so tracing
+  adds nothing to request latency and cannot throw into it. Consequences to know:
+  (a) span duration is `latencyMs`, which is provider-measured on the LangChain path and
+  wall-clock on the proxy path — it is not gateway end-to-end time; (b) `ttftMs` is
+  captured only on the true byte-relay streaming path, and is absent elsewhere; (c) the
+  five early-return paths in `gateway/handler.js` (maintenance mode, per-app kill switch,
+  demo mode) write no record and so emit no span, so a maintenance window reads as silence
+  rather than errors; (d) the batch queue is per-process and in-memory, so an ungraceful
+  kill loses queued spans — graceful shutdown (SIGTERM) flushes them; (e) sampling is
+  head-based and per-process, though an incoming sampled `traceparent` is always honored so
+  caller-initiated traces stay complete. The master switch is `ARBR_OTEL_ENABLED`, never
+  `OTEL_ENABLED` (which would also flip `@langchain/core` into LangSmith-OTel mode).
+
 - **Arbr's own AI spend is counted but never attributed to a customer.** Arbr makes LLM
   calls for itself (task classification on the routing path, AI policy generation, eval
   judging, connection/model tests). Those are real money on the customer's provider key,

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -64,6 +64,7 @@ export default defineConfig({
           { text: 'Model registry', link: '/models' },
           { text: 'Budgets & governance', link: '/budgets' },
           { text: 'Accountable admin access', link: '/auth' },
+          { text: 'OpenTelemetry tracing', link: '/opentelemetry' },
           { text: 'Cloud secret-manager integration', link: '/secret-manager' },
           { text: 'Design-partner demo fixture', link: '/demo-fixture' },
         ]

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,285 @@
+# Arbr — Feature Reference
+
+Complete inventory of every capability in the Arbr AI control plane. For depth on any area, follow the linked docs.
+
+---
+
+## Gateway endpoints
+
+All endpoints share the same auth, routing, logging, and budget enforcement.
+
+| Endpoint | Protocol | Description |
+|---|---|---|
+| `POST /v1/chat` | HTTP | Arbr-native — accepts business metadata, returns routing decision + text |
+| `POST /v1/chat/completions` | HTTP + SSE | OpenAI-compatible — drop-in for any OpenAI SDK or chat UI |
+| `POST /v1/embeddings` | HTTP | OpenAI-compatible embeddings — works with OpenAI and Gemini models |
+| `GET /v1/realtime` | WebSocket | Transparent proxy to OpenAI Realtime API with auth injection + session logging |
+
+### Native endpoint (`POST /v1/chat`)
+
+- Accepts `application`, `workflow`, `department`, `userId` metadata per call
+- Full routing: rules, budgets, caching, automated policies
+- Returns `routingDecision`, `model`, `modelRequested`, `classifiedBy`, `cacheHit`, token usage
+- Pass-through to any model string on any live provider, even if unregistered
+
+See [Native endpoint](/gateway/native).
+
+### OpenAI-compatible endpoint (`POST /v1/chat/completions`)
+
+- Drop-in base URL replacement for any OpenAI SDK, LangChain `ChatOpenAI`, LibreChat, OpenWebUI, OpenCode, and more
+- SSE streaming (`"stream": true`) with real token-by-token delivery, no buffering
+- Routes through the same routing stack as `/v1/chat`
+- Application attributed from the gateway API key
+
+See [OpenAI-compat endpoint](/gateway/openai-compat), [Streaming](/gateway/streaming).
+
+### Embeddings (`POST /v1/embeddings`)
+
+- OpenAI-compatible request/response shape (`object: "embedding"`)
+- Providers: OpenAI (`text-embedding-3-*`) and Gemini (`text-embedding-004`)
+- Supports `input` as a string or array of strings
+- Logged to RequestRecord as `taskType: "embedding"` with token counts and cost
+
+### Realtime voice proxy (`WS /v1/realtime`)
+
+- Bidirectional WebSocket proxy to OpenAI Realtime API (`wss://api.openai.com/v1/realtime`)
+- Arbr injects the real provider API key; clients authenticate with a gateway key only
+- Relays all frames without modification — tool calls, audio deltas, events
+- On session close, logs `audioInputTokens`, `audioOutputTokens`, `textInputTokens`, `textOutputTokens`, `sessionDurationMs` to RequestRecord
+
+---
+
+## Providers
+
+Connect any combination — all providers share the same routing, logging, and budget layer.
+
+| Provider | Key | Notes |
+|---|---|---|
+| **Anthropic** | `anthropic` | Claude Opus/Sonnet/Haiku; prompt-cache token tracking |
+| **OpenAI** | `openai` | GPT-4o, GPT-4o Mini; also accepts a custom `baseURL` for LiteLLM |
+| **Google Gemini** | `gemini` | Gemini 2.5 Pro/Flash/Flash-Lite; prompt-cache token tracking |
+| **Amazon Bedrock** | `bedrock-nova` | Nova Pro/Lite/Micro and cross-inference models; AWS credential-based |
+| **DeepSeek** | `deepseek` | DeepSeek Chat and Reasoner |
+| **Moonshot AI** | `moonshot` | Moonshot 8K/32K/128K |
+| **xAI (Grok)** | `xai` | Grok 3 and Grok 3 Mini |
+| **Groq** | `groq` | Llama 3 models at inference speed |
+| **Any LiteLLM proxy** | `openai` (custom base URL) | Hundreds of additional models through a LiteLLM instance |
+
+Provider keys are stored encrypted server-side via dotenvx. They never appear in responses.
+
+See [Providers](/providers/overview) and individual provider pages.
+
+---
+
+## Routing
+
+The routing layer sits between every request and the provider. Precedence is fixed and deterministic:
+
+| Priority | Condition | Tag |
+|---|---|---|
+| 1 | Budget **Block** cap breached → reject 429 | `budget` |
+| 2 | Budget **Downgrade** cap breached → force light-tier model | `budget` |
+| 3 | Developer pinned a specific model → used as-is, all policies skip | `explicit` |
+| 4a | `model: "auto"` — cache hit | `cache` |
+| 4b | `model: "auto"` — first matching human routing rule | `rule` |
+| 4c | `model: "auto"` — automated routing policy (cost guardrail or AI) | `auto` / `ai` |
+| 4d | `model: "auto"` — default provider + model | `passthrough` |
+| 5 | Provider error → retry other live providers | `fallback` |
+
+### Routing modes
+
+Set in Settings → Routing → Automated routing:
+
+- **Off** — rules + default model only
+- **Cost guardrail** — downgrades premium models on cheap task types automatically
+- **AI routing** — AI-generated `{taskType → model}` map, editable and reviewable before activation
+
+### Human routing rules
+
+Created in Settings → Routing rules or accepted from Recommendations. Each rule matches on `taskType`, `application`, `workflow`, `department`, or `userId` and routes to a specific provider + model. Rules are off by default when created from a recommendation — a human must enable them.
+
+### Task classification
+
+When `taskType` is not provided, Arbr infers it from the latest user turn:
+
+- **Keyword match** — rule-based, zero latency
+- **AI classify** — used when AI routing mode is on and no keyword match
+
+Known cheap types: `classification`, `extraction`, `summarisation`, `translation`, `faq`, `support response`.
+
+Every request records `classifiedBy`, `difficulty` (1–10 score), and `confidence` (0–1).
+
+### Difficulty-aware routing
+
+Within a task type, difficulty score adjusts the model pick:
+
+- **Easy (≤ 3)** → cheaper model in the tier
+- **Normal (4–7)** → policy default
+- **Hard (≥ 8)** → stronger model in the tier
+
+Low-confidence results (< 0.5) do not drive routing changes.
+
+### Routing explainability
+
+Every `RequestRecord` includes a `routingExplain` object: which rule matched, which policy entry fired, whether a difficulty adjustment overrode the default, and which fallback was taken. Visible in the Requests drilldown.
+
+See [Routing](/routing).
+
+---
+
+## Response caching
+
+- Identical `(served_model, messages)` → returns the stored response instantly
+- `routingDecision: "cache"` in the response
+- `cacheHit: true` on the RequestRecord; cache hit rate tracked in the overview dashboard
+
+---
+
+## Model registry
+
+- 29 built-in models seeded automatically, covering all eight providers
+- Custom models addable at runtime via dashboard (Settings → Models) or Admin API
+- Each entry: model ID, provider, label, tier (`light` / `mid` / `premium`), input $/1M, output $/1M
+- Pass-through to unregistered models always works — cost logged as `$0` until a pricing entry exists
+- Built-in models are updated by re-seeding; custom models are never overwritten by seed runs
+
+See [Model registry](/models).
+
+---
+
+## Observability
+
+### Per-request logging
+
+Every call — all endpoints — writes one `RequestRecord` to MongoDB:
+
+```
+requestId, timestamp
+application, workflow, userId, department
+provider, model, modelRequested, taskType
+promptTokens, completionTokens, totalTokens
+audioInputTokens, audioOutputTokens (realtime only)
+sessionDurationMs (realtime only)
+inputCost, outputCost, totalCost
+latencyMs, ttftMs, gatewayOverheadMs
+status, routingDecision, classifiedBy
+difficulty, difficultyScore, confidence
+cacheHit, cachedReadTokens, cacheWriteTokens, cacheSavingUsd
+knownPricing, routingExplain
+```
+
+### Dashboard views
+
+| View | What it shows |
+|---|---|
+| **Overview** | Total requests, cost, avg latency, cache hit rate, realised savings from routing, provider prompt-cache savings |
+| **Requests** | Full request log — filterable by date, app, model, provider, task type, status; click any row for drilldown |
+| **Applications** | Per-app cost, requests, success rate, avg latency; health signal, kill switch per app |
+| **Models** | Spend and request count by model |
+| **Providers** | Spend, tokens, and 24h error rate + latency per provider |
+| **Teams** | Spend and requests by department |
+| **Workflows** | Spend and requests by workflow |
+| **Users** | Per-user spend and request count |
+| **Recommendations** | Premium-model overuse flagged with dollar saving; accept to create a routing rule |
+
+### Attribution dimensions
+
+Requests can carry: `application`, `workflow`, `department`, `userId`. On the OpenAI-compat endpoint, `application` is inferred from the gateway API key.
+
+### Time-series
+
+Daily or hourly trend charts for requests, cost, and failures over any date range.
+
+### Provider health
+
+24h error rate and average latency per provider — surfaces degraded connections before they affect routing.
+
+### Realised savings
+
+Tracks requests where a cheaper model was served instead of the one requested. Re-prices the served tokens at the requested model's rate to compute the actual saving. Visible in the Overview.
+
+---
+
+## Governance
+
+### API key authentication
+
+- Gateway keys (`ab_…`) authenticate data-plane calls and carry attribution
+- Created in Settings → API keys; raw key shown **once** (SHA-256 hash stored server-side)
+- Per-key **rate limit (RPM)** — returns 429 `rate_limited` when exceeded
+- **Require API keys** toggle — when on, anonymous calls are rejected
+
+### Budgets (cost caps)
+
+Scoped by `application`, `provider`, `department`, `workflow`, `model`, or global. Rolling `day` or `month` window.
+
+| Action | Effect |
+|---|---|
+| **Alert** | Cap appears as breached in dashboard and `/api/status`; requests unaffected |
+| **Downgrade** | All requests in the capped scope forced to the provider's light-tier model |
+| **Block** | Requests in the capped scope rejected with 429 `budget_exceeded` |
+
+Downgrade and Block outrank explicit developer model pins.
+
+### Application kill switch
+
+Per-application kill switch in the Applications dashboard — disables all requests from an application instantly without deleting its key or config.
+
+### Admin key
+
+`ARBR_ADMIN_KEY` gates the dashboard and all `/api/*` admin routes. Unset = open (local dev only). Set before exposing beyond localhost.
+
+See [Budgets & governance](/budgets).
+
+---
+
+## SDKs
+
+### JavaScript — `arbr-client`
+
+```sh
+npm install arbr-client
+```
+
+- `client.chat(opts)` — native endpoint call with routing metadata in response
+- `client.stream(opts)` — buffered streaming, yields chunks after the full call
+- `client.embeddings(opts)` — single or batch text embeddings
+- Configurable `timeoutMs`, `retries` (exponential backoff + jitter), injectable `fetch`
+- TypeScript types included (`index.d.ts`)
+
+### Python — `arbr-client`
+
+```sh
+pip install arbr-client
+```
+
+- `client.chat(messages, ...)` — sync
+- `async_client.chat(messages, ...)` — async
+- `client.embeddings(input, *, model, ...)` — single or batch
+- Retry and timeout support; no third-party dependencies
+
+See [JS SDK](/sdk/js), [Python SDK](/sdk/python).
+
+---
+
+## Integrations
+
+- **LibreChat** — set base URL + gateway key; full chat UI routed through Arbr
+- **OpenCode** — terminal AI coding agent; register Arbr as a custom OpenAI-compatible provider
+- **NVIDIA NIM** — connect NIM-hosted models via the OpenAI-compat endpoint
+- **LangChain** — `ChatOpenAI` pointed at Arbr base URL, no other changes
+- **Any OpenAI SDK** — Python, Node.js, Go, Ruby — change `base_url` only
+
+See [Integrations](/integrations/librechat), [OpenCode](/integrations/opencode).
+
+---
+
+## Deployment
+
+- Node.js + Express server; MongoDB for storage
+- Single Docker container or bare-metal; no external queue or cache required
+- `dotenvx`-encrypted `.env` — provider keys encrypted at rest in the repo
+- GCP deployment guide included (Cloud Run + Atlas)
+- Configurable via env vars: port, host, default model, max tokens, RPM limits, caching toggle
+
+See [Deployment](/deployment), [GCP deployment](/deployment-gcp), [Configuration](/configuration).

--- a/docs/opentelemetry.md
+++ b/docs/opentelemetry.md
@@ -1,0 +1,110 @@
+# OpenTelemetry tracing
+
+Arbr can export one **OpenTelemetry trace span per gateway request**, parented to the
+calling application's own distributed trace. Point your apps at the gateway and every LLM
+call shows up inline in the traces you already have — Grafana Tempo, Jaeger, Datadog,
+Honeycomb, whatever you run — with **no application code changes**, because the gateway
+does the emitting.
+
+It is **off by default**. When disabled, the OpenTelemetry SDK is never even loaded, so it
+costs nothing to leave off.
+
+## Enable it
+
+```sh
+# .env
+ARBR_OTEL_ENABLED=true
+ARBR_OTEL_ENDPOINT=http://your-collector:4318/v1/traces
+```
+
+That is the minimum. On boot the banner confirms it:
+
+```
+  tracing:     OTLP → http://your-collector:4318/v1/traces (sample 1)
+```
+
+## How trace context works
+
+Arbr reads the incoming **W3C `traceparent`** header off each gateway request and makes its
+span a child of the caller's span. So if your application is already instrumented, the LLM
+call nests inside the same trace as the surrounding work:
+
+```
+your-app: POST /checkout            ← your span
+  └─ arbr: chat gpt-4o-mini         ← Arbr emits this, in the same trace
+       gen_ai.request.model = auto
+       gen_ai.response.model = gpt-4o-mini
+       arbr.routing.decision = ai
+```
+
+If a request has no `traceparent`, Arbr emits a root span instead, so nothing is lost.
+
+## Configuration
+
+Every variable except the master switch falls back to the standard `OTEL_*` name, so Arbr
+drops into an already-instrumented cluster using the environment your platform already sets.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `ARBR_OTEL_ENABLED` | `false` | Master switch. Never falls back (see the warning below). |
+| `ARBR_OTEL_ENDPOINT` | `http://localhost:4318/v1/traces` | Full traces endpoint. Falls back to `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, then `OTEL_EXPORTER_OTLP_ENDPOINT`. |
+| `ARBR_OTEL_HEADERS` | none | Exporter headers (e.g. a vendor key), as `key1=val1,key2=val2`. Falls back to `OTEL_EXPORTER_OTLP_HEADERS`. |
+| `ARBR_OTEL_SERVICE_NAME` | `arbr-control-plane` | Falls back to `OTEL_SERVICE_NAME`. |
+| `ARBR_OTEL_SAMPLE_RATIO` | `1` | Head sampling, 0 to 1. Failures and caller-sampled traces are always kept. |
+| `ARBR_OTEL_CAPTURE_CONTENT` | `false` | Put prompt/response text on spans. Also requires payload capture to be on. |
+| `ARBR_OTEL_CONTENT_MAX_CHARS` | `8192` | Per-attribute clamp on captured content. |
+
+::: warning Do not set `OTEL_ENABLED`
+The master switch is `ARBR_OTEL_ENABLED`, deliberately **not** `OTEL_ENABLED`. That variable
+also switches `@langchain/core` into its own LangSmith-OTel tracing mode, so Arbr never reads
+it and warns at boot if it finds it set. Installing the OpenTelemetry packages by itself
+activates nothing.
+:::
+
+## What's on a span
+
+- **GenAI conventions:** `gen_ai.operation.name`, `gen_ai.system` / `gen_ai.provider.name`,
+  `gen_ai.request.model`, `gen_ai.response.model`, `gen_ai.usage.input_tokens` /
+  `output_tokens`, and `gen_ai.usage.cost`.
+- **Arbr specifics:** `arbr.routing.decision`, `arbr.task_type`, `arbr.classified_by`,
+  `arbr.difficulty`, `arbr.cache.hit`, `arbr.cost.total_usd`, `arbr.latency_ms`,
+  `arbr.status`, and more.
+- **Status:** a successful call leaves the span status unset; a failure or a budget block
+  sets `ERROR` with a normalized `error.type`.
+
+The span is named `{operation} {served-model}` (for example `chat gpt-4o-mini`), using the
+model actually served rather than `auto`.
+
+Sampling is decided per request so a caller's sampled trace is never left with a hole, and
+failures and budget blocks are never dropped even at a low sample ratio.
+
+## Test it locally
+
+Run a collector (Jaeger's all-in-one exposes OTLP on 4318 and a UI on 16686):
+
+```sh
+docker run --rm -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one
+```
+
+Start Arbr with tracing on, then send a request carrying a `traceparent`:
+
+```sh
+curl -X POST http://localhost:4100/v1/chat \
+  -H 'Content-Type: application/json' \
+  -H 'traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01' \
+  -d '{ "application": "demo", "model": "auto",
+        "messages": [{ "role": "user", "content": "hello" }] }'
+```
+
+Open the Jaeger UI at `http://localhost:16686` and find the trace by that id. The Arbr span
+appears under it, named for the served model and carrying the `gen_ai.*` and `arbr.*`
+attributes.
+
+## Known limitations
+
+Span duration is Arbr's measured `latencyMs`, not full gateway end-to-end time. Requests
+rejected before routing (maintenance mode, a per-app kill switch, demo mode) write no record
+and so emit no span. The export queue is per-process and in-memory; a graceful shutdown
+(SIGTERM) flushes it, but an ungraceful kill can drop queued spans. See the
+[architecture notes](https://github.com/project-arbr/arbr-control-plane/blob/main/ARCHITECTURE.md)
+for the full list.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,12 @@
         "@langchain/core": "^1.2.2",
         "@langchain/google-genai": "^2.2.0",
         "@langchain/openai": "^1.5.5",
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
+        "@opentelemetry/resources": "^2.9.0",
+        "@opentelemetry/sdk-trace-base": "^2.9.0",
+        "@opentelemetry/sdk-trace-node": "^2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.43.0",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "csrf-csrf": "^4.0.3",
@@ -1760,6 +1766,220 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.9.0.tgz",
+      "integrity": "sha512-OQ0vzvbZBiUhjqLnUaoNfYmP8553Crr3aggB4y0ZUi815mZ7idpdJXQmoKdeBKJelYttoBlLSSHubmyw3wvX4w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.220.0.tgz",
+      "integrity": "sha512-/+ExB3lRkf+erv4PnoywyL7RHKITidxtUpUTS55k7OQ0dB42S7gEF1gry7swb9MSm1hYLUhJg4QQh9W8SpwwqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/otlp-exporter-base": "0.220.0",
+        "@opentelemetry/otlp-transformer": "0.220.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.220.0.tgz",
+      "integrity": "sha512-CXYo8UD5Mn9YbgebO2EL4wejtA+gxLmLiu6HCk2KH2BR7XhFN6/6p1UlCb23DYCjeYkndevLHuejCCN1yx4+OQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/otlp-transformer": "0.220.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.220.0.tgz",
+      "integrity": "sha512-lXGrv7KXZ0gNH9SVNUaa6vv6phVYGvJxfXAlMbzbakiXru75f5MZl8Z7oqiMMQD77riVHJCFlQvbZs/VVN2/4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-logs": "0.220.0",
+        "@opentelemetry/sdk-metrics": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.220.0.tgz",
+      "integrity": "sha512-WywcTkQtv2iNmt+6y5Kcd4rzvx9bLVsBa2Nwcmg01IUaBTkTow3W4d9KE5vNBpEDtb9tp21WcRBY/lANRrApYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.9.0.tgz",
+      "integrity": "sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
+      "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.9.0.tgz",
+      "integrity": "sha512-ec9a7ps37huy5itYk0MalaZdSLlM6AXWp/FhtEjgMpp5leEGojBDvAl/UWttQnkMZOvFHKzRESn8TD3yKTF5nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.9.0",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/sdk-trace-base": "2.9.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@paralleldrive/cuid2": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://github.com/project-arbr/arbr-control-plane#readme",
   "type": "commonjs",
   "engines": {
-    "node": ">=18"
+    "node": "^18.19.0 || >=20.6.0"
   },
   "scripts": {
     "server": "node server/src/index.js",
@@ -55,6 +55,12 @@
     "@langchain/core": "^1.2.2",
     "@langchain/google-genai": "^2.2.0",
     "@langchain/openai": "^1.5.5",
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
+    "@opentelemetry/resources": "^2.9.0",
+    "@opentelemetry/sdk-trace-base": "^2.9.0",
+    "@opentelemetry/sdk-trace-node": "^2.9.0",
+    "@opentelemetry/semantic-conventions": "^1.43.0",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "csrf-csrf": "^4.0.3",

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -266,6 +266,10 @@ function describe() {
     lines.push(`               or trusted-header for individual accountable access)`);
   }
   lines.push(`  fallback:    ${config.fallbackScope}`);
+  const otel = require("./telemetry/config");
+  lines.push(otel.enabled
+    ? `  tracing:     OTLP → ${otel.endpointDisplay} (sample ${otel.sampleRatio})`
+    : `  tracing:     OFF (set ARBR_OTEL_ENABLED=true to export OTLP spans)`);
   if (config.demoMode) {
     lines.push(`  mode:        DEMO at boot — no provider keys in env.`);
     lines.push(`               Add keys in the dashboard (Models page) or to`);

--- a/server/src/gateway/embeddings.js
+++ b/server/src/gateway/embeddings.js
@@ -128,6 +128,9 @@ async function handleEmbeddings(req, res) {
     workflow:    req.headers["x-arbr-workflow"] || body["x-arbr-workflow"] || "embedding",
     userId:      body.user || req.headers["x-arbr-user-id"] || req.apiKey?.userId || null,
     department:  body["x-arbr-department"] || req.headers["x-arbr-department"] || req.apiKey?.department || null,
+    // W3C trace context for the OTel span (stripped before storage; see logger.js).
+    _traceparent: req.headers.traceparent,
+    _tracestate: req.headers.tracestate,
   };
 
   // Resolve provider from model ID

--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -338,6 +338,11 @@ async function handleChat(req, res) {
     workflow: body.workflow || "unknown",
     userId: body.userId || null,
     department: body.department || "unknown",
+    // W3C trace context, so the OTel span nests inside the caller's trace. Stripped
+    // before the record is stored (see logging/logger.js). Spread into every log
+    // call below via ...meta, so no per-call-site edits are needed.
+    _traceparent: req.headers.traceparent,
+    _tracestate: req.headers.tracestate,
   };
 
   // The developer's literal model intent, for the log ("auto" when deferred).

--- a/server/src/gateway/openaiCompat.js
+++ b/server/src/gateway/openaiCompat.js
@@ -343,6 +343,9 @@ async function handleOpenAICompat(req, res) {
     workflow: body["x-arbr-workflow"] || req.headers["x-arbr-workflow"] || "completion",
     userId: body.user || req.headers["x-arbr-user-id"] || req.apiKey?.userId || null,
     department: body["x-arbr-department"] || req.headers["x-arbr-department"] || req.apiKey?.department || null,
+    // W3C trace context for the OTel span (stripped before storage; see logger.js).
+    _traceparent: req.headers.traceparent,
+    _tracestate: req.headers.tracestate,
   };
 
   // Normalize max_tokens → maxTokens for the routing layer.

--- a/server/src/gateway/realtimeProxy.js
+++ b/server/src/gateway/realtimeProxy.js
@@ -72,6 +72,9 @@ async function handleRealtimeSession(req, clientWs) {
     workflow:    req.headers["x-arbr-workflow"] || "realtime-voice",
     userId:      req.apiKey?.userId     || req.headers["x-arbr-user-id"] || null,
     department:  req.apiKey?.department || req.headers["x-arbr-department"] || null,
+    // W3C trace context for the OTel span (stripped before storage; see logger.js).
+    _traceparent: req.headers.traceparent,
+    _tracestate: req.headers.tracestate,
   };
 
   function teardown(status) {

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -29,6 +29,7 @@ const apiRoutes = require("./api/routes");
 const authRoutes = require("./api/routes/auth");
 const connections = require("./providers/connections");
 const { computeReadiness } = require("./health/readiness");
+const telemetry = require("./telemetry");
 
 // Built dashboard (created by `npm --prefix web run build`). When present, the
 // server serves it on the same port — single-port production / Docker.
@@ -57,6 +58,7 @@ async function start() {
   await mongoose.connect(config.mongoUri);
   await registry.init(); // seed ModelEntry if empty + warm in-memory cache
   await backfillInternalKind(); // idempotent; no-op after the first run
+  telemetry.init(); // OTLP trace export — a no-op unless ARBR_OTEL_ENABLED is set
 
   // Production: force data-plane API keys on so anonymous /v1 calls are rejected.
   if (config.isProduction) {
@@ -299,7 +301,11 @@ function installShutdownHandlers({ server }) {
       canaryMonitor.stop();
       evalWorker.stop();
 
-      // 6 · Mongo last — the drained writes above need it alive.
+      // 6 · Flush and shut down the OTel exporter, so spans buffered for the drained
+      // writes above are exported before the process exits (a no-op when disabled).
+      await telemetry.shutdown();
+
+      // 7 · Mongo last — the drained writes above need it alive.
       await mongoose.disconnect();
       console.log("[shutdown] clean");
     } catch (err) {

--- a/server/src/logging/logger.js
+++ b/server/src/logging/logger.js
@@ -5,6 +5,7 @@ const { costFor } = require("../pricing/registry");
 const { maskMessages, maskPii, clampText } = require("./piiFilter");
 const Settings = require("../models/Settings");
 const capEngine = require("../routing/capEngine");
+const telemetry = require("../telemetry");
 
 function payloadFields(record, settings) {
   if (settings?.captureRequestPayloads === false) {
@@ -37,18 +38,21 @@ function payloadFields(record, settings) {
 // (expected, reported back as such) from a real write failure per-event.
 // Every other caller should keep using write() below, not this directly.
 async function writeOrThrow(record) {
-  const promptTokens = record.promptTokens || 0;
-  const completionTokens = record.completionTokens || 0;
-  const totalTokens = record.totalTokens || promptTokens + completionTokens;
-  const cachedReadTokens = record.cachedReadTokens || 0;
-  const cacheWriteTokens = record.cacheWriteTokens || 0;
-  const { inputCost, outputCost, totalCost } = record.knownPricing === false
+  // Transport-only fields: the W3C trace context read off the gateway request, used
+  // to parent the OTel span. Never stored — strip before building the Mongo doc.
+  const { _traceparent, _tracestate, ...rec } = record;
+  const promptTokens = rec.promptTokens || 0;
+  const completionTokens = rec.completionTokens || 0;
+  const totalTokens = rec.totalTokens || promptTokens + completionTokens;
+  const cachedReadTokens = rec.cachedReadTokens || 0;
+  const cacheWriteTokens = rec.cacheWriteTokens || 0;
+  const { inputCost, outputCost, totalCost } = rec.knownPricing === false
     ? { inputCost: 0, outputCost: 0, totalCost: 0 }
-    : costFor(record.model, promptTokens, completionTokens, { cachedReadTokens, cacheWriteTokens });
+    : costFor(rec.model, promptTokens, completionTokens, { cachedReadTokens, cacheWriteTokens });
   // Estimated $ saved by cached reads vs paying full input rate for them.
   let cacheSavingUsd = 0;
-  if (record.knownPricing !== false && cachedReadTokens > 0) {
-    const full = costFor(record.model, promptTokens, completionTokens);
+  if (rec.knownPricing !== false && cachedReadTokens > 0) {
+    const full = costFor(rec.model, promptTokens, completionTokens);
     cacheSavingUsd = Math.max(0, full.totalCost - totalCost);
   }
 
@@ -56,11 +60,11 @@ async function writeOrThrow(record) {
   // PII-mask when enabled, then size-cap. Only the logged copy is masked — the model
   // already received the original text. Settings are read lazily (singleton pattern).
   const s = await Settings.get().catch(() => null);
-  const { messages, responseText } = payloadFields(record, s);
+  const { messages, responseText } = payloadFields(rec, s);
 
-  const doc = await RequestRecord.create({
-    ...record,
-    knownPricing: record.knownPricing !== false, // normalize to a stored boolean
+  const fields = {
+    ...rec,
+    knownPricing: rec.knownPricing !== false, // normalize to a stored boolean
     messages,
     responseText,
     promptTokens,
@@ -72,16 +76,24 @@ async function writeOrThrow(record) {
     inputCost,
     outputCost,
     totalCost,
-  });
+  };
+
+  // Emit the OTel trace span BEFORE the DB write, so a Mongo failure can't suppress
+  // it. Content capture inherits the masking above (messages/responseText already
+  // masked, and undefined when captureRequestPayloads is off). Synchronous and
+  // swallowed inside telemetry — it never throws into this path.
+  telemetry.emit(fields, { traceparent: _traceparent, tracestate: _tracestate });
+
+  const doc = await RequestRecord.create(fields);
 
   // Hard budget counters: only count successful, priced spend (not blocked/failed).
-  if (record.status === "success" && totalCost > 0 && record.knownPricing !== false) {
+  if (rec.status === "success" && totalCost > 0 && rec.knownPricing !== false) {
     setImmediate(() =>
       capEngine.recordSpend(totalCost, {
-        application: record.application,
-        provider: record.provider,
+        application: rec.application,
+        provider: rec.provider,
         // Arbr's own overhead counts against a global cap but not a scoped one.
-        internalKind: record.internalKind || null,
+        internalKind: rec.internalKind || null,
       }).catch(() => {})
     );
   }

--- a/server/src/telemetry/attributes.js
+++ b/server/src/telemetry/attributes.js
@@ -1,0 +1,157 @@
+// Pure mapping from a RequestRecord-shaped object to OpenTelemetry span data.
+// No @opentelemetry/* import here — otel.js owns the SDK. Nearly all the logic
+// lives in this file, so it unit-tests without loading the SDK.
+//
+// The GenAI semantic conventions are still evolving; attribute names may shift
+// between versions. Keeping the whole mapping here means a rename is a one-file
+// change. Cost (`gen_ai.usage.cost`) and the message-content attributes are the
+// least stable; treat them as de-facto.
+
+// Arbr provider id → OTel gen_ai.system value. semconv is unstable on the exact
+// strings, so unmapped ids pass through verbatim.
+const PROVIDER_MAP = {
+  openai: "openai",
+  anthropic: "anthropic",
+  gemini: "gcp.gemini",
+  "bedrock-nova": "aws.bedrock",
+  deepseek: "deepseek",
+  moonshot: "moonshot",
+  xai: "xai",
+  groq: "groq",
+  litellm: "litellm",
+};
+
+function providerName(p) {
+  return p ? (PROVIDER_MAP[p] || p) : undefined;
+}
+
+function operationName(record) {
+  return record.taskType === "embedding" ? "embeddings" : "chat";
+}
+
+// Span name: "{operation} {served-model}". The spec says name with the request
+// model, but Arbr's modelRequested is literally "auto" on routed traffic, which
+// makes every span read "chat auto". Name with the SERVED model and record both
+// as attributes.
+function spanName(record) {
+  const op = operationName(record);
+  return record.model ? `${op} ${record.model}` : op;
+}
+
+function set(a, key, val) {
+  if (val !== undefined && val !== null && val !== "") a[key] = val;
+}
+
+function clamp(s, n) {
+  return s.length > n ? s.slice(0, n) : s;
+}
+
+function attributesFor(record, { captureContent = false, contentMaxChars = 8192 } = {}) {
+  const a = {};
+  const provider = providerName(record.provider);
+
+  // GenAI semantic conventions.
+  set(a, "gen_ai.operation.name", operationName(record));
+  set(a, "gen_ai.system", provider);        // legacy name, still what most backends key on
+  set(a, "gen_ai.provider.name", provider); // newer name, emitted during the transition
+  set(a, "gen_ai.request.model", record.modelRequested);
+  set(a, "gen_ai.response.model", record.model);
+  set(a, "gen_ai.response.id", record.requestId);
+  if (record.promptTokens != null) a["gen_ai.usage.input_tokens"] = record.promptTokens;
+  if (record.completionTokens != null) a["gen_ai.usage.output_tokens"] = record.completionTokens;
+  if (record.totalCost != null) a["gen_ai.usage.cost"] = record.totalCost; // non-standard, de-facto
+
+  // Standard non-GenAI.
+  set(a, "user.id", record.userId);
+
+  // arbr.* — everything semconv has no home for. Flat scalars (queryable in every
+  // backend), never nested JSON.
+  set(a, "arbr.request_id", record.requestId);
+  set(a, "arbr.application", record.application);
+  set(a, "arbr.workflow", record.workflow);
+  set(a, "arbr.department", record.department);
+  set(a, "arbr.task_type", record.taskType);
+  set(a, "arbr.classified_by", record.classifiedBy);
+  set(a, "arbr.difficulty", record.difficulty);
+  if (record.difficultyScore != null) a["arbr.difficulty_score"] = record.difficultyScore;
+  if (record.confidence != null) a["arbr.confidence"] = record.confidence;
+  set(a, "arbr.routing.decision", record.routingDecision);
+  if (record.cacheHit != null) a["arbr.cache.hit"] = !!record.cacheHit;
+  if (record.cachedReadTokens) a["arbr.cache.read_tokens"] = record.cachedReadTokens;
+  if (record.cacheSavingUsd) a["arbr.cache.saving_usd"] = record.cacheSavingUsd;
+  if (record.inputCost != null) a["arbr.cost.input_usd"] = record.inputCost;
+  if (record.outputCost != null) a["arbr.cost.output_usd"] = record.outputCost;
+  if (record.totalCost != null) a["arbr.cost.total_usd"] = record.totalCost;
+  if (record.knownPricing != null) a["arbr.cost.known_pricing"] = record.knownPricing !== false;
+  if (record.latencyMs != null) a["arbr.latency_ms"] = record.latencyMs;
+  if (record.ttftMs != null) a["arbr.ttft_ms"] = record.ttftMs;
+  if (record.gatewayOverheadMs != null) a["arbr.gateway_overhead_ms"] = record.gatewayOverheadMs;
+  // status has three values (success|failure|blocked); OTel status has two, so keep it.
+  set(a, "arbr.status", record.status);
+  set(a, "arbr.internal_kind", record.internalKind);
+  set(a, "arbr.source", record.source);
+
+  // routingExplain (a Mixed field) flattened to scalars.
+  const ex = record.routingExplain;
+  if (ex && typeof ex === "object") {
+    set(a, "arbr.routing.basis", ex.basis);
+    if (ex.rule && ex.rule.note) set(a, "arbr.routing.rule", ex.rule.note);
+    if (ex.override && ex.override.type) set(a, "arbr.routing.override_type", ex.override.type);
+  }
+
+  // Content — opt-in, clamped small. Collectors drop oversized spans, so one long
+  // prompt would otherwise lose the whole trace. This is the least-stable mapping.
+  if (captureContent) {
+    if (record.messages) a["gen_ai.input.messages"] = clamp(JSON.stringify(record.messages), contentMaxChars);
+    if (record.responseText) a["gen_ai.output.messages"] = clamp(String(record.responseText), contentMaxChars);
+  }
+
+  return a;
+}
+
+// OTel status is two-valued. success → UNSET (setting OK overrides a backend's own
+// error heuristics); failure and blocked → ERROR. arbr.status keeps the full three.
+function spanStatus(record) {
+  if (record.status === "failure") return { code: "ERROR", message: record.errorMessage || "request failed" };
+  if (record.status === "blocked") return { code: "ERROR", message: record.errorMessage || "blocked" };
+  return { code: "UNSET" };
+}
+
+// A normalized error.type token for non-success spans.
+function errorType(record) {
+  if (record.status === "success") return undefined;
+  const m = String(record.errorMessage || "").toLowerCase();
+  if (record.status === "blocked") {
+    if (m.includes("budget") || m.includes("cap")) return "budget_exceeded";
+    if (m.includes("guardrail")) return "guardrail_violation";
+    if (m.includes("injection")) return "prompt_injection";
+    if (m.includes("kill") || m.includes("maintenance") || m.includes("disabled")) return "app_disabled";
+    return "blocked";
+  }
+  return "provider_error";
+}
+
+// Span timing. start = record.timestamp; end = start + latencyMs, clamped to a 1ms
+// floor so zero-latency failure records still render. Some records (embeddings,
+// realtime) carry no timestamp — fall back to now - latency.
+function timing(record, now = Date.now()) {
+  const latency = Math.max(1, Number(record.latencyMs) || 0);
+  const start = record.timestamp ? new Date(record.timestamp).getTime() : now - latency;
+  return { startMs: start, endMs: start + latency };
+}
+
+// The sampling decision, made here (not via an SDK sampler) so two policies the
+// sampler can't see always apply: honor a sampled parent (never leave a hole in the
+// caller's trace), and never drop a failure or a block. rng is injectable for tests.
+function shouldSample(record, parent, ratio, rng = Math.random) {
+  if (parent && parent.sampled) return true;
+  if (record.status && record.status !== "success") return true;
+  if (ratio >= 1) return true;
+  if (ratio <= 0) return false;
+  return rng() < ratio;
+}
+
+module.exports = {
+  attributesFor, spanName, spanStatus, errorType, timing, shouldSample,
+  operationName, providerName,
+};

--- a/server/src/telemetry/config.js
+++ b/server/src/telemetry/config.js
@@ -1,0 +1,68 @@
+// Telemetry configuration, resolved once from the environment.
+//
+// The master switch is ARBR_OTEL_ENABLED, deliberately NOT OTEL_ENABLED:
+// `langsmith` (transitive via @langchain/core) reads OTEL_ENABLED and, when true,
+// flips LangChain into its own OTel tracing mode. Reading it here would couple
+// this feature to a dependency's behaviour. Installing the OTel packages alone
+// activates nothing — only OTEL_ENABLED / LANGSMITH_TRACING_MODE / LANGSMITH_OTEL_ENABLED
+// do — so we never read or set those three, and warn if OTEL_ENABLED is present.
+//
+// Every OTHER knob falls back to the standard OTEL_* names, so Arbr drops into an
+// already-instrumented cluster using the env a platform team already injects.
+
+function env(...names) {
+  for (const n of names) {
+    const v = process.env[n];
+    if (v != null && v !== "") return v;
+  }
+  return undefined;
+}
+
+function bool(v, dflt = false) {
+  if (v == null || v === "") return dflt;
+  return /^(1|true|yes|on)$/i.test(String(v).trim());
+}
+
+function ratio(v, dflt = 1) {
+  const n = Number(v);
+  return Number.isFinite(n) && n >= 0 && n <= 1 ? n : dflt;
+}
+
+function posInt(v, dflt) {
+  const n = parseInt(v, 10);
+  return Number.isFinite(n) && n > 0 ? n : dflt;
+}
+
+// OTLP header list: "key1=val1,key2=val2".
+function parseHeaders(raw) {
+  const out = {};
+  if (!raw) return out;
+  for (const pair of String(raw).split(",")) {
+    const i = pair.indexOf("=");
+    if (i > 0) out[pair.slice(0, i).trim()] = pair.slice(i + 1).trim();
+  }
+  return out;
+}
+
+// A full traces endpoint set explicitly wins. Otherwise we leave `endpointOverride`
+// undefined and let the OTLP exporter self-resolve from OTEL_EXPORTER_OTLP_* (it
+// correctly appends /v1/traces to a base endpoint; we can't, so we don't try).
+const endpointOverride = env("ARBR_OTEL_ENDPOINT", "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") || null;
+const otelBase = env("OTEL_EXPORTER_OTLP_ENDPOINT");
+
+const config = {
+  enabled: bool(process.env.ARBR_OTEL_ENABLED, false),
+  endpointOverride,
+  // For the boot banner only.
+  endpointDisplay: endpointOverride
+    || (otelBase ? `${otelBase.replace(/\/$/, "")}/v1/traces` : "http://localhost:4318/v1/traces (default)"),
+  headersOverride: parseHeaders(env("ARBR_OTEL_HEADERS")),
+  serviceName: env("ARBR_OTEL_SERVICE_NAME", "OTEL_SERVICE_NAME") || "arbr-control-plane",
+  sampleRatio: ratio(process.env.ARBR_OTEL_SAMPLE_RATIO, 1),
+  captureContent: bool(process.env.ARBR_OTEL_CAPTURE_CONTENT, false),
+  contentMaxChars: posInt(process.env.ARBR_OTEL_CONTENT_MAX_CHARS, 8192),
+  // The poisoned variable — detected so init() can warn, never used to configure.
+  otelEnabledDetected: bool(process.env.OTEL_ENABLED, false),
+};
+
+module.exports = config;

--- a/server/src/telemetry/index.js
+++ b/server/src/telemetry/index.js
@@ -1,0 +1,42 @@
+// Telemetry facade. The app imports this; it delegates to the lazy OTel edge.
+//
+// emit() is a synchronous no-op when disabled (one boolean test, no allocation),
+// so leaving tracing off costs nothing on the request path.
+const config = require("./config");
+const otel = require("./otel");
+
+let _started = false;
+
+function init() {
+  if (_started) return;
+  _started = true;
+
+  if (config.otelEnabledDetected) {
+    console.warn(
+      "[telemetry] OTEL_ENABLED=true detected. Arbr ignores it (use ARBR_OTEL_ENABLED); " +
+      "note that variable also switches @langchain/core into LangSmith-OTel mode.",
+    );
+  }
+  if (!config.enabled) return;
+
+  otel.init();
+  if (otel.isEnabled()) {
+    console.log(
+      `[telemetry] OTLP trace export ON → ${config.endpointDisplay} ` +
+      `(sample ${config.sampleRatio}, content ${config.captureContent ? "on" : "off"})`,
+    );
+  }
+}
+
+function emit(record, ctx) {
+  if (config.enabled) otel.emit(record, ctx);
+}
+
+function isEnabled() {
+  return config.enabled && otel.isEnabled();
+}
+
+const forceFlush = () => otel.forceFlush();
+const shutdown = () => otel.shutdown();
+
+module.exports = { init, emit, isEnabled, forceFlush, shutdown, config };

--- a/server/src/telemetry/otel.js
+++ b/server/src/telemetry/otel.js
@@ -1,0 +1,124 @@
+// The only file that touches @opentelemetry/*. Everything is lazy: nothing is
+// required until init() runs with tracing enabled, so a default (disabled) boot
+// never loads the SDK — zero cost, zero memory, and no chance of touching a global.
+// All the logic lives in the pure siblings; this is the thin SDK edge.
+const config = require("./config");
+const { parseTraceparent } = require("./traceContext");
+const attrs = require("./attributes");
+
+let _sdk = null;    // { api, provider, tracer } once initialized
+let _lastErrAt = 0; // rate-limit exporter error logs (a dead collector must not flood stdout)
+
+function init() {
+  if (_sdk || !config.enabled) return;
+  try {
+    const api = require("@opentelemetry/api");
+    const { NodeTracerProvider } = require("@opentelemetry/sdk-trace-node");
+    const { BatchSpanProcessor, AlwaysOnSampler } = require("@opentelemetry/sdk-trace-base");
+    const { OTLPTraceExporter } = require("@opentelemetry/exporter-trace-otlp-http");
+    const { resourceFromAttributes } = require("@opentelemetry/resources");
+    const { ATTR_SERVICE_NAME } = require("@opentelemetry/semantic-conventions");
+
+    // No url/headers passed unless overridden — the exporter self-resolves the
+    // standard OTEL_EXPORTER_OTLP_* env (it appends /v1/traces to a base endpoint).
+    const exporter = new OTLPTraceExporter({
+      ...(config.endpointOverride ? { url: config.endpointOverride } : {}),
+      ...(Object.keys(config.headersOverride).length ? { headers: config.headersOverride } : {}),
+    });
+
+    const provider = new NodeTracerProvider({
+      resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: config.serviceName }),
+      // Sampling is decided in emit() (so failures/blocks and sampled parents are
+      // never dropped), so the SDK sampler is always-on.
+      sampler: new AlwaysOnSampler(),
+      spanProcessors: [
+        new BatchSpanProcessor(exporter, {
+          maxQueueSize: 2048,
+          maxExportBatchSize: 512,
+          scheduledDelayMillis: 5000,
+          exportTimeoutMillis: 30000,
+        }),
+      ],
+      // Hard backstop against oversized content attributes (collectors drop big spans).
+      spanLimits: { attributeValueLengthLimit: config.contentMaxChars, attributeCountLimit: 96 },
+    });
+
+    // Deliberately NOT provider.register() — we hold a provider-local tracer and
+    // never install a global context manager or propagator, so nothing else in the
+    // process is affected by tracing being on.
+    const tracer = provider.getTracer("arbr-control-plane");
+    _sdk = { api, provider, tracer };
+  } catch (err) {
+    console.error("[telemetry] init failed, tracing disabled:", err.message);
+    _sdk = null;
+  }
+}
+
+function isEnabled() {
+  return !!_sdk;
+}
+
+// emit(record, { traceparent }) — synchronous, and never throws into the caller.
+function emit(record, ctx = {}) {
+  if (!_sdk) return;
+  try {
+    const parent = parseTraceparent(ctx.traceparent);
+    if (!attrs.shouldSample(record, parent, config.sampleRatio)) return;
+    const { api, tracer } = _sdk;
+
+    // Anchor to ROOT_CONTEXT (we're in a detached setImmediate with no meaningful
+    // ambient context). Parent to the caller's span when a traceparent is present,
+    // so the LLM call nests inside their distributed trace; otherwise a root span.
+    let context = api.ROOT_CONTEXT;
+    if (parent) {
+      context = api.trace.setSpanContext(api.ROOT_CONTEXT, {
+        traceId: parent.traceId,
+        spanId: parent.spanId,
+        traceFlags: parent.sampled ? api.TraceFlags.SAMPLED : api.TraceFlags.NONE,
+        isRemote: true,
+      });
+    }
+
+    const { startMs, endMs } = attrs.timing(record);
+    const span = tracer.startSpan(
+      attrs.spanName(record),
+      {
+        kind: api.SpanKind.CLIENT,
+        startTime: startMs,
+        attributes: attrs.attributesFor(record, {
+          captureContent: config.captureContent,
+          contentMaxChars: config.contentMaxChars,
+        }),
+      },
+      context,
+    );
+
+    const st = attrs.spanStatus(record);
+    if (st.code === "ERROR") {
+      span.setStatus({ code: api.SpanStatusCode.ERROR, message: st.message });
+      const et = attrs.errorType(record);
+      if (et) span.setAttribute("error.type", et);
+    }
+    span.end(endMs);
+  } catch (err) {
+    const now = Date.now();
+    if (now - _lastErrAt > 60_000) {
+      console.error("[telemetry] emit failed:", err.message);
+      _lastErrAt = now;
+    }
+  }
+}
+
+async function forceFlush() {
+  if (!_sdk) return;
+  try { await _sdk.provider.forceFlush(); } catch { /* best effort */ }
+}
+
+async function shutdown() {
+  if (!_sdk) return;
+  const p = _sdk;
+  _sdk = null;
+  try { await p.provider.shutdown(); } catch { /* best effort */ }
+}
+
+module.exports = { init, isEnabled, emit, forceFlush, shutdown };

--- a/server/src/telemetry/traceContext.js
+++ b/server/src/telemetry/traceContext.js
@@ -1,0 +1,25 @@
+// W3C Trace Context parsing. Pure and dependency-free, so it unit-tests without
+// loading the OpenTelemetry SDK.
+//
+//   traceparent = version "-" trace-id "-" parent-id "-" trace-flags
+//     version:     2 hex   (ff is reserved / invalid)
+//     trace-id:   32 hex   (must not be all zero)
+//     parent-id:  16 hex   (must not be all zero)
+//     trace-flags: 2 hex   (bit 0 = sampled)
+const RE = /^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/;
+const ZERO_TRACE = "00000000000000000000000000000000";
+const ZERO_SPAN = "0000000000000000";
+
+// Returns { traceId, spanId, traceFlags, sampled } or null if absent / malformed.
+function parseTraceparent(header) {
+  if (!header || typeof header !== "string") return null;
+  const m = RE.exec(header.trim().toLowerCase());
+  if (!m) return null;
+  const [, version, traceId, spanId, flags] = m;
+  if (version === "ff") return null;
+  if (traceId === ZERO_TRACE || spanId === ZERO_SPAN) return null;
+  const traceFlags = parseInt(flags, 16);
+  return { traceId, spanId, traceFlags, sampled: (traceFlags & 0x1) === 1 };
+}
+
+module.exports = { parseTraceparent };

--- a/server/test/integration/otelExport.test.js
+++ b/server/test/integration/otelExport.test.js
@@ -1,0 +1,138 @@
+"use strict";
+// End-to-end: a real in-process OTLP/HTTP collector (port 0, torn down after),
+// the enabled telemetry module, and the actual logger seam. Exercises the whole
+// path without booting index.js — logger.writeOrThrow is called directly.
+//
+// telemetry/config reads env at require-time, so telemetry (and logger, which
+// requires it) are required lazily in before(), AFTER the collector port is known
+// and the enable flag is set.
+const { test, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const http = require("http");
+const mongoose = require("mongoose");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+
+const TRACE = "0af7651916cd43dd8448eb211c80319c";
+const PARENT = "b7ad6b7169203331";
+
+let collector, mongod, telemetry, logger, RequestRecord;
+const spans = [];
+
+function attrMap(span) {
+  return Object.fromEntries((span.attributes || []).map((a) => [
+    a.key,
+    a.value.stringValue ?? a.value.intValue ?? a.value.doubleValue ?? a.value.boolValue,
+  ]));
+}
+
+before(async () => {
+  await new Promise((resolve) => {
+    collector = http.createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => (body += c));
+      req.on("end", () => {
+        try {
+          const payload = JSON.parse(body);
+          for (const rs of payload.resourceSpans || [])
+            for (const ss of rs.scopeSpans || [])
+              for (const s of ss.spans || []) spans.push(s);
+        } catch { /* ignore */ }
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end("{}");
+      });
+    });
+    collector.listen(0, "127.0.0.1", resolve);
+  });
+
+  process.env.ARBR_OTEL_ENABLED = "true";
+  process.env.ARBR_OTEL_ENDPOINT = `http://127.0.0.1:${collector.address().port}/v1/traces`;
+  process.env.ARBR_OTEL_SAMPLE_RATIO = "1";
+
+  telemetry = require("../../src/telemetry");     // reads the env set just above
+  logger = require("../../src/logging/logger");   // requires telemetry (now cached, enabled)
+  RequestRecord = require("../../src/models/RequestRecord");
+  telemetry.init();
+
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri("arbr-otel"));
+});
+
+after(async () => {
+  await telemetry.shutdown();
+  await mongoose.disconnect();
+  await mongod.stop();
+  await new Promise((r) => collector.close(r));
+});
+
+test("telemetry initialised with the collector endpoint", () => {
+  assert.equal(telemetry.isEnabled(), true);
+});
+
+test("a gateway record writes to Mongo AND emits a span parented to the caller", async () => {
+  await logger.writeOrThrow({
+    requestId: "otel-req-1",
+    timestamp: new Date(),
+    application: "checkout",
+    provider: "openai",
+    model: "gpt-4o-mini",
+    modelRequested: "auto",
+    taskType: "summarisation",
+    promptTokens: 120,
+    completionTokens: 30,
+    latencyMs: 210,
+    status: "success",
+    routingDecision: "ai",
+    // W3C trace context off the (simulated) incoming request — the headline feature.
+    _traceparent: `00-${TRACE}-${PARENT}-01`,
+  });
+
+  // The record persisted, and the transport-only field was NOT stored.
+  const doc = await RequestRecord.findOne({ requestId: "otel-req-1" }).lean();
+  assert.ok(doc, "RequestRecord was written");
+  assert.equal(doc._traceparent, undefined, "the trace context is not stored on the record");
+
+  await telemetry.forceFlush();
+  await new Promise((r) => setTimeout(r, 200));
+
+  const span = spans.find((s) => attrMap(s)["arbr.request_id"] === "otel-req-1");
+  assert.ok(span, "a span was exported to the collector");
+  assert.equal(span.traceId, TRACE, "span nests in the caller's trace");
+  assert.equal(span.parentSpanId ?? span.parentSpanID, PARENT, "parented to the caller's span");
+  assert.equal(span.kind, 3, "CLIENT span");
+  assert.equal(span.name, "chat gpt-4o-mini", "named with the served model");
+  const a = attrMap(span);
+  assert.equal(a["gen_ai.request.model"], "auto");
+  assert.equal(a["gen_ai.response.model"], "gpt-4o-mini");
+  assert.equal(a["gen_ai.system"], "openai");
+  assert.equal(a["arbr.routing.decision"], "ai");
+});
+
+test("a record with no traceparent still exports, as a root span", async () => {
+  await logger.writeOrThrow({
+    requestId: "otel-req-2", timestamp: new Date(), application: "support",
+    provider: "anthropic", model: "claude-haiku-4-5", modelRequested: "claude-haiku-4-5",
+    promptTokens: 10, completionTokens: 5, latencyMs: 90, status: "success",
+  });
+  await telemetry.forceFlush();
+  await new Promise((r) => setTimeout(r, 200));
+
+  const span = spans.find((s) => attrMap(s)["arbr.request_id"] === "otel-req-2");
+  assert.ok(span, "root span exported");
+  assert.ok(!span.parentSpanId || span.parentSpanId === "" || span.parentSpanId === "0000000000000000",
+    "no parent (root span)");
+});
+
+test("a failed record exports an ERROR span with error.type", async () => {
+  await logger.writeOrThrow({
+    requestId: "otel-req-3", timestamp: new Date(), application: "checkout",
+    provider: "openai", model: "gpt-4o", modelRequested: "gpt-4o",
+    status: "failure", errorMessage: "upstream 502 from provider", latencyMs: 0,
+  });
+  await telemetry.forceFlush();
+  await new Promise((r) => setTimeout(r, 200));
+
+  const span = spans.find((s) => attrMap(s)["arbr.request_id"] === "otel-req-3");
+  assert.ok(span, "failure span exported");
+  assert.equal(span.status.code, 2, "OTel status ERROR");
+  assert.equal(attrMap(span)["error.type"], "provider_error");
+});

--- a/server/test/unit/otelAttributes.test.js
+++ b/server/test/unit/otelAttributes.test.js
@@ -1,0 +1,92 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const attrs = require("../../src/telemetry/attributes");
+
+const base = {
+  requestId: "req-1", timestamp: new Date("2026-01-01T00:00:00Z"),
+  application: "checkout", workflow: "wf", userId: "u1", department: "eng",
+  provider: "openai", model: "gpt-4o-mini", modelRequested: "auto",
+  taskType: "summarisation", promptTokens: 100, completionTokens: 20,
+  totalCost: 0.0012, inputCost: 0.001, outputCost: 0.0002, knownPricing: true,
+  latencyMs: 240, status: "success", routingDecision: "ai", classifiedBy: "ai",
+};
+
+test("span name uses the served model, not the requested 'auto'", () => {
+  assert.equal(attrs.spanName(base), "chat gpt-4o-mini");
+  assert.equal(attrs.spanName({ ...base, taskType: "embedding", model: "text-embedding-3-small" }),
+    "embeddings text-embedding-3-small");
+});
+
+test("maps gen_ai.* and arbr.* attributes", () => {
+  const a = attrs.attributesFor(base);
+  assert.equal(a["gen_ai.operation.name"], "chat");
+  assert.equal(a["gen_ai.request.model"], "auto");
+  assert.equal(a["gen_ai.response.model"], "gpt-4o-mini");
+  assert.equal(a["gen_ai.usage.input_tokens"], 100);
+  assert.equal(a["gen_ai.usage.output_tokens"], 20);
+  assert.equal(a["gen_ai.usage.cost"], 0.0012);
+  assert.equal(a["gen_ai.system"], "openai");
+  assert.equal(a["gen_ai.provider.name"], "openai");
+  assert.equal(a["user.id"], "u1");
+  assert.equal(a["arbr.application"], "checkout");
+  assert.equal(a["arbr.routing.decision"], "ai");
+  assert.equal(a["arbr.cost.total_usd"], 0.0012);
+  assert.equal(a["arbr.status"], "success");
+});
+
+test("maps provider ids to semconv values", () => {
+  assert.equal(attrs.providerName("bedrock-nova"), "aws.bedrock");
+  assert.equal(attrs.providerName("gemini"), "gcp.gemini");
+  assert.equal(attrs.providerName("some-custom-provider"), "some-custom-provider"); // passthrough
+  assert.equal(attrs.providerName(undefined), undefined);
+});
+
+test("omits null/undefined/empty attributes rather than emitting 'null'", () => {
+  const a = attrs.attributesFor({ requestId: "r", model: "m", status: "success", application: null, userId: undefined, workflow: "" });
+  assert.ok(!("arbr.application" in a));
+  assert.ok(!("user.id" in a));
+  assert.ok(!("arbr.workflow" in a));
+});
+
+test("captures content only when enabled, and clamps it", () => {
+  const rec = { ...base, messages: [{ role: "user", content: "x".repeat(5000) }], responseText: "y".repeat(5000) };
+  assert.ok(!("gen_ai.input.messages" in attrs.attributesFor(rec)), "off by default");
+  const a = attrs.attributesFor(rec, { captureContent: true, contentMaxChars: 100 });
+  assert.equal(a["gen_ai.input.messages"].length, 100);
+  assert.equal(a["gen_ai.output.messages"].length, 100);
+});
+
+test("status: success is UNSET, failure and blocked are ERROR", () => {
+  assert.equal(attrs.spanStatus(base).code, "UNSET");
+  assert.equal(attrs.spanStatus({ ...base, status: "failure", errorMessage: "boom" }).code, "ERROR");
+  assert.equal(attrs.spanStatus({ ...base, status: "blocked" }).code, "ERROR");
+});
+
+test("errorType normalises blocked and failed", () => {
+  assert.equal(attrs.errorType({ status: "blocked", errorMessage: "budget cap exceeded" }), "budget_exceeded");
+  assert.equal(attrs.errorType({ status: "blocked", errorMessage: "guardrail_violation" }), "guardrail_violation");
+  assert.equal(attrs.errorType({ status: "failure", errorMessage: "upstream 502" }), "provider_error");
+  assert.equal(attrs.errorType({ status: "success" }), undefined);
+});
+
+test("timing floors zero-latency records to 1ms and falls back when no timestamp", () => {
+  const t1 = attrs.timing({ timestamp: new Date("2026-01-01T00:00:00Z"), latencyMs: 0 });
+  assert.equal(t1.endMs - t1.startMs, 1, "zero latency renders as 1ms");
+  const now = 1_000_000;
+  const t2 = attrs.timing({ latencyMs: 50 }, now); // no timestamp (embeddings/realtime shape)
+  assert.equal(t2.startMs, now - 50);
+  assert.equal(t2.endMs, now);
+});
+
+test("sampling: honors a sampled parent, never drops failures, respects ratio", () => {
+  const success = { status: "success" };
+  const failure = { status: "failure" };
+  const sampledParent = { sampled: true };
+  assert.equal(attrs.shouldSample(success, sampledParent, 0), true, "sampled parent wins over ratio 0");
+  assert.equal(attrs.shouldSample(failure, null, 0), true, "failures never dropped");
+  assert.equal(attrs.shouldSample(success, null, 1), true);
+  assert.equal(attrs.shouldSample(success, null, 0), false);
+  assert.equal(attrs.shouldSample(success, null, 0.5, () => 0.4), true);  // rng below ratio
+  assert.equal(attrs.shouldSample(success, null, 0.5, () => 0.9), false); // rng above ratio
+});

--- a/server/test/unit/otelDisabled.test.js
+++ b/server/test/unit/otelDisabled.test.js
@@ -1,0 +1,32 @@
+"use strict";
+// The zero-config regression guard. With ARBR_OTEL_ENABLED unset, requiring the
+// telemetry module must NOT load the OpenTelemetry SDK, and emit() must be a safe
+// no-op. This keeps the "boots with no config, costs nothing" invariant honest.
+// (node --test isolates each test file in its own process, so another file
+// enabling tracing can't pollute this one's require.cache.)
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+delete process.env.ARBR_OTEL_ENABLED;
+
+const telemetry = require("../../src/telemetry");
+
+test("disabled by default", () => {
+  telemetry.init();
+  assert.equal(telemetry.isEnabled(), false);
+});
+
+test("the OpenTelemetry SDK is never loaded when disabled", () => {
+  const loaded = Object.keys(require.cache).filter((k) => k.includes("@opentelemetry"));
+  assert.deepEqual(loaded, [], "no @opentelemetry/* module should be in the require cache");
+});
+
+test("emit is a no-op that never throws when disabled", () => {
+  assert.doesNotThrow(() => telemetry.emit({ requestId: "x", model: "m", status: "success" }, {}));
+  assert.doesNotThrow(() => telemetry.emit({}, {}));
+});
+
+test("forceFlush and shutdown are safe no-ops when disabled", async () => {
+  await telemetry.forceFlush();
+  await telemetry.shutdown();
+});

--- a/server/test/unit/otelTraceContext.test.js
+++ b/server/test/unit/otelTraceContext.test.js
@@ -1,0 +1,44 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { parseTraceparent } = require("../../src/telemetry/traceContext");
+
+const TRACE = "0af7651916cd43dd8448eb211c80319c";
+const SPAN = "b7ad6b7169203331";
+
+test("parses a valid sampled traceparent", () => {
+  const r = parseTraceparent(`00-${TRACE}-${SPAN}-01`);
+  assert.deepEqual(r, { traceId: TRACE, spanId: SPAN, traceFlags: 1, sampled: true });
+});
+
+test("parses an unsampled traceparent", () => {
+  const r = parseTraceparent(`00-${TRACE}-${SPAN}-00`);
+  assert.equal(r.sampled, false);
+});
+
+test("rejects an all-zero trace id", () => {
+  assert.equal(parseTraceparent(`00-${"0".repeat(32)}-${SPAN}-01`), null);
+});
+
+test("rejects an all-zero span id", () => {
+  assert.equal(parseTraceparent(`00-${TRACE}-${"0".repeat(16)}-01`), null);
+});
+
+test("rejects the reserved ff version", () => {
+  assert.equal(parseTraceparent(`ff-${TRACE}-${SPAN}-01`), null);
+});
+
+test("rejects wrong lengths and garbage", () => {
+  assert.equal(parseTraceparent(`00-${TRACE}-${SPAN}`), null);        // missing flags
+  assert.equal(parseTraceparent(`00-abc-${SPAN}-01`), null);          // short trace id
+  assert.equal(parseTraceparent("not-a-traceparent"), null);
+  assert.equal(parseTraceparent(""), null);
+  assert.equal(parseTraceparent(undefined), null);
+  assert.equal(parseTraceparent(null), null);
+});
+
+test("is case-insensitive and trims", () => {
+  const r = parseTraceparent(`  00-${TRACE.toUpperCase()}-${SPAN.toUpperCase()}-01  `);
+  assert.equal(r.traceId, TRACE);
+  assert.equal(r.spanId, SPAN);
+});


### PR DESCRIPTION
## Summary

Implements **#148**: Arbr emits one OpenTelemetry span per gateway request, **parented to the caller's own distributed trace** via the incoming W3C `traceparent` header, exported over OTLP/HTTP. A team points their apps at the gateway and every LLM call shows up inline in the traces they already run (Tempo, Jaeger, Datadog, Honeycomb) with **zero application code changes**.

This is PR 1 of the phased plan in #148. PR 0 (graceful shutdown, the flush prerequisite) already shipped as #152.

**Off by default**, gated on `ARBR_OTEL_ENABLED`. When disabled the OpenTelemetry SDK is never even loaded, so leaving it off costs nothing.

## What it does, in one trace

```
your-app: POST /checkout          ← your existing span
  └─ arbr: chat gpt-4o-mini        ← Arbr emits this, in the SAME trace
       gen_ai.request.model=auto · gen_ai.response.model=gpt-4o-mini
       arbr.routing.decision=ai · arbr.cost.total_usd=0.0012
```

## Design

- **One isolated module** (`server/src/telemetry/`). `traceContext`, `attributes`, and `config` are pure (no SDK import) and hold all the logic; `otel.js` is the only file that touches `@opentelemetry/*`, and only lazily inside `init()`.
- **One seam.** Hooked in `logging/logger.js` `writeOrThrow`, the single function every request record flows through. The span is emitted *before* the Mongo write (a DB failure can't suppress it) and *after* PII masking (content capture inherits it). It's synchronous and swallowed, so it can never throw into the request path.
- **Trace context for free.** It rides the existing `meta` object already spread into every log call across the four gateway files. One field added to four literals covers 20+ call sites. The internal classifier record doesn't spread `meta`, so it correctly opts out of the caller's trace.
- **Sampling in `emit()`**, so a caller's sampled trace is never left with a hole and failures/blocks are never dropped even at a low ratio.
- **Flushed on graceful shutdown** (before `mongoose.disconnect`), so buffered spans survive a SIGTERM.

## The `OTEL_ENABLED` gotcha

The master switch is `ARBR_OTEL_ENABLED`, deliberately **not** `OTEL_ENABLED` — that variable also flips `@langchain/core` into its own LangSmith-OTel mode. Arbr never reads it and **warns at boot if it finds it set**. Every other knob falls back to the standard `OTEL_*` names, so this drops into an already-instrumented cluster. (Installing the OTel packages alone activates nothing.)

## Dependencies

Five `@opentelemetry/*` packages, all pure JS (the `-http` exporter, not `-grpc`/`-proto`). Verified no new native/node-gyp packages enter the tree. Their engine floor is `^18.19.0 || >=20.6.0`, so I bumped `package.json`'s node engine to match — **CI and the Dockerfile already use Node 20**, so no runtime change.

## Tests

24 tests, all passing:
- **traceparent parsing** — valid, all-zero trace/span, reserved `ff`, garbage, case/trim.
- **attribute/status/timing/sampling mapping** — served-model span name, gen_ai + arbr attributes, null omission, content clamp, ERROR vs UNSET status, zero-latency floor, sampling rules.
- **Zero-config regression guard** — with the flag unset, requiring the module loads no `@opentelemetry/*` and `emit()` is a no-op.
- **End-to-end integration** — a real in-process OTLP collector; `logger.writeOrThrow` with a `traceparent` both persists a `RequestRecord` and exports a span whose `traceId`/`parentSpanId` match the caller, plus a root-span case and an ERROR-span case.

Full server suite: no new failures versus `main` (the same pre-existing env-dependent tests fail locally; CI is green on those). Lint: 0 errors.

## Docs

`docs/opentelemetry.md` (enable, trace-context walkthrough, config table, a local Jaeger test), an `.env.example` block, and an honest "known limitations" bullet in `ARCHITECTURE.md` (span duration is `latencyMs` not end-to-end; the five early-return paths emit no span; the queue is per-process).

## Try it

```sh
docker run --rm -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one
# then, with ARBR_OTEL_ENABLED=true and the endpoint set:
curl -X POST localhost:4100/v1/chat \
  -H 'traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01' \
  -H 'Content-Type: application/json' \
  -d '{"application":"demo","model":"auto","messages":[{"role":"user","content":"hi"}]}'
```
The Arbr span appears in Jaeger under that trace id.

## Follow-ups (from #148, not in this PR)

- PR 2 — runtime controls in the Governance UI (pause/tune without a redeploy).
- PR 3 — spans for the five early-return paths, an `X-Arbr-Trace-Id` response header, realtime WS session spans.

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)