### PR TITLE
docs(readme): tighten positioning, add nav and llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,14 @@
   <a href="assets/brand/BRAND.md"><img alt="Brand guidelines" src="https://img.shields.io/badge/brand-guidelines-2f37ff"></a>
 </p>
 
-> Find safer, cheaper model routes. Prove them against your workload. Roll them out with
-> human approval, then measure the savings actually realised.
+<p align="center">
+  <a href="#quickstart">Quickstart</a> ·
+  <a href="#where-arbr-fits">Why Arbr</a> ·
+  <a href="docs/quickstart.md">Docs</a> ·
+  <a href="ROADMAP.md">Roadmap</a>
+</p>
+
+<p align="center"><strong>Prove it. Approve it. Verify it held.</strong></p>
 
 Arbr is a self-hosted **model optimisation and governance control plane** for teams with
 AI traffic in production. It turns request-level cost and performance data into concrete

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,30 @@
+# Arbr Control Plane
+
+> Self-hosted model-optimisation and governance control plane for LLM traffic already in
+> production. One OpenAI-compatible gateway logs every call, discovers cheaper-model
+> opportunities from real traffic, evaluates candidates against evidence, and applies them
+> only after human approval — with realised savings measured after rollout, and rollback
+> always available.
+
+## Docs
+
+- [Quickstart](docs/quickstart.md): install, demo mode, first optimisation walkthrough
+- [Gateway overview](docs/gateway/overview.md): native and OpenAI-compatible endpoints
+- [Routing](docs/routing.md): rules, AI policy, guardrails, canaries
+- [Budgets](docs/budgets.md): spend caps, alerts, downgrades
+- [Models](docs/models.md): model registry, LiteLLM catalog sync, pricing
+- [API reference](docs/api-reference.md): full endpoint reference
+- [Configuration](docs/configuration.md): environment variables
+- [Deployment](docs/deployment.md): production deployment guide
+- [Authentication](docs/auth.md): admin key, OIDC/RBAC, gateway API keys
+
+## SDKs
+
+- [JavaScript client](docs/sdk/js.md): `arbr-client` for Node >= 18
+- [Python client](docs/sdk/python.md): `arbr-client` for Python >= 3.11
+
+## Optional
+
+- [Architecture](ARCHITECTURE.md): internals and design rationale
+- [Roadmap](ROADMAP.md): what's planned, and what's intentionally deferred
+- [Competitive analysis: Portkey](docs/competitive-analysis-portkey.md): feature-by-feature gap analysis


### PR DESCRIPTION
## Summary
Benchmarked Arbr's README against two well-positioned OSS repos (heygen-com/hyperframes, 37k stars; headroomlabs-ai/headroom, 61k stars) on content/messaging, not features. Applied the changes that were low-risk and didn't require fabricating assets or numbers:

- Replaced the two-sentence blockquote tagline with a short, bold 3-beat line (`Prove it. Approve it. Verify it held.`) directly under the title — the fuller explanatory paragraph right below is unchanged.
- Added a nav bar (`Quickstart · Why Arbr · Docs · Roadmap`) under the badges, so there's a one-glance "try it now" path instead of everything living in prose.
- Added `llms.txt` at the repo root — a compact doc index in the emerging llms.txt convention, so coding agents reading this repo (a relevant audience given what Arbr is) get a map instead of parsing the full README.

Not done (would need real assets/data, didn't want to fabricate):
- A demo GIF to replace the static dashboard PNG.
- A "realised savings" proof number pulled from real usage.

## Test plan
- [ ] Preview README.md rendering on GitHub — confirm nav anchors (`#quickstart`, `#where-arbr-fits`) resolve correctly and `docs/quickstart.md` link renders.
- [ ] Confirm `llms.txt` renders as plain text and all linked doc paths exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)