### PR TITLE
docs(security): update scope for OIDC/RBAC, secret manager, ops routes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,10 +22,14 @@ When reporting, include where possible:
 
 This project is an LLM gateway and control plane. Areas of particular interest:
 
-- The admin API and dashboard authentication (`ARBR_ADMIN_KEY`)
-- Encryption of provider credentials at rest (`ARBR_ENCRYPTION_KEY`)
+- The admin API and dashboard authentication (`ARBR_ADMIN_KEY`, and per-user OIDC /
+  trusted-header identity and role-based access control)
+- Encryption of provider credentials at rest (`ARBR_ENCRYPTION_KEY`), and resolution of
+  credentials held in a cloud secret manager (`gcp-sm://...` references)
 - The OpenAI-compatible and native gateway endpoints
-- Any path that could leak stored provider keys
+- Any path that could leak stored provider keys, including config/policy export and the
+  support-diagnostics bundle — both are designed to exclude credentials and captured
+  request/response content by construction, not by redaction
 
 ## Supported versions
 


### PR DESCRIPTION
## Summary
`SECURITY.md`'s scope section hadn't changed since the original open-source-prep PR (#1) and didn't mention anything shipped since — per-user OIDC/trusted-header identity and RBAC (F-04), cloud secret-manager credential resolution (F-07), or the config-export/support-bundle routes (F-08). Added those as explicit areas of interest.

Also enabled two repo settings this doc's own text depends on but weren't actually turned on:
- **Private vulnerability reporting** — the doc links straight to `.../security/advisories/new`, which this feature powers.
- **Dependabot security updates** (required enabling the base vulnerability-alerts feature first).

## Test plan
- [x] Verified both settings are now enabled via the API (`private-vulnerability-reporting`, `security_and_analysis.dependabot_security_updates`)
- [x] Proof-read the updated scope section