### PR TITLE
docs: fill in F-08 backup/restore and ops routes that were missing

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -125,7 +125,7 @@ need the public hostname.
 - [ ] Gateway API keys issued per application
 - [ ] TLS at the proxy (Option A/B); 4100 not directly internet-reachable
 - [ ] MongoDB not publicly bound (compose default is fine — no host port); backups scheduled
-  (`mongodump` cron or a managed Mongo/Atlas)
+  (`ops/backup.sh` on a cron, or a managed Mongo/Atlas) — see "Backup & restore" below
 - [ ] Provider keys via environment/secret manager (env takes precedence over dashboard-stored)
 - [ ] Budgets configured with **Block/Downgrade** actions for cost protection
 - [ ] Payload capture remains off unless partner consent and retention requirements are documented
@@ -139,7 +139,27 @@ need the public hostname.
   aren't. Scale vertically first; Redis-backed state is the documented future path.
 - **Restarts are cheap**: all durable state is in MongoDB. `docker compose restart app` (or
   redeploy the image) loses only the in-memory caches.
-- **Upgrades**: `git pull && docker compose build app && docker compose up -d app`.
+- **Upgrades**: `git pull && docker compose build app && docker compose up -d app`. For a
+  gated, health-checked, auto-rollback-on-failure upgrade instead of building on the host,
+  see `ops/deploy.sh` and the walkthrough in
+  [Deploy on GCP → Deploying a new version](docs/deployment-gcp.md#deploying-a-new-version-gated-image-based) —
+  it pulls the CI-published image (`ghcr.io/project-arbr/arbr-control-plane`) rather than
+  building locally. It was written for the GCP reference deployment's compose-file layout;
+  on another cloud, adjust the `COMPOSE_FILES` variable at the top of the script to match
+  the compose files you actually run.
+
+## Backup & restore
+
+```sh
+bash ops/backup.sh          # mongodump via the mongo container, to a gzip archive
+bash ops/restore.sh <file>  # DESTRUCTIVE — confirms, restores, restarts, health-checks
+```
+
+Same caveat as above: both scripts hardcode the GCP reference deployment's compose-file
+list (`docker-compose.yml` + `docker-compose.gcp.yml` + `docker-compose.deploy.yml`) — adjust
+`COMPOSE_FILES` at the top of each script if this deployment uses a different set (e.g.
+`docker-compose.prod.yml` as set up above). Full runbook, verification checklist, and
+disaster-recovery scenario: [Operational readiness](docs/operational-readiness.md).
 - **Logs**: stdout (`docker compose logs -f app`); the boot banner prints port, mode
   (demo/live), and whether admin auth is on.
 - **Status endpoint** (`/api/status`): use a gateway key from your monitoring system to watch

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -356,3 +356,39 @@ Set the default model (applies to the default provider; used in auto mode).
 ```json
 { "model": "gpt-4o-mini" }
 ```
+
+### `POST /api/secrets/refresh`
+
+Administrator only. Re-resolves every credential-shaped env var (picks up a rotated
+cloud secret-manager value with no restart) and invalidates the connections cache.
+Never returns a value.
+
+```json
+{ "resolved": 3, "failures": [] }
+```
+
+## Operational readiness
+
+### `GET /health/ready`
+
+Public, no auth. Readiness — distinct from `GET /health` above. See
+[Operational readiness](/operational-readiness).
+
+### `GET /api/ops/export`
+
+Administrator only. Exports `Settings`, `Rule`, and `Cap` documents as one JSON object.
+Never includes provider credentials — that collection isn't queried.
+
+### `POST /api/ops/import`
+
+Administrator only. Restores a previously exported bundle. Creates fresh documents (not
+an ID-preserving merge); Settings fields are applied from a schema-derived allowlist, not
+a raw merge of the request body.
+
+### `POST /api/ops/support-bundle`
+
+Administrator only. Returns a diagnostics bundle — version/config summary, current
+Settings, disk usage, 24h request/error-rate counts, and the last 50 audit-log entries
+(projected to a fixed field list). Never includes credentials or captured request/response
+content — see [Operational readiness](/operational-readiness) for exactly what's excluded
+and why.


### PR DESCRIPTION
## Summary
From the `arbr-github-audit` skill's first real run.

- `DEPLOYMENT.md`'s backup checklist item still said "mongodump cron or Atlas" with no mention of `ops/backup.sh`/`ops/restore.sh` (F-08); the "Upgrades" line only described the deprecated build-on-host path. Added both, plus a caveat that the ops scripts hardcode the GCP reference deployment's compose-file list — noted so a reader on another cloud doesn't run them unmodified and get a confusing error.
- `docs/api-reference.md` was missing 4 real, live routes: `POST /api/secrets/refresh`, `GET /api/ops/export`, `POST /api/ops/import`, `POST /api/ops/support-bundle`.

## Test plan
- [x] `npm run docs:build` clean, no dead links from the new cross-references
- [x] Verified all 4 added routes against their actual route files (`connections.js`, `ops.js`)