### PR TITLE
chore(deps): add Dockerfile to Dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,3 +54,12 @@ updates:
     groups:
       github-actions:
         patterns: ["*"]
+
+  # Dockerfile base image (node:20-alpine) — the only ecosystem on disk with no
+  # update coverage before this: base-image security patches never got a PR.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    labels: ["dependencies", "docker"]


### PR DESCRIPTION
## Summary
From the `arbr-github-audit` skill's first real run. `Dockerfile` pins `node:20-alpine` at two `FROM` lines but had no `package-ecosystem: "docker"` entry in `.github/dependabot.yml` — the only real manifest on disk without update coverage (root/web/clients npm, clients/python pip, and github-actions are all already covered).

## Test plan
- [x] New block mirrors the existing entries' structure/indentation exactly