### PR TITLE
docs: disambiguate autonomy claim, extend quickstart to the full loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,14 @@ Open **http://localhost:4100** and follow the demo lifecycle:
 1. Inspect workload cost and model usage on **Overview**.
 2. Open **Recommendations → Recompute** to discover an optimisation opportunity.
 3. Inspect its projected savings and evidence requirements.
-4. Add a provider on the **Models** page when you are ready to run a live candidate
-   evaluation and guarded rollout.
+4. Open the seeded **"classification on gpt-4o"** recommendation — it's already past
+   approval, with a guarded canary live in production, no provider key required.
+5. Run `npm run demo:seed` (inside the container: `docker compose exec app npm run demo:seed`)
+   to seed a second canary that's already breaching its guardrails, then roll it back —
+   either by clicking **Roll back**, or by waiting for the auto-rollback monitor to catch it
+   itself. `npm run demo:reset` removes only this seeded data, never real data.
+6. Add a provider on the **Models** page when you are ready to run a live candidate
+   evaluation against your own traffic.
 
 ### Option B — Local (Node + your own MongoDB)
 
@@ -545,8 +551,11 @@ absent today:
   difficulty signal, not a learned model of answer quality.
 - **PII-aware routing.** Prompts and responses are masked in logs
   (`server/src/logging/piiFilter.js`), but PII is not yet used as a routing signal.
-- **Closed-loop evaluation.** Shadow-eval measures a candidate model on live traffic; it
-  does not yet feed routing automatically.
+- **Fully autonomous rollout.** Offline replay, shadow evaluation, and canary rollout are all
+  built and gate every routing change on real evidence — but the result is always surfaced to
+  a human to accept, promote, or roll back. Arbr will never expand or promote a rollout by
+  itself, even when every guardrail stays clean. This is permanent, by design, not a
+  to-be-finished feature — see the [optimisation lifecycle](#the-optimisation-lifecycle).
 - **High availability / horizontal scale.** The service runs as a single standalone
   instance today (like a LiteLLM proxy); Helm/Kubernetes is on the [roadmap](ROADMAP.md).
 


### PR DESCRIPTION
## Summary
Prompted by feeding the feature catalog to an external LLM for a positioning review — its biggest critique ("closed-loop evaluation is not yet available") traced back to one genuinely ambiguous README sentence, not an actual gap. Two small edits:

- **"Not yet" section**: reworded the "Closed-loop evaluation" bullet, which read as "evaluation is incomplete" on a skim when it actually means human approval is permanent by design (offline replay, shadow eval, and canary rollout are all fully built).
- **Quickstart**: the Docker walkthrough stopped at "add a provider key" without ever mentioning the live canary the base seed already includes. Added that step, plus a step pointing at `npm run demo:seed` (F-06) to show a guardrail-breaching canary and its automatic rollback — the one part of the loop the base seed alone doesn't demonstrate.

No application code changed — README only.

Closes #26.

## Test plan
- [x] Proof-read both edited sections in place
- [x] Verified the quickstart's new steps against the actual seed output (`server/src/seed/seed.js:89,218-223` for the live canary; `server/scripts/demo-fixture.js:106-168` for the `demo:seed`/`demo:reset` scenario names and console output)