### PR TITLE
feat(routing): make multi-replica deployment real, document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,12 +556,16 @@ absent today:
   a human to accept, promote, or roll back. Arbr will never expand or promote a rollout by
   itself, even when every guardrail stays clean. This is permanent, by design, not a
   to-be-finished feature — see the [optimisation lifecycle](#the-optimisation-lifecycle).
-- **High availability / horizontal scale.** The service runs as a single standalone
-  instance today (like a LiteLLM proxy); Helm/Kubernetes is on the [roadmap](ROADMAP.md).
 
 Budgets, gateway API keys, and governance controls that earlier versions listed here as
 "deferred" have since shipped; see the **Controlled routing**, **Governance**, and
 **Authentication** sections above.
+
+Horizontal scale — running more than one instance behind a load balancer — has also since
+shipped; see [Running more than one replica](docs/deployment-gcp.md#running-more-than-one-replica).
+Budget/rate-limit enforcement is Mongo-backed and correct across replicas; the response caches
+and OpenTelemetry span queue are per-process, which the linked section explains. A Helm chart is
+still on the [roadmap](ROADMAP.md) — today's path is the docker-compose overlay linked above.
 
 ---
 

--- a/docker-compose.replicas.yml
+++ b/docker-compose.replicas.yml
@@ -1,0 +1,18 @@
+# Optional overlay enabling more than one `app` container behind nginx's
+# upstream — see docs/deployment-gcp.md's "Running more than one replica"
+# section for the full walkthrough (nginx config, when this is and isn't
+# safe, and a deploy-script gotcha to know about).
+#
+# Layer this on top of the base file(s) and scale explicitly:
+#   docker compose -f docker-compose.yml -f docker-compose.gcp.yml -f docker-compose.replicas.yml up -d --scale app=3
+#
+# Each replica claims the next host port in the range below (4100, 4101,
+# 4102); nginx's upstream block targets those ports directly. Add more
+# ports to the range if you need more than 3 replicas.
+services:
+  app:
+    # !override replaces the base file's port list instead of appending to
+    # it (Compose's default list-merge behavior would otherwise leave both
+    # the single fixed mapping and this range active at once).
+    ports: !override
+      - "4100-4102:4100"

--- a/docs/deployment-gcp.md
+++ b/docs/deployment-gcp.md
@@ -150,6 +150,66 @@ Certbot edits the nginx config and sets up auto-renewal. Your dashboard is now a
 
 In GCP Console → **VPC Network → Firewall rules** — confirm there is **no rule** allowing ingress on port `4100` from `0.0.0.0/0`. Only ports `80` and `443` should be publicly reachable.
 
+## Running more than one replica
+
+Optional — Steps 1-9 already give you a working single-instance deployment. This section is
+for teams that want more than one `app` container behind nginx, for capacity or redundancy.
+
+**What's actually safe across replicas today**: budget enforcement (`CapSpend`) and RPM limits
+(`RateBucket`) are Mongo-backed with atomic updates — correct with any number of replicas, no
+double-spend or double-counting. Two things are *not* shared across replicas, by design, and
+are worth knowing rather than being surprised by: the exact-match/semantic response caches are
+per-process, so your aggregate cache-hit rate goes down as replicas go up (not a correctness
+issue — a miss just means a real provider call instead of a hit); and the OpenTelemetry span
+batch queue is per-process, so an ungraceful kill of one replica can lose that replica's queued
+spans (observability data only, never request data).
+
+1. **Overlay the replica ports file** and scale explicitly:
+   ```sh
+   docker compose -f docker-compose.yml -f docker-compose.gcp.yml -f docker-compose.replicas.yml up -d --scale app=3
+   ```
+   This runs 3 `app` containers on host ports 4100-4102 (see `docker-compose.replicas.yml` —
+   add more ports to its range for more replicas).
+
+2. **Point nginx at all of them** — replace the single `proxy_pass http://127.0.0.1:4100;`
+   lines from Step 7 with an `upstream` block:
+   ```nginx
+   upstream arbr_app {
+       server 127.0.0.1:4100;
+       server 127.0.0.1:4101;
+       server 127.0.0.1:4102;
+   }
+
+   server {
+       listen 80;
+       server_name arbr.yourco.com;
+
+       location / {
+           proxy_pass http://arbr_app;
+           proxy_set_header Host              $host;
+           proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+           proxy_set_header X-Forwarded-Proto $scheme;
+           proxy_read_timeout 300s;
+       }
+
+       location /v1/chat/completions {
+           proxy_pass http://arbr_app;
+           proxy_http_version 1.1;
+           proxy_set_header Connection '';
+           proxy_buffering off;
+           proxy_cache off;
+           proxy_read_timeout 300s;
+           chunked_transfer_encoding on;
+       }
+   }
+   ```
+   Then `sudo nginx -t && sudo systemctl reload nginx`.
+
+3. **Know the `ops/deploy.sh` gotcha**: its `up -d` call doesn't pass `--scale`, so a routine
+   deploy silently scales you back down to 1 replica. If you're running N replicas, edit the
+   `up -d --no-build app` line in `ops/deploy.sh` to add `--scale app=N` — otherwise every
+   deploy undoes your scaling.
+
 ## Step 10 — First login and setup
 
 1. Open **https://arbr.yourco.com** — the login screen appears

--- a/server/src/models/NotificationDedup.js
+++ b/server/src/models/NotificationDedup.js
@@ -1,0 +1,20 @@
+// Cross-replica dedup for outbound webhook notifications. A successful insert
+// means "this call is the sender"; a duplicate-key error means another
+// replica (or an earlier request on this one) already claimed the key within
+// the window. Self-expires via the TTL index, so no manual pruning is needed.
+const mongoose = require("mongoose");
+
+const DEDUP_WINDOW_SECONDS = 5 * 60;
+
+const notificationDedupSchema = new mongoose.Schema(
+  {
+    dedupKey: { type: String, required: true },
+    createdAt: { type: Date, default: Date.now },
+  },
+  { collection: "notification_dedups" }
+);
+
+notificationDedupSchema.index({ dedupKey: 1 }, { unique: true });
+notificationDedupSchema.index({ createdAt: 1 }, { expireAfterSeconds: DEDUP_WINDOW_SECONDS });
+
+module.exports = mongoose.model("NotificationDedup", notificationDedupSchema);

--- a/server/src/routing/notifier.js
+++ b/server/src/routing/notifier.js
@@ -2,14 +2,20 @@
 // Events: cap_breach, provider_error (future), new_application (future).
 // Never throws into the caller — network failures are logged and swallowed.
 const Settings = require("../models/Settings");
-const { createBoundedTtlCache } = require("../utils/boundedTtlCache");
+const NotificationDedup = require("../models/NotificationDedup");
 
-// In-memory dedup: prevents duplicate cap_breach pings within a 5-minute window.
-// The TTL is the dedup window, so a live entry means "already sent recently" and
-// entries prune themselves. Bounded because the dedup key falls back to a slice
-// of the payload, which is not guaranteed stable across callers.
-const DEDUP_WINDOW_MS = 5 * 60 * 1000;
-const recentlySent = createBoundedTtlCache({ ttlMs: DEDUP_WINDOW_MS, maxEntries: 1000 });
+// Cross-replica dedup: same event+key suppressed for the window (see
+// NotificationDedup's TTL index). Bounded because the dedup key falls back to
+// a slice of the payload, which is not guaranteed stable across callers.
+async function claimedByThisCall(dedupKey) {
+  try {
+    await NotificationDedup.create({ dedupKey });
+    return true;
+  } catch (err) {
+    if (err.code === 11000) return false; // another replica already sent this
+    throw err;
+  }
+}
 
 async function notify(event, payload) {
   try {
@@ -17,10 +23,8 @@ async function notify(event, payload) {
     const url = settings.webhookUrl;
     if (!url) return;
 
-    // Dedup: same event+key → suppress for the window.
     const dedupKey = `${event}:${payload.key || JSON.stringify(payload).slice(0, 80)}`;
-    if (recentlySent.has(dedupKey)) return;
-    recentlySent.set(dedupKey, Date.now());
+    if (!(await claimedByThisCall(dedupKey))) return;
 
     await fetch(url, {
       method: "POST",

--- a/server/test/integration/notifierDedup.test.js
+++ b/server/test/integration/notifierDedup.test.js
@@ -1,0 +1,70 @@
+"use strict";
+// Cross-replica dedup coverage for the webhook notifier. Before this fix,
+// `recentlySent` was an in-memory Map — two replicas (or two concurrent calls
+// racing on the same process) could each decide independently that a
+// cap_breach webhook hadn't fired recently and both send it. The fix moves
+// the claim to an atomic Mongo insert (NotificationDedup, unique on
+// dedupKey), so exactly one caller wins regardless of how many "replicas"
+// (simulated here as concurrent calls) race for the same event+key.
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+const mongoose = require("mongoose");
+
+const Settings = require("../../src/models/Settings");
+const NotificationDedup = require("../../src/models/NotificationDedup");
+const { notify } = require("../../src/routing/notifier");
+
+let mongod;
+let originalFetch;
+let sendCount;
+
+before(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+after(async () => {
+  global.fetch = originalFetch;
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+beforeEach(async () => {
+  await Settings.deleteMany({});
+  await NotificationDedup.deleteMany({});
+  await Settings.create({ webhookUrl: "https://example.test/webhook" });
+  sendCount = 0;
+  originalFetch = global.fetch;
+  global.fetch = async () => {
+    sendCount += 1;
+    return { ok: true };
+  };
+});
+
+test("concurrent notify() calls for the same event+key send exactly once", async () => {
+  const payload = { key: "cap-123:month:2026-07" };
+  await Promise.all([
+    notify("cap_breach", payload),
+    notify("cap_breach", payload),
+    notify("cap_breach", payload),
+    notify("cap_breach", payload),
+    notify("cap_breach", payload),
+  ]);
+  assert.equal(sendCount, 1);
+});
+
+test("different keys are not deduped against each other", async () => {
+  await Promise.all([
+    notify("cap_breach", { key: "cap-A:month:2026-07" }),
+    notify("cap_breach", { key: "cap-B:month:2026-07" }),
+  ]);
+  assert.equal(sendCount, 2);
+});
+
+test("a later call within the window is still suppressed (sequential, not just racing)", async () => {
+  const payload = { key: "cap-999:month:2026-07" };
+  await notify("cap_breach", payload);
+  await notify("cap_breach", payload);
+  assert.equal(sendCount, 1);
+});


### PR DESCRIPTION
## What

Closes the "no HA/horizontal scale" adoption hurdle — turned out much smaller than the README's
blanket "Not yet" claim implied once checked against actual code, not doc prose.

**Verified before touching anything**: budget enforcement (`CapSpend`, atomic Mongo `$inc`) and
RPM limits (`RateBucket`, Mongo fixed-window counters) are already correct across any number of
replicas. The one real bug: `notifier.js`'s cap-breach webhook dedup was an in-memory Map — two
replicas could each independently decide a webhook hadn't fired recently and both send it.

## Changes

- **`server/src/routing/notifier.js`** — dedup now goes through an atomic Mongo insert
  (`NotificationDedup`, unique index on `dedupKey`, TTL-expired after 5 min) instead of an
  in-memory cache. A duplicate-key error means another replica already claimed it.
- **`server/test/integration/notifierDedup.test.js`** — proves it: 5 concurrent `notify()` calls
  for the same event+key send exactly once; different keys aren't cross-deduped; a later
  sequential call within the window is still suppressed.
- **`docker-compose.replicas.yml`** — new overlay giving N `app` containers distinct host ports
  (`4100-4102`) via Compose's port-range syntax, using `!override` so it replaces rather than
  appends to the base file's port list (Compose's default list-merge is concatenation, not
  replacement — verified via `docker compose config` before relying on it).
- **`docs/deployment-gcp.md`** — new "Running more than one replica" section: what's actually
  safe today, the compose/nginx `upstream` walkthrough, and a real `ops/deploy.sh` gotcha (its
  `up -d` doesn't pass `--scale`, so a routine deploy silently scales back to 1 replica unless
  you edit that line).
- **`README.md`** — the "Not yet" section's blanket HA claim is no longer true; replaced with
  the honest, specific version (horizontally scalable; two named non-correctness tradeoffs —
  per-replica response-cache hit rate, per-replica OTel queue on ungraceful kill).

## Verification

- `MONGOMS_VERSION=7.0.14 npm run test:server` — 452/452 pass.
- `docker compose -f docker-compose.yml -f docker-compose.replicas.yml config` — confirmed
  exactly one `ports` mapping (the range), not both base + override stacked.
- `npm run docs:build` — clean; new anchor resolves.
- **Not done**: a full running smoke test with real nginx + multiple live containers. The
  compose-merge correctness and the dedup's atomicity are both verified directly; an end-to-end
  smoke test on an actual VM is a reasonable manual check before relying on this in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)