### PR TITLE
docs(architecture): fix stale handler.js line citation for budget enforcement

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -62,7 +62,7 @@ verified against the code, not approximated:
 4. **Enforce budget** — `routing/capEngine.js` runs *after* routing, against the model
    routing just decided on. A breached enforcing cap outranks everything decided in step
    3, **including an explicit pin** — that's the point of enforcement (per the code's own
-   comment at `gateway/handler.js:372-374`): block returns 429; downgrade forces the
+   comment at `gateway/handler.js:382-384`): block returns 429; downgrade forces the
    provider's light-tier model regardless of how the served model was originally chosen.
 5. **Output-side clamp, then cache** — `pricing.clampMaxTokens` caps output to the *served*
    model's known ceiling, then the exact-match response cache


### PR DESCRIPTION
## What does this PR do?

The request-flow section of `ARCHITECTURE.md` (step 4, budget enforcement) cites `gateway/handler.js:372-374` as the source comment for the "a breached enforcing cap outranks everything, including an explicit pin" rule. Those lines are actually the unrelated `model_not_allowed` 403 handler. The enforcement comment it refers to lives at `server/src/gateway/handler.js:382-384`. This corrects the line citation only; the described behavior is accurate and unchanged.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] CI / build

## Checklist

- [ ] I've tested this locally with `npm run dev`
- [x] No API keys, `.env` values, or secrets are committed
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format (`feat:`, `fix:`, etc.)
- [x] I've updated docs if the change affects user-facing behaviour

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pFGE7L8oEj3hwSmg5yjTK

---
_Generated by [Claude Code](https://claude.ai/code/session_019pFGE7L8oEj3hwSmg5yjTK)_