### PR TITLE
fix: land OTel runtime controls on main (stacked-PR-squash gotcha)

### DIFF
--- a/docs/opentelemetry.md
+++ b/docs/opentelemetry.md
@@ -61,6 +61,21 @@ it and warns at boot if it finds it set. Installing the OpenTelemetry packages b
 activates nothing.
 :::
 
+## Runtime controls (no redeploy)
+
+`ARBR_OTEL_ENABLED` in the environment is the hard on/off switch: it decides whether the
+exporter is loaded at all. Once it's on, you can pause and retune tracing from the dashboard
+under **Governance → Observability → Distributed tracing**, without a restart:
+
+- **Emit spans** — pause and resume exporting. While on, failures and caller-sampled traces
+  are always kept regardless of the sample ratio; while paused, nothing is emitted.
+- **Sample ratio** — retune the fraction of successful requests traced.
+- **Capture prompt & response on spans** — toggle content capture (still gated on payload
+  capture being on).
+
+These override the environment values and take effect within a few seconds. Leaving a field
+unset falls back to the corresponding `ARBR_OTEL_*` environment value.
+
 ## What's on a span
 
 - **GenAI conventions:** `gen_ai.operation.name`, `gen_ai.system` / `gen_ai.provider.name`,

--- a/server/src/api/routes/governance.js
+++ b/server/src/api/routes/governance.js
@@ -4,6 +4,8 @@ const { logAction } = require("../auditLogger");
 const { requireRole } = require("../rbac");
 const Settings = require("../../models/Settings");
 const { config } = require("../../config");
+const telemetry = require("../../telemetry");
+const telemetryConfig = require("../../telemetry/config");
 
 const router = express.Router();
 
@@ -30,6 +32,14 @@ function governanceView(s) {
     semanticCacheEnabled:    s.semanticCacheEnabled ?? false,
     semanticCacheThreshold:  s.semanticCacheThreshold ?? 0.92,
     semanticCacheTtlMinutes: s.semanticCacheTtlMinutes ?? 60,
+    // OTLP tracing. otelConfigured is read-only: whether ARBR_OTEL_ENABLED is set in
+    // the environment (the hard gate). The editable fields only narrow an env-enabled
+    // exporter; null means "use the environment value".
+    otelConfigured:          telemetryConfig.enabled,
+    otelEndpoint:            telemetryConfig.enabled ? telemetryConfig.endpointDisplay : null,
+    otelEnabled:             s.otel?.enabled ?? null,
+    otelSampleRatio:         s.otel?.sampleRatio ?? telemetryConfig.sampleRatio,
+    otelCaptureContent:      s.otel?.captureContent ?? null,
   };
 }
 
@@ -85,10 +95,19 @@ router.patch("/governance", requireRole("administrator"), async (req, res, next)
       update.semanticCacheThreshold = Math.min(1, Math.max(0, Number(body.semanticCacheThreshold) || 0.92));
     if ("semanticCacheTtlMinutes" in body)
       update.semanticCacheTtlMinutes = Math.max(1, Number(body.semanticCacheTtlMinutes) || 60);
+    // OTLP tracing runtime overrides. These only narrow an env-enabled exporter.
+    if ("otelEnabled" in body)
+      update["otel.enabled"] = body.otelEnabled == null ? null : !!body.otelEnabled;
+    if ("otelSampleRatio" in body)
+      update["otel.sampleRatio"] = body.otelSampleRatio == null ? null : Math.min(1, Math.max(0, Number(body.otelSampleRatio) || 0));
+    if ("otelCaptureContent" in body)
+      update["otel.captureContent"] = body.otelCaptureContent == null ? null : !!body.otelCaptureContent;
 
     await Settings.updateOne({ key: "global" }, { $set: update }, { upsert: true });
     Settings.invalidateCache();
     const s = await Settings.get();
+    // Push tracing changes to the live exporter now, rather than waiting for the poll.
+    setImmediate(() => telemetry.refreshRuntime());
     setImmediate(() => logAction("governance.update", "settings", "global", body, req.user));
     res.json(governanceView(s));
   } catch (e) { next(e); }

--- a/server/src/models/Settings.js
+++ b/server/src/models/Settings.js
@@ -104,6 +104,18 @@ const settingsSchema = new mongoose.Schema(
     semanticCacheEnabled:      { type: Boolean, default: false },
     semanticCacheThreshold:    { type: Number,  default: 0.92 },  // 0–1 cosine similarity
     semanticCacheTtlMinutes:   { type: Number,  default: 60 },    // cache TTL in minutes
+
+    // Runtime overrides for OTLP trace export. ARBR_OTEL_ENABLED (env) is the HARD
+    // gate — whether the exporter is loaded at all; these only narrow an env-enabled
+    // exporter, so an operator can pause tracing or retune it without a redeploy.
+    //   enabled:        soft on/off. null = on (default when env-enabled).
+    //   sampleRatio:    0–1 head sampling. null = use ARBR_OTEL_SAMPLE_RATIO.
+    //   captureContent: put prompt/response on spans. null = use ARBR_OTEL_CAPTURE_CONTENT.
+    otel: {
+      enabled:        { type: Boolean, default: null },
+      sampleRatio:    { type: Number,  default: null },
+      captureContent: { type: Boolean, default: null },
+    },
   },
   { collection: "settings" }
 );

--- a/server/src/telemetry/index.js
+++ b/server/src/telemetry/index.js
@@ -4,6 +4,7 @@
 // so leaving tracing off costs nothing on the request path.
 const config = require("./config");
 const otel = require("./otel");
+const runtime = require("./runtime");
 
 let _started = false;
 
@@ -39,4 +40,8 @@ function isEnabled() {
 const forceFlush = () => otel.forceFlush();
 const shutdown = () => otel.shutdown();
 
-module.exports = { init, emit, isEnabled, forceFlush, shutdown, config };
+// Re-read the Settings-backed runtime overrides now, instead of waiting for the poll.
+// Called from PATCH /governance so a dashboard change takes effect immediately.
+const refreshRuntime = () => (config.enabled ? runtime.refresh() : Promise.resolve());
+
+module.exports = { init, emit, isEnabled, forceFlush, shutdown, refreshRuntime, config };

--- a/server/src/telemetry/otel.js
+++ b/server/src/telemetry/otel.js
@@ -5,6 +5,7 @@
 const config = require("./config");
 const { parseTraceparent } = require("./traceContext");
 const attrs = require("./attributes");
+const runtime = require("./runtime");
 
 let _sdk = null;    // { api, provider, tracer } once initialized
 let _lastErrAt = 0; // rate-limit exporter error logs (a dead collector must not flood stdout)
@@ -48,6 +49,7 @@ function init() {
     // process is affected by tracing being on.
     const tracer = provider.getTracer("arbr-control-plane");
     _sdk = { api, provider, tracer };
+    runtime.start(); // begin polling Settings for soft on/off + sampling/content overrides
   } catch (err) {
     console.error("[telemetry] init failed, tracing disabled:", err.message);
     _sdk = null;
@@ -62,8 +64,10 @@ function isEnabled() {
 function emit(record, ctx = {}) {
   if (!_sdk) return;
   try {
+    const rt = runtime.current();
+    if (!rt.softEnabled) return; // paused from the dashboard without a redeploy
     const parent = parseTraceparent(ctx.traceparent);
-    if (!attrs.shouldSample(record, parent, config.sampleRatio)) return;
+    if (!attrs.shouldSample(record, parent, rt.sampleRatio)) return;
     const { api, tracer } = _sdk;
 
     // Anchor to ROOT_CONTEXT (we're in a detached setImmediate with no meaningful
@@ -86,7 +90,7 @@ function emit(record, ctx = {}) {
         kind: api.SpanKind.CLIENT,
         startTime: startMs,
         attributes: attrs.attributesFor(record, {
-          captureContent: config.captureContent,
+          captureContent: rt.captureContent,
           contentMaxChars: config.contentMaxChars,
         }),
       },
@@ -118,6 +122,7 @@ async function shutdown() {
   if (!_sdk) return;
   const p = _sdk;
   _sdk = null;
+  runtime.stop();
   try { await p.provider.shutdown(); } catch { /* best effort */ }
 }
 

--- a/server/src/telemetry/runtime.js
+++ b/server/src/telemetry/runtime.js
@@ -1,0 +1,51 @@
+// Runtime tracing overrides, sourced from Settings so an operator can pause tracing
+// or retune sampling / content capture without a redeploy.
+//
+// env (config.js) is the HARD gate — whether the exporter is loaded at all. These
+// overrides can only NARROW an env-enabled exporter; they can't turn tracing on when
+// the SDK was never loaded (packages can't be required at runtime). emit() reads the
+// snapshot synchronously, so it's refreshed on a background interval and eagerly on a
+// governance PATCH, never awaited on the hot path.
+const config = require("./config");
+
+let Settings = null; // required lazily, only once tracing is actually running
+let timer = null;
+
+let snap = {
+  softEnabled: true,
+  sampleRatio: config.sampleRatio,
+  captureContent: config.captureContent,
+};
+
+async function refresh() {
+  try {
+    if (!Settings) Settings = require("../models/Settings");
+    const s = await Settings.get();
+    const o = (s && s.otel) || {};
+    snap = {
+      softEnabled: o.enabled !== false, // null/undefined → on
+      sampleRatio: o.sampleRatio != null ? o.sampleRatio : config.sampleRatio,
+      captureContent: o.captureContent != null ? o.captureContent : config.captureContent,
+    };
+  } catch {
+    // Keep the last good snapshot (env defaults on first failure). A Mongo blip
+    // must never take tracing down or flip its behaviour.
+  }
+}
+
+function start() {
+  if (timer) return;
+  refresh();
+  timer = setInterval(refresh, 5000);
+  if (timer.unref) timer.unref();
+}
+
+function stop() {
+  if (timer) { clearInterval(timer); timer = null; }
+}
+
+function current() {
+  return snap;
+}
+
+module.exports = { start, stop, refresh, current };

--- a/server/test/integration/governanceOtel.test.js
+++ b/server/test/integration/governanceOtel.test.js
@@ -1,0 +1,70 @@
+"use strict";
+// The governance route exposes and persists the OTLP tracing runtime overrides.
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+const mongoose = require("mongoose");
+const express = require("express");
+const supertest = require("supertest");
+
+process.env.ARBR_ADMIN_KEY = "";
+
+const Settings = require("../../src/models/Settings");
+const apiRoutes = require("../../src/api/routes");
+
+let mongod, agent;
+
+const stubAdmin = (req, _res, next) => { req.user = { id: "t", email: "t@t", role: "administrator" }; next(); };
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(stubAdmin);
+  app.use("/api", apiRoutes);
+  return app;
+}
+
+before(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri("arbr-gov-otel"));
+  agent = supertest(buildApp());
+});
+after(async () => { await mongoose.disconnect(); await mongod.stop(); });
+beforeEach(async () => { await Settings.deleteMany({}); Settings.invalidateCache(); });
+
+test("governance view reports the tracing config (env-driven otelConfigured)", async () => {
+  const { body } = await agent.get("/api/governance").expect(200);
+  // ARBR_OTEL_ENABLED is unset in this process, so tracing is not configured.
+  assert.equal(body.otelConfigured, false);
+  assert.equal(body.otelEndpoint, null);
+  assert.equal(body.otelEnabled, null);           // null = use env default (on)
+  assert.equal(body.otelCaptureContent, null);
+});
+
+test("PATCH persists the tracing overrides and they round-trip", async () => {
+  await agent.patch("/api/governance")
+    .send({ otelEnabled: false, otelSampleRatio: 0.25, otelCaptureContent: true })
+    .expect(200);
+
+  const s = await Settings.get();
+  assert.equal(s.otel.enabled, false);
+  assert.equal(s.otel.sampleRatio, 0.25);
+  assert.equal(s.otel.captureContent, true);
+
+  const { body } = await agent.get("/api/governance").expect(200);
+  assert.equal(body.otelEnabled, false);
+  assert.equal(body.otelSampleRatio, 0.25);
+  assert.equal(body.otelCaptureContent, true);
+});
+
+test("sample ratio is clamped to 0..1 and null resets to the env default", async () => {
+  await agent.patch("/api/governance").send({ otelSampleRatio: 5 }).expect(200);
+  assert.equal((await Settings.get()).otel.sampleRatio, 1, "clamped to 1");
+
+  await agent.patch("/api/governance").send({ otelSampleRatio: -2 }).expect(200);
+  assert.equal((await Settings.get()).otel.sampleRatio, 0, "clamped to 0");
+
+  await agent.patch("/api/governance").send({ otelEnabled: null, otelCaptureContent: null }).expect(200);
+  const s = await Settings.get();
+  assert.equal(s.otel.enabled, null, "null clears the soft override");
+  assert.equal(s.otel.captureContent, null);
+});

--- a/server/test/integration/otelRuntime.test.js
+++ b/server/test/integration/otelRuntime.test.js
@@ -1,0 +1,92 @@
+"use strict";
+// Runtime controls (PR 2): with the exporter env-enabled, a Settings-backed soft
+// switch pauses tracing and a Settings sampleRatio retunes it, both without a restart.
+// Uses the same in-process OTLP collector as otelExport.test.js.
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+const http = require("http");
+const mongoose = require("mongoose");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+
+let collector, mongod, telemetry, runtime, logger, Settings;
+let spans = [];
+
+function reqId(span) {
+  const a = (span.attributes || []).find((x) => x.key === "arbr.request_id");
+  return a?.value?.stringValue;
+}
+
+before(async () => {
+  await new Promise((resolve) => {
+    collector = http.createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => (body += c));
+      req.on("end", () => {
+        try {
+          const p = JSON.parse(body);
+          for (const rs of p.resourceSpans || [])
+            for (const ss of rs.scopeSpans || [])
+              for (const s of ss.spans || []) spans.push(s);
+        } catch { /* ignore */ }
+        res.writeHead(200); res.end("{}");
+      });
+    });
+    collector.listen(0, "127.0.0.1", resolve);
+  });
+
+  process.env.ARBR_OTEL_ENABLED = "true";
+  process.env.ARBR_OTEL_ENDPOINT = `http://127.0.0.1:${collector.address().port}/v1/traces`;
+  process.env.ARBR_OTEL_SAMPLE_RATIO = "1";
+
+  telemetry = require("../../src/telemetry");
+  runtime = require("../../src/telemetry/runtime");
+  logger = require("../../src/logging/logger");
+  Settings = require("../../src/models/Settings");
+  telemetry.init();
+
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri("arbr-otel-rt"));
+});
+
+after(async () => {
+  await telemetry.shutdown();
+  await mongoose.disconnect();
+  await mongod.stop();
+  await new Promise((r) => collector.close(r));
+});
+
+beforeEach(() => { spans = []; });
+
+async function setOtel(patch) {
+  await Settings.updateOne({ key: "global" }, { $set: patch }, { upsert: true });
+  Settings.invalidateCache();
+  await runtime.refresh(); // what PATCH /governance triggers
+}
+
+async function emitAndFlush(record) {
+  await logger.writeOrThrow({ timestamp: new Date(), provider: "openai", model: "gpt-4o-mini", ...record });
+  await telemetry.forceFlush();
+  await new Promise((r) => setTimeout(r, 150));
+}
+
+test("the soft switch pauses and resumes tracing without a restart", async () => {
+  await setOtel({ "otel.enabled": false });
+  await emitAndFlush({ requestId: "rt-off", status: "success", latencyMs: 10 });
+  assert.equal(spans.find((s) => reqId(s) === "rt-off"), undefined, "no span while paused");
+
+  await setOtel({ "otel.enabled": true });
+  await emitAndFlush({ requestId: "rt-on", status: "success", latencyMs: 10 });
+  assert.ok(spans.find((s) => reqId(s) === "rt-on"), "span emitted after resume");
+});
+
+test("a Settings sampleRatio of 0 drops successes but keeps failures", async () => {
+  await setOtel({ "otel.enabled": true, "otel.sampleRatio": 0 });
+
+  await emitAndFlush({ requestId: "rt-drop", status: "success", latencyMs: 10 });
+  assert.equal(spans.find((s) => reqId(s) === "rt-drop"), undefined, "success dropped at ratio 0");
+
+  await emitAndFlush({ requestId: "rt-keep", status: "failure", errorMessage: "boom", latencyMs: 0 });
+  assert.ok(spans.find((s) => reqId(s) === "rt-keep"), "failure kept even at ratio 0");
+
+  await setOtel({ "otel.sampleRatio": null }); // restore
+});

--- a/web/src/pages/Governance.jsx
+++ b/web/src/pages/Governance.jsx
@@ -721,6 +721,68 @@ function ObservabilityTab({ gov, setGov, save, saving, ok, err }) {
         </form>
       </Card>
 
+      {/* Distributed tracing (OTLP) */}
+      <Card title="Distributed tracing">
+        {!gov.otelConfigured ? (
+          <div className="py-2 text-sm text-gray-500">
+            Export an OpenTelemetry span per gateway request, parented to the caller's trace.
+            Set <code className="rounded bg-gray-100 px-1 font-mono text-xs">ARBR_OTEL_ENABLED=true</code> and
+            an endpoint in the environment to turn this on. Once enabled, you can pause and tune it here without a redeploy.
+          </div>
+        ) : (
+          <>
+            <div className="mb-3 text-xs text-gray-400">
+              Exporting to <span className="font-mono">{gov.otelEndpoint}</span>. The environment is the on/off switch for
+              loading the exporter; these controls narrow it at runtime.
+            </div>
+            <div className="divide-y divide-gray-100">
+              <div className="py-3">
+                <SettingRow
+                  label="Emit spans"
+                  sub="Pause tracing without restarting. Failures and caller-sampled traces are always kept."
+                >
+                  <Toggle
+                    checked={gov.otelEnabled !== false}
+                    onChange={(v) => setGov({ ...gov, otelEnabled: v })}
+                    label="emit spans"
+                  />
+                </SettingRow>
+              </div>
+              <div className="py-3">
+                <div className="label mb-1">Sample ratio</div>
+                <div className="flex items-center gap-2">
+                  <input
+                    className="input w-24"
+                    type="number"
+                    min="0"
+                    max="1"
+                    step="0.05"
+                    value={gov.otelSampleRatio ?? 1}
+                    onChange={(e) => setGov({ ...gov, otelSampleRatio: Number(e.target.value) })}
+                  />
+                  <span className="text-sm text-gray-400">0–1 · fraction of successful requests traced</span>
+                </div>
+              </div>
+              <div className="py-3">
+                <SettingRow
+                  label="Capture prompt & response on spans"
+                  sub="Off by default. Also requires payload capture (Guardrails tab) to be on."
+                >
+                  <Toggle
+                    checked={!!gov.otelCaptureContent}
+                    onChange={(v) => setGov({ ...gov, otelCaptureContent: v })}
+                    label="capture content on spans"
+                  />
+                </SettingRow>
+              </div>
+            </div>
+            <form onSubmit={(e) => { e.preventDefault(); save("tracing")({ otelEnabled: gov.otelEnabled, otelSampleRatio: gov.otelSampleRatio, otelCaptureContent: gov.otelCaptureContent }); }}>
+              <SaveRow saving={saving.tracing} ok={ok.tracing} err={err.tracing} />
+            </form>
+          </>
+        )}
+      </Card>
+
       {/* Alerting & Webhooks */}
       <Card title="Alerting & Webhooks">
         <div className="divide-y divide-gray-100">


### PR DESCRIPTION
## Summary
PR #192 ("runtime tracing controls in the governance dashboard") showed as **Merged**, but its base was `feat/otel-trace-export` (PR #191's feature branch), not `main`. #191 squash-merged into main without #192's commit on top, so #192's actual code — `server/src/telemetry/runtime.js`, `server/test/integration/{governanceOtel,otelRuntime}.test.js`, and the `web/src/pages/Governance.jsx` UI — never reached `main`. Same root cause as the recurring stacked-PR-squash gotcha (see #128, #162, #185).

Fixed by cherry-picking #192's single commit (`0fb66d3`) onto a fresh branch off current `main` — applied clean, no conflicts (the tree state at #191's pre-squash tip matches what's on main).

## Test plan
- [x] `npm run lint` clean (0 errors)
- [x] `MONGOMS_VERSION=7.0.14 npm run test:server` — 439/439 pass (after `npm install` for the `@opentelemetry/*` deps #191 added)
- [x] Confirmed via `git cat-file -e origin/main:server/src/telemetry/runtime.js` (and the two new test files) that they were genuinely missing before this PR