### PR TITLE
chore(dependabot): correct stale base-image version in comment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,7 +55,7 @@ updates:
       github-actions:
         patterns: ["*"]
 
-  # Dockerfile base image (node:20-alpine) — the only ecosystem on disk with no
+  # Dockerfile base image (node:26-alpine) — the only ecosystem on disk with no
   # update coverage before this: base-image security patches never got a PR.
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
## What does this PR do?

The `docker` ecosystem entry in `.github/dependabot.yml` carries an explanatory comment that still names the base image as `node:20-alpine`. The Dockerfile was bumped to `node:26-alpine` in #203, so the comment is now stale. This updates the comment to match; no Dependabot configuration behavior changes.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] CI / build

## Checklist

- [ ] I've tested this locally with `npm run dev`
- [x] No API keys, `.env` values, or secrets are committed
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format (`feat:`, `fix:`, etc.)
- [x] I've updated docs if the change affects user-facing behaviour

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pFGE7L8oEj3hwSmg5yjTK

---
_Generated by [Claude Code](https://claude.ai/code/session_019pFGE7L8oEj3hwSmg5yjTK)_