### PR TITLE
fix(gateway): bound _appConfigCache so a caller-supplied key cannot grow it forever

### DIFF
--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -25,15 +25,25 @@ const { maybeShadowEval } = require("../eval/shadow");
 const logger = require("../logging/logger");
 const Settings = require("../models/Settings");
 const ApplicationConfig = require("../models/ApplicationConfig");
+const { createBoundedTtlCache } = require("../utils/boundedTtlCache");
 
 // Short-lived cache to avoid a DB hit per request for app configs.
-const _appConfigCache = new Map(); // appName → { cfg, expiresAt }
+//
+// Bounded on purpose: the key is the caller-supplied application name, and
+// anonymous calls are allowed until Settings.requireApiKey is turned on, so an
+// untrusted caller can otherwise mint a permanent entry per request. The cap is
+// far above any real deployment's application count, so it only ever bites abuse.
+const _appConfigCache = createBoundedTtlCache({ ttlMs: 30_000, maxEntries: 1000 });
+
 async function getAppConfig(appName) {
   if (!appName || appName === "unknown") return null;
-  const cached = _appConfigCache.get(appName);
-  if (cached && cached.expiresAt > Date.now()) return cached.cfg;
+  const hit = _appConfigCache.getEntry(appName);
+  if (hit) return hit.value;
   const cfg = await ApplicationConfig.findOne({ applicationName: appName }).lean().catch(() => null);
-  _appConfigCache.set(appName, { cfg, expiresAt: Date.now() + 30_000 });
+  // Misses are cached too. Unknown names are the cheap case to spam, and caching
+  // the null is exactly what keeps that traffic off the database; now that the
+  // map is bounded, doing so no longer trades a DB problem for a memory one.
+  _appConfigCache.set(appName, cfg);
   return cfg;
 }
 

--- a/server/src/routing/notifier.js
+++ b/server/src/routing/notifier.js
@@ -2,9 +2,14 @@
 // Events: cap_breach, provider_error (future), new_application (future).
 // Never throws into the caller — network failures are logged and swallowed.
 const Settings = require("../models/Settings");
+const { createBoundedTtlCache } = require("../utils/boundedTtlCache");
 
 // In-memory dedup: prevents duplicate cap_breach pings within a 5-minute window.
-const recentlySent = new Map(); // key → last sent timestamp
+// The TTL is the dedup window, so a live entry means "already sent recently" and
+// entries prune themselves. Bounded because the dedup key falls back to a slice
+// of the payload, which is not guaranteed stable across callers.
+const DEDUP_WINDOW_MS = 5 * 60 * 1000;
+const recentlySent = createBoundedTtlCache({ ttlMs: DEDUP_WINDOW_MS, maxEntries: 1000 });
 
 async function notify(event, payload) {
   try {
@@ -12,10 +17,9 @@ async function notify(event, payload) {
     const url = settings.webhookUrl;
     if (!url) return;
 
-    // Dedup: same event+key → suppress for 5 minutes.
+    // Dedup: same event+key → suppress for the window.
     const dedupKey = `${event}:${payload.key || JSON.stringify(payload).slice(0, 80)}`;
-    const lastSent = recentlySent.get(dedupKey) || 0;
-    if (Date.now() - lastSent < 5 * 60 * 1000) return;
+    if (recentlySent.has(dedupKey)) return;
     recentlySent.set(dedupKey, Date.now());
 
     await fetch(url, {

--- a/server/src/utils/boundedTtlCache.js
+++ b/server/src/utils/boundedTtlCache.js
@@ -1,0 +1,62 @@
+// A Map with a TTL and a hard entry cap, for caches keyed on caller-supplied
+// strings.
+//
+// A plain Map guarded by an `expiresAt` check leaks: entries go logically stale
+// but stay resident for the process lifetime, so a caller that varies the key on
+// every request grows it without bound. Here expired entries are dropped on read
+// and an insert at capacity evicts the oldest, so size is bounded by maxEntries
+// no matter how many distinct keys are seen.
+//
+// Eviction is insertion-ordered FIFO (Map preserves insertion order). Refreshing
+// an existing key keeps its original position, so eviction order is approximate
+// rather than true LRU. That is the same trade-off routing/responseCache.js
+// makes, and it is fine when the point is bounding memory rather than maximising
+// hit rate.
+
+function createBoundedTtlCache({ ttlMs, maxEntries }) {
+  if (!(ttlMs > 0)) throw new Error("boundedTtlCache: ttlMs must be > 0");
+  if (!(maxEntries > 0)) throw new Error("boundedTtlCache: maxEntries must be > 0");
+
+  const store = new Map(); // key -> { value, expiresAt }
+
+  // Returns the live entry, or undefined on a miss or expiry. Callers read
+  // `.value`. Handing back the entry rather than the value is what lets a cached
+  // `null` (a negative cache) be told apart from a miss.
+  function getEntry(key) {
+    const entry = store.get(key);
+    if (!entry) return undefined;
+    if (entry.expiresAt <= Date.now()) {
+      store.delete(key);
+      return undefined;
+    }
+    return entry;
+  }
+
+  function get(key) {
+    const entry = getEntry(key);
+    return entry ? entry.value : undefined;
+  }
+
+  function has(key) {
+    return getEntry(key) !== undefined;
+  }
+
+  function set(key, value) {
+    // Refreshing a key already held must not evict anything, so only an insert
+    // that actually grows the map counts against the cap.
+    if (store.size >= maxEntries && !store.has(key)) {
+      const oldest = store.keys().next().value;
+      if (oldest !== undefined) store.delete(oldest);
+    }
+    store.set(key, { value, expiresAt: Date.now() + ttlMs });
+    return value;
+  }
+
+  function clear() {
+    store.clear();
+  }
+
+  return { getEntry, get, has, set, clear, get size() { return store.size; } };
+}
+
+module.exports = { createBoundedTtlCache };

--- a/server/test/unit/boundedTtlCache.test.js
+++ b/server/test/unit/boundedTtlCache.test.js
@@ -1,0 +1,82 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { createBoundedTtlCache } = require("../../src/utils/boundedTtlCache");
+
+test("hits before the TTL, misses after it", async () => {
+  const c = createBoundedTtlCache({ ttlMs: 20, maxEntries: 10 });
+  c.set("a", 1);
+  assert.equal(c.get("a"), 1);
+  await new Promise((r) => setTimeout(r, 35));
+  assert.equal(c.get("a"), undefined);
+});
+
+test("an expired entry is evicted on read, not merely ignored", async () => {
+  const c = createBoundedTtlCache({ ttlMs: 20, maxEntries: 10 });
+  c.set("a", 1);
+  assert.equal(c.size, 1);
+  await new Promise((r) => setTimeout(r, 35));
+  c.get("a");
+  assert.equal(c.size, 0, "reading an expired key must free it");
+});
+
+// The issue: a caller varying the key on every request grew the map forever.
+test("size stays capped no matter how many distinct keys arrive", () => {
+  const c = createBoundedTtlCache({ ttlMs: 60_000, maxEntries: 50 });
+  for (let i = 0; i < 5000; i++) c.set(`app-${i}`, { i });
+  assert.equal(c.size, 50);
+});
+
+test("eviction at capacity drops the oldest and keeps the newest", () => {
+  const c = createBoundedTtlCache({ ttlMs: 60_000, maxEntries: 3 });
+  c.set("a", 1);
+  c.set("b", 2);
+  c.set("c", 3);
+  c.set("d", 4); // evicts "a"
+  assert.equal(c.get("a"), undefined);
+  assert.equal(c.get("d"), 4);
+  assert.equal(c.size, 3);
+});
+
+test("refreshing an existing key does not evict another", () => {
+  const c = createBoundedTtlCache({ ttlMs: 60_000, maxEntries: 2 });
+  c.set("a", 1);
+  c.set("b", 2);
+  c.set("a", 9); // a refresh, not growth
+  assert.equal(c.size, 2);
+  assert.equal(c.get("a"), 9);
+  assert.equal(c.get("b"), 2, "the other key must survive a refresh");
+});
+
+// getAppConfig caches `null` for unknown apps; that negative cache is what keeps
+// spammed unknown names off the database, so a miss and a cached null must differ.
+test("a cached null reads as a hit, not a miss", () => {
+  const c = createBoundedTtlCache({ ttlMs: 60_000, maxEntries: 10 });
+  c.set("unknown-app", null);
+  const hit = c.getEntry("unknown-app");
+  assert.notEqual(hit, undefined, "a cached null must still return an entry");
+  assert.equal(hit.value, null);
+  assert.equal(c.has("unknown-app"), true);
+  assert.equal(c.getEntry("never-seen"), undefined);
+  assert.equal(c.has("never-seen"), false);
+});
+
+test("has() honours the TTL", async () => {
+  const c = createBoundedTtlCache({ ttlMs: 20, maxEntries: 10 });
+  c.set("k", "v");
+  assert.equal(c.has("k"), true);
+  await new Promise((r) => setTimeout(r, 35));
+  assert.equal(c.has("k"), false);
+});
+
+test("clear() empties the cache", () => {
+  const c = createBoundedTtlCache({ ttlMs: 60_000, maxEntries: 10 });
+  c.set("a", 1);
+  c.clear();
+  assert.equal(c.size, 0);
+});
+
+test("rejects a nonsensical configuration", () => {
+  assert.throws(() => createBoundedTtlCache({ ttlMs: 0, maxEntries: 10 }));
+  assert.throws(() => createBoundedTtlCache({ ttlMs: 10, maxEntries: 0 }));
+});


### PR DESCRIPTION
Fixes #158.

## The bug

`_appConfigCache` was a `Map` keyed on the **caller-supplied** application name, with a TTL check but no eviction and no size cap. Entries expired *logically* and were never removed, so every distinct name left a permanent entry:

```js
const cached = _appConfigCache.get(appName);
if (cached && cached.expiresAt > Date.now()) return cached.cfg;   // stale entry stays resident
```

Anonymous calls are allowed until `Settings.requireApiKey` is turned on, so on a default instance an unauthenticated caller could send a new `application` per request and grow the map without bound, on the hot path of the one endpoint designed to take untrusted traffic.

## The fix

Adds `utils/boundedTtlCache`: expired entries are dropped **on read**, and an insert at capacity evicts the oldest, so size is bounded by `maxEntries` regardless of key cardinality.

This is the pattern `routing/responseCache.js` already uses. I extracted it rather than copying it a third time, since the same shape now appears in three places.

### Two judgement calls worth review

**Misses are still cached.** The issue floated skipping `.set()` when `cfg` is `null`. I kept negative caching: unknown names are the cheap case to spam, and caching the null is exactly what keeps that traffic off Mongo. Dropping it would trade a memory problem for a database one. Now that the map is bounded, keeping it costs nothing.

That required `getEntry()` to return the *entry* rather than the value, so a cached `null` still reads as a hit rather than a miss. There's a test pinning that.

**`maxEntries: 1000`** is far above any real deployment's application count, so it only ever bites abuse.

## Also fixed

`routing/notifier.js`, called out in the issue as the same shape. Its 5-minute dedup `Map` was never pruned. Its dedup key falls back to `JSON.stringify(payload).slice(0, 80)`, so stable keys aren't actually guaranteed. The TTL is now the dedup window itself, which makes entries self-pruning and the timestamp arithmetic unnecessary.

## Verification

- 9 new unit tests, including the regression: 5,000 distinct keys leave the map at its 50-entry cap
- Covers expiry-frees-memory, oldest-evicted-first, refresh-doesn't-evict, and cached-null-is-a-hit
- Full unit suite: 310/311. The one failure (`assertProductionReady`) is pre-existing and env-dependent, and reproduces on clean `main`
- `npm run lint`: 0 errors, no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)