### PR TITLE
docs: add missing providers/vars to README config table and .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -160,5 +160,9 @@ MONGO_URI=mongodb://localhost:27017/arbr-control-plane
 # Settings → Connections, which takes precedence.
 # DEFAULT_PROVIDER=
 
+# Default max_tokens when the caller omits it, capped by the model's own
+# output ceiling. See README's config table.
+# ARBR_DEFAULT_MAX_TOKENS=4096
+
 # --- Web dashboard (dev server) ---
 WEB_PORT=5173

--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ All via `.env` (see `.env.example`). Nothing is required to start.
 | `MONGO_URI` | `mongodb://localhost:27017/arbr-control-plane` | Database |
 | `ARBR_ADMIN_KEY` | — (open, dev only) | **Auth for the dashboard/admin API.** Required in production |
 | `ARBR_ENCRYPTION_KEY` | dev fallback | Encrypts dashboard-stored provider keys. Required in production |
-| `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` / `AWS_*` | — | Optional; enable live calls |
+| `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` / `AWS_*` / `DEEPSEEK_API_KEY` / `MOONSHOT_API_KEY` / `XAI_API_KEY` / `GROQ_API_KEY` | — | Optional; enable live calls |
 | `DEFAULT_PROVIDER` | first live | Initial default-provider preference (runtime-selectable in Settings) |
 | `ARBR_DEFAULT_MAX_TOKENS` | `4096` | Default `max_tokens` when the caller omits it. Capped by the model's own output ceiling. |
 | `SEED_ON_BOOT` | `false`¹ | Docker only: load demo data on start (**wipes request records**) |


### PR DESCRIPTION
## What

Two mechanical doc-accuracy fixes surfaced by the weekly audit routine's first run (which
itself couldn't push — GitHub App write access still needs fixing separately):

- README's env-var config table listed only \`OPENAI_API_KEY\` / \`ANTHROPIC_API_KEY\` /
  \`GEMINI_API_KEY\` / \`AWS_*\`. \`server/src/config.js\`'s \`PROVIDERS\` registry and
  \`.env.example\` both already ship DeepSeek, Moonshot, xAI, and Groq — added them.
- \`.env.example\` was missing \`ARBR_DEFAULT_MAX_TOKENS\`, which README already documents
  (default \`4096\`) but which wasn't actually present in the file it's supposed to live in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)