### PR TITLE
docs(vitepress): exclude internal competitive-analysis doc from the built site

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -6,6 +6,11 @@ export default defineConfig({
 
   ignoreDeadLinks: [/localhost/],
 
+  // Internal-only — not linked from the sidebar, and excluded here so it's
+  // genuinely file-only: not built, not in the local search index, not
+  // reachable by a direct /competitive-analysis-portkey URL.
+  srcExclude: ['competitive-analysis-portkey.md'],
+
   themeConfig: {
     siteTitle: 'ARBR',
 


### PR DESCRIPTION
## What

Closes a gap the weekly audit routine found: \`docs/competitive-analysis-portkey.md\` was
decided to stay a file-only, internal artifact — deliberately left out of the sidebar nav.
But VitePress still builds and search-indexes every \`.md\` under \`docs/\` regardless of
nav linkage, so it was live at \`/competitive-analysis-portkey\` and turned up in local
search — reachable by anyone who guessed the URL or searched for "competitive" or "portkey".

\`srcExclude\` actually removes it from the build output, which is what "file-only" was
supposed to mean.

## Verification

- \`rm -rf docs/.vitepress/dist docs/.vitepress/cache && npm run docs:build\` — clean.
- Confirmed \`docs/.vitepress/dist/competitive-analysis-portkey.html\` no longer exists.
- Confirmed the page's hash no longer appears in the site's search index data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)