### PR TITLE
feat(cli): recover arbr wrap — stranded by a stacked-PR-squash merge

### DIFF
--- a/clients/cli/CHANGELOG.md
+++ b/clients/cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.2.0
+
+- Added `arbr wrap <claude|codex|opencode|cursor>` — starts a local, loopback-only
+  proxy, launches the agent with its traffic redirected through it, and reports
+  spend/model-mix on exit (terminal summary + `arbr-wrap-report.html`). v1 does not
+  run task classification on live traffic, so it has no premium-overuse
+  recommendations — `audit` remains the way to get those. `codex`/`opencode` support
+  is best-effort and not yet verified against real installs (see README).
+- `report.js` gained a `mode: "audit" | "wrap"` option and a shared per-model spend
+  breakdown table, reused by both subcommands.
+
 ## 0.1.0
 
 - Initial release: `arbr audit <file.jsonl>` — standalone, zero-infra premium-model

--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -1,7 +1,7 @@
 # arbr-cli
 
-Audit a log of past LLM requests for premium-model overuse — no server, no database,
-no signup. Point it at a file, get a number back.
+Audit a log of past LLM requests for premium-model overuse, or wrap a coding agent
+live to see what a session costs — no server, no database, no signup.
 
 ```sh
 npx arbr-cli audit --demo
@@ -63,6 +63,36 @@ arbr audit --demo [--out <report.html>]
 Every run prints a terminal summary immediately, then writes the fuller HTML report —
 the same pass over the data produces both.
 
+## `arbr wrap` — live session spend, no log file needed
+
+```sh
+arbr wrap claude    # or: codex, opencode, cursor
+```
+
+Starts a local proxy on `127.0.0.1` (never reachable from the network), launches the
+agent with its API traffic redirected through it, and reports spend + model mix when
+the session ends — the terminal summary plus an `arbr-wrap-report.html`, same as
+`audit`. **v1 reports spend and model mix only** — it does not run task
+classification on live traffic, so it can't produce `audit`'s "switch model X → Y"
+recommendations (that needs a task label per request, which live agent traffic
+doesn't have). `arbr audit` remains the way to get those.
+
+Per-agent support, and what to know before relying on each:
+
+| Agent | Mechanism | Status |
+|---|---|---|
+| `claude` | `ANTHROPIC_BASE_URL` env var (Anthropic's documented gateway pattern) | Transparent — no file touched |
+| `codex` | Temporary `~/.codex/config.toml` patch (backed up and restored on exit, including on Ctrl-C) | **Unverified against a real install** — a past Codex GitHub issue reported config.toml overrides not always being respected; test it yourself before relying on it. Use `--codex-home <path>` to point at an isolated config dir instead of your real one. |
+| `opencode` | `OPENCODE_CONFIG_CONTENT` env var, injecting a new `arbr` provider | Not transparent — you must select a model under `arbr/<model-id>` in the session for it to be observed. **Unverified against a real install**; two open OpenCode issues report custom `baseURL`/`headers` not always reaching the real request. |
+| `cursor` | None — Cursor CLI's endpoint override is reported broken upstream | Prints manual IDE setup steps (Settings → Models → Override OpenAI Base URL) instead of automating anything |
+
+The `codex` config patch is written defensively (original content kept in memory,
+a timestamped backup file written alongside it, restored in a `finally` block and on
+`SIGINT`/`SIGTERM`) but has not been exercised against a real Codex installation as
+part of this change — only the file-patching logic itself is unit-tested, against
+temp files, never a real `~/.codex`. Treat `codex`/`opencode` wrap support as
+best-effort until you've verified it against your installed CLI version.
+
 ## Why this exists
 
 Arbr itself is a self-hosted, team-oriented control plane (MongoDB + Docker + a
@@ -84,6 +114,12 @@ The two files under `src/vendor/` are manually-synced copies of
 If either upstream file changes in a way that affects pricing or the recommendation
 algorithm, update the vendored copy here too — there's no build step that does this
 automatically, the same tradeoff already made for `server/src/providers/llm-router/`.
+
+`wrap`'s proxy core (`src/wrap.js`) is *not* vendored from `server/src/gateway/
+openaiCompat.js` — it follows the same fetch → stream-bytes-back → parse-usage
+technique but is freshly written, since Arbr's own native (Anthropic/Gemini/Bedrock)
+provider path round-trips through LangChain and doesn't stream token-by-token, so
+there was nothing directly reusable for that path.
 
 ## License
 

--- a/clients/cli/bin/arbr.js
+++ b/clients/cli/bin/arbr.js
@@ -5,25 +5,38 @@ const path = require("path");
 const fs = require("fs");
 const { runAudit } = require("../src/audit");
 const { renderReport } = require("../src/report");
+const { runWrapSession } = require("../src/wrap");
 
-const HELP = `arbr — audit a log of past LLM requests for premium-model overuse.
+const HELP = `arbr — audit a log of past LLM requests, or wrap a coding agent live.
 
 Usage:
   arbr audit <file.jsonl> [--out <report.html>] [--cheap-task-types a,b,c]
   arbr audit --demo [--out <report.html>]
+  arbr wrap <claude|codex|opencode|cursor> [--out <report.html>] [--codex-home <path>]
 
-Options:
+Audit options:
   --out <path>              where to write the HTML report (default: ./arbr-audit-report.html)
   --cheap-task-types <csv>  comma-separated task types to treat as "should be cheap"
                              (default: classification, extraction, summarisation,
                              translation, faq, support response)
   --demo                    run against the bundled sample log instead of a file
+
+Wrap options:
+  --out <path>       where to write the HTML report (default: ./arbr-wrap-report.html)
+  --codex-home <path> override ~/.codex for the wrapped session (codex only)
+
   -h, --help                show this help
 
-Input format: one JSON object per line (JSONL), reusing Arbr's own request-log field
-names — taskType, model, provider, promptTokens, completionTokens, totalCost. If you
-already run Arbr, export your RequestRecord collection into this shape for a real audit.
-See README.md for the full field list and an export example.
+Audit input format: one JSON object per line (JSONL), reusing Arbr's own request-log
+field names — taskType, model, provider, promptTokens, completionTokens, totalCost.
+If you already run Arbr, export your RequestRecord collection into this shape for a
+real audit. See README.md for the full field list and an export example.
+
+Wrap reports spend and model mix only (no task classification yet, so no
+premium-overuse recommendations — use \`arbr audit\` on a classified log for those).
+Claude Code and Codex are wrapped transparently; OpenCode requires selecting a model
+under the injected "arbr/" provider in-session; Cursor's CLI has no reliable
+redirect today, so it prints manual IDE setup instructions instead. See README.md.
 `;
 
 function parseArgs(argv) {
@@ -32,6 +45,7 @@ function parseArgs(argv) {
     const a = argv[i];
     if (a === "--out") args.out = argv[++i];
     else if (a === "--cheap-task-types") args.cheapTaskTypes = argv[++i];
+    else if (a === "--codex-home") args.codexHome = argv[++i];
     else if (a === "--demo") args.demo = true;
     else if (a === "-h" || a === "--help") args.help = true;
     else args._.push(a);
@@ -56,26 +70,23 @@ function printSummary(result) {
   }
 }
 
-async function main() {
-  const argv = process.argv.slice(2);
-  const [cmd, ...rest] = argv;
-
-  if (!cmd || cmd === "-h" || cmd === "--help") {
-    console.log(HELP);
-    process.exit(cmd ? 0 : 1);
+function printWrapSummary(result) {
+  const { totalRequests, totalCost, groups } = result;
+  console.log(`\nSession done: ${totalRequests.toLocaleString()} requests, $${totalCost.toFixed(2)} total spend.`);
+  const byModel = new Map();
+  for (const g of groups) {
+    const m = byModel.get(g.model) || { requests: 0, cost: 0 };
+    m.requests += g.requests; m.cost += g.currentCost;
+    byModel.set(g.model, m);
   }
-
-  if (cmd !== "audit") {
-    console.error(`Unknown command: ${cmd}\n`);
-    console.log(HELP);
-    process.exit(1);
+  for (const [model, m] of [...byModel.entries()].sort((a, b) => b[1].cost - a[1].cost)) {
+    console.log(`  ${model}: ${m.requests.toLocaleString()} requests, $${m.cost.toFixed(2)}`);
   }
+}
 
+async function runAuditCommand(rest) {
   const args = parseArgs(rest);
-  if (args.help) {
-    console.log(HELP);
-    process.exit(0);
-  }
+  if (args.help) { console.log(HELP); process.exit(0); }
 
   const inputPath = args.demo
     ? path.join(__dirname, "..", "fixtures", "sample.jsonl")
@@ -105,8 +116,51 @@ async function main() {
   printSummary(result);
 
   const outPath = args.out || "arbr-audit-report.html";
-  fs.writeFileSync(outPath, renderReport(result));
+  fs.writeFileSync(outPath, renderReport(result, { mode: "audit" }));
   console.log(`\nReport written to ${outPath}`);
+}
+
+async function runWrapCommand(rest) {
+  const args = parseArgs(rest);
+  if (args.help) { console.log(HELP); process.exit(0); }
+
+  const agentName = args._[0];
+  if (!agentName) {
+    console.error("Error: provide an agent, e.g. `arbr wrap claude`.\n");
+    console.log(HELP);
+    process.exit(1);
+  }
+
+  let result;
+  try {
+    result = await runWrapSession(agentName, { codexHome: args.codexHome });
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+
+  printWrapSummary(result);
+
+  const outPath = args.out || "arbr-wrap-report.html";
+  fs.writeFileSync(outPath, renderReport(result, { mode: "wrap" }));
+  console.log(`\nReport written to ${outPath}`);
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const [cmd, ...rest] = argv;
+
+  if (!cmd || cmd === "-h" || cmd === "--help") {
+    console.log(HELP);
+    process.exit(cmd ? 0 : 1);
+  }
+
+  if (cmd === "audit") return runAuditCommand(rest);
+  if (cmd === "wrap") return runWrapCommand(rest);
+
+  console.error(`Unknown command: ${cmd}\n`);
+  console.log(HELP);
+  process.exit(1);
 }
 
 main();

--- a/clients/cli/package.json
+++ b/clients/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arbr-cli",
-  "version": "0.1.0",
-  "description": "Arbr CLI — audit a log of past LLM requests for premium-model overuse and get a shareable HTML report, with zero server, zero database, and zero signup.",
+  "version": "0.2.0",
+  "description": "Arbr CLI — audit a log of past LLM requests for premium-model overuse, or wrap a coding agent live to see what a session costs, with zero server, zero database, and zero signup.",
   "license": "MIT",
   "bin": {
     "arbr": "./bin/arbr.js"

--- a/clients/cli/src/report.js
+++ b/clients/cli/src/report.js
@@ -14,14 +14,35 @@ function pct(n) {
   return `${Math.round(n)}%`;
 }
 
+// Sums groups (whatever their taskType) down to one row per model — the "full
+// picture" view both audit and wrap can show, independent of whether task-based
+// overuse detection ran at all.
+function aggregateByModel(groups) {
+  const byModel = new Map();
+  for (const g of groups || []) {
+    const key = g.model || "unknown";
+    if (!byModel.has(key)) byModel.set(key, { model: key, requests: 0, cost: 0 });
+    const m = byModel.get(key);
+    m.requests += g.requests || 0;
+    m.cost += g.currentCost || 0;
+  }
+  return [...byModel.values()].sort((a, b) => b.cost - a.cost);
+}
+
 // Renders a single self-contained HTML file — no external fonts, scripts, or
 // stylesheets, so it opens correctly offline and is safe to send as a standalone
 // attachment. Uses the same design-token pattern (paper/ink/amber/blue, light+dark
 // via prefers-color-scheme) as Arbr's other shareable reports, scoped to system fonts
 // to keep this package small and independent of network access at render time.
+//
+// opts.mode: "audit" (default) or "wrap" — wrap sessions never run task
+// classification in v1, so they skip the recommendations table entirely (it would
+// always be empty) and lead with the per-model breakdown instead, with copy that
+// doesn't imply overuse detection was attempted.
 function renderReport(result, opts = {}) {
-  const { totalRequests, totalCost, recommendations, flaggedCost, flaggedSavings, overusePct } = result;
+  const { totalRequests, totalCost, recommendations, flaggedCost, flaggedSavings, overusePct, groups } = result;
   const generatedAt = opts.generatedAt || new Date();
+  const mode = opts.mode || "audit";
 
   const rows = recommendations.map((r) => `
     <tr>
@@ -32,18 +53,38 @@ function renderReport(result, opts = {}) {
       <td class="num tone-amber">${money(r.projectedSavings)}</td>
     </tr>`).join("");
 
-  const emptyState = recommendations.length === 0
+  const emptyState = mode === "audit" && recommendations.length === 0
     ? `<p class="empty">No premium-model overuse found in this log — either the traffic is already
        well-routed, or there isn't enough volume yet in any one (task type, model) group to be sure
        (each group needs at least ${result.minRequests || 20} requests before it's flagged).</p>`
     : "";
+
+  const wrapNote = mode === "wrap"
+    ? `<p class="empty">This session's traffic isn't task-classified, so it's reported by spend and
+       model mix only — not per-task overuse. Run <span class="num">arbr audit</span> on a
+       task-labeled log for "switch model X&nbsp;&#8594;&nbsp;Y" recommendations.</p>`
+    : "";
+
+  const modelRows = aggregateByModel(groups).map((m) => `
+    <tr>
+      <td class="num">${esc(m.model)}</td>
+      <td class="num">${m.requests.toLocaleString()}</td>
+      <td class="num">${money(m.cost)}</td>
+    </tr>`).join("");
+  const modelBreakdown = (groups && groups.length > 0) ? `
+  <div class="overflow">
+    <table>
+      <thead><tr><th>Model</th><th>Requests</th><th>Spend</th></tr></thead>
+      <tbody>${modelRows}</tbody>
+    </table>
+  </div>` : "";
 
   return `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Arbr Audit Report</title>
+<title>${mode === "wrap" ? "Arbr Wrap Report" : "Arbr Audit Report"}</title>
 <style>
   :root {
     --paper: #EEF0F3; --surface: #FFFFFF; --ink: #14171C; --ink-soft: #3B404A;
@@ -84,24 +125,29 @@ function renderReport(result, opts = {}) {
 </head>
 <body>
 <div class="page">
-  <p class="eyebrow">Arbr Audit</p>
-  <h1>Where your LLM spend is going, and what it could cost instead</h1>
+  <p class="eyebrow">${mode === "wrap" ? "Arbr Wrap" : "Arbr Audit"}</p>
+  <h1>${mode === "wrap" ? "What this session cost, model by model" : "Where your LLM spend is going, and what it could cost instead"}</h1>
 
   <div class="stat-row">
     <div class="stat">
       <div class="stat-value num">${totalRequests.toLocaleString()}</div>
-      <div class="stat-label">requests analyzed</div>
+      <div class="stat-label">requests ${mode === "wrap" ? "this session" : "analyzed"}</div>
     </div>
     <div class="stat">
       <div class="stat-value num">${money(totalCost)}</div>
-      <div class="stat-label">total spend in this log</div>
+      <div class="stat-label">total spend ${mode === "wrap" ? "this session" : "in this log"}</div>
     </div>
     <div class="stat">
+      ${mode === "wrap" ? `
+      <div class="stat-value num">${aggregateByModel(groups).length}</div>
+      <div class="stat-label">models used this session</div>` : `
       <div class="stat-value num tone-amber">${money(flaggedSavings)}</div>
-      <div class="stat-label">projected savings found (${pct(overusePct)} of spend)</div>
+      <div class="stat-label">projected savings found (${pct(overusePct)} of spend)</div>`}
     </div>
   </div>
 
+  ${wrapNote}
+  ${mode === "wrap" ? modelBreakdown : ""}
   ${emptyState}
   ${recommendations.length > 0 ? `
   <div class="overflow">
@@ -112,9 +158,10 @@ function renderReport(result, opts = {}) {
       <tbody>${rows}</tbody>
     </table>
   </div>` : ""}
+  ${mode === "audit" ? modelBreakdown : ""}
 
   <footer>
-    Generated by <span class="num">arbr audit</span> on ${esc(generatedAt.toISOString().slice(0, 10))}.
+    Generated by <span class="num">arbr ${mode === "wrap" ? "wrap" : "audit"}</span> on ${esc(generatedAt.toISOString().slice(0, 10))}.
     Flags compare task type and model tier against a static price table, not answer quality —
     verify a suggested downgrade against your own traffic before switching.
   </footer>

--- a/clients/cli/src/wrap.js
+++ b/clients/cli/src/wrap.js
@@ -1,0 +1,200 @@
+"use strict";
+
+const http = require("http");
+const pricing = require("./vendor/pricingTable");
+const { aggregateGroups } = require("./audit");
+const { launchClaude, launchOpenCode, launchCodex, printCursorInstructions } = require("./wrapAgents");
+
+const WIRE_BY_AGENT = { claude: "anthropic", codex: "openai", opencode: "openai", cursor: "openai" };
+const AUTOMATED_AGENTS = new Set(["claude", "codex", "opencode"]);
+
+// Fixed real upstreams. v1 only proxies each provider's single chat/completion
+// endpoint (Anthropic's /v1/messages, OpenAI's /v1/chat/completions) — a wrapped
+// agent calling any other endpoint (e.g. a models-list call) gets forwarded to the
+// same fixed path, which is a known v1 limitation, not a bug: coding-agent traffic
+// is overwhelmingly one repeated call shape, and getting that one shape right well
+// is more useful than a half-generic router.
+const UPSTREAMS = {
+  anthropic: "https://api.anthropic.com/v1/messages",
+  openai: "https://api.openai.com/v1/chat/completions",
+};
+
+// Anthropic SSE: usage arrives split across two events — message_start carries
+// input_tokens (and a starting output_tokens, usually 0), message_delta carries the
+// final output_tokens once generation stops. Take the max seen for each field so
+// either a delta or a cumulative-count SSE implementation is handled the same way.
+function parseAnthropicSSE(text) {
+  let promptTokens = 0, completionTokens = 0;
+  for (const line of text.split("\n")) {
+    if (!line.startsWith("data:")) continue;
+    const payload = line.slice(5).trim();
+    if (!payload || payload === "[DONE]") continue;
+    let evt;
+    try { evt = JSON.parse(payload); } catch { continue; }
+    const usage = evt?.message?.usage || evt?.usage;
+    if (!usage) continue;
+    if (typeof usage.input_tokens === "number") promptTokens = Math.max(promptTokens, usage.input_tokens);
+    if (typeof usage.output_tokens === "number") completionTokens = Math.max(completionTokens, usage.output_tokens);
+  }
+  return { promptTokens, completionTokens };
+}
+
+// OpenAI SSE only carries a `usage` object in the final chunk, and only when the
+// caller's request included `stream_options: {include_usage: true}`. If the client
+// didn't ask for it, usage stays 0 for that call — cost then reports as $0 for it,
+// same "unknown" convention Arbr's own server uses for unpriced calls.
+function parseOpenAISSE(text) {
+  let promptTokens = 0, completionTokens = 0;
+  for (const line of text.split("\n")) {
+    if (!line.startsWith("data:")) continue;
+    const payload = line.slice(5).trim();
+    if (!payload || payload === "[DONE]") continue;
+    let evt;
+    try { evt = JSON.parse(payload); } catch { continue; }
+    if (evt.usage) {
+      promptTokens = evt.usage.prompt_tokens || promptTokens;
+      completionTokens = evt.usage.completion_tokens || completionTokens;
+    }
+  }
+  return { promptTokens, completionTokens };
+}
+
+function parseNonStreamingUsage(wire, json) {
+  const usage = json.usage || {};
+  if (wire === "anthropic") {
+    return { promptTokens: usage.input_tokens || 0, completionTokens: usage.output_tokens || 0 };
+  }
+  return { promptTokens: usage.prompt_tokens || 0, completionTokens: usage.completion_tokens || 0 };
+}
+
+// Forward one request to the real provider, streaming the response straight back to
+// the client untouched (same technique as server/src/gateway/openaiCompat.js's
+// proxyOpenAICompat: read the upstream body with a reader, write each chunk to the
+// client immediately, and separately accumulate the text to parse usage from after
+// the fact — the bytes the client sees are never altered).
+async function forwardRequest({ wire, requestHeaders, requestBody, res, onRecord }) {
+  let parsedBody = {};
+  try { parsedBody = JSON.parse(requestBody || "{}"); } catch { /* leave empty */ }
+  const model = parsedBody.model || "unknown";
+  const isStreaming = parsedBody.stream === true;
+  const upstreamUrl = UPSTREAMS[wire];
+
+  const headers = { "content-type": "application/json" };
+  if (wire === "anthropic") {
+    if (requestHeaders["x-api-key"]) headers["x-api-key"] = requestHeaders["x-api-key"];
+    if (requestHeaders["anthropic-version"]) headers["anthropic-version"] = requestHeaders["anthropic-version"];
+    if (requestHeaders["authorization"]) headers["authorization"] = requestHeaders["authorization"];
+  } else {
+    if (requestHeaders["authorization"]) headers["authorization"] = requestHeaders["authorization"];
+  }
+
+  let upstreamRes;
+  try {
+    upstreamRes = await fetch(upstreamUrl, { method: "POST", headers, body: requestBody });
+  } catch (err) {
+    res.writeHead(502, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: { message: `arbr wrap: upstream fetch failed: ${err.message}` } }));
+    return;
+  }
+
+  res.writeHead(upstreamRes.status, {
+    "content-type": upstreamRes.headers.get("content-type") || "application/json",
+  });
+
+  if (!upstreamRes.body) {
+    res.end();
+    return;
+  }
+
+  const reader = upstreamRes.body.getReader();
+  const decoder = new TextDecoder();
+  let fullText = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    res.write(Buffer.from(value));
+    fullText += decoder.decode(value, { stream: true });
+  }
+  res.end();
+
+  let promptTokens = 0, completionTokens = 0;
+  try {
+    if (isStreaming) {
+      const parsed = wire === "anthropic" ? parseAnthropicSSE(fullText) : parseOpenAISSE(fullText);
+      promptTokens = parsed.promptTokens; completionTokens = parsed.completionTokens;
+    } else {
+      const parsed = parseNonStreamingUsage(wire, JSON.parse(fullText));
+      promptTokens = parsed.promptTokens; completionTokens = parsed.completionTokens;
+    }
+  } catch { /* leave usage at 0 rather than crash the proxy over a parse issue */ }
+
+  const { totalCost } = pricing.costFor(model, promptTokens, completionTokens);
+  onRecord({ model, provider: wire, promptTokens, completionTokens, totalCost });
+}
+
+// Starts the local proxy. Binds to 127.0.0.1 ONLY — this must never be reachable
+// from the network, since it forwards real provider credentials.
+function startProxy({ wire, onRecord }) {
+  const server = http.createServer((req, res) => {
+    const chunks = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => {
+      const body = Buffer.concat(chunks).toString("utf8");
+      forwardRequest({ wire, requestHeaders: req.headers, requestBody: body, res, onRecord }).catch((err) => {
+        if (!res.headersSent) res.writeHead(500, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: { message: `arbr wrap: ${err.message}` } }));
+      });
+    });
+  });
+
+  return new Promise((resolve, reject) => {
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve(server));
+  });
+}
+
+// Full session: start the proxy, launch the agent (or print manual instructions for
+// cursor), wait for it to finish, then build the same result shape `runAudit`
+// returns — `recommendations` stays empty (v1 never runs task classification on live
+// traffic; see report.js's `mode: "wrap"` copy, which explains this instead of
+// implying overuse detection ran).
+async function runWrapSession(agentName, opts = {}) {
+  if (!WIRE_BY_AGENT[agentName]) {
+    throw new Error(`Unknown agent: ${agentName} (supported: claude, codex, opencode, cursor)`);
+  }
+
+  const records = [];
+  const server = await startProxy({ wire: WIRE_BY_AGENT[agentName], onRecord: (r) => records.push(r) });
+  const port = server.address().port;
+  console.log(`arbr wrap: local proxy listening on 127.0.0.1:${port} (${agentName})`);
+
+  try {
+    if (agentName === "cursor") {
+      printCursorInstructions(port);
+      await new Promise((resolve) => {
+        process.once("SIGINT", () => { console.log("\narbr wrap: stopping."); resolve(); });
+      });
+    } else {
+      const child = agentName === "claude" ? launchClaude(port)
+        : agentName === "codex" ? launchCodex(port, opts)
+        : launchOpenCode(port);
+      await new Promise((resolve, reject) => {
+        child.on("error", reject);
+        child.on("exit", () => resolve());
+      });
+    }
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+
+  const { groups, totalRequests, totalCost } = aggregateGroups(records);
+  return {
+    totalRequests, totalCost, groups,
+    recommendations: [], flaggedCost: 0, flaggedSavings: 0, overusePct: 0,
+  };
+}
+
+module.exports = {
+  startProxy, parseAnthropicSSE, parseOpenAISSE, parseNonStreamingUsage, UPSTREAMS,
+  runWrapSession, AUTOMATED_AGENTS,
+};

--- a/clients/cli/src/wrapAgents.js
+++ b/clients/cli/src/wrapAgents.js
@@ -1,0 +1,134 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { spawn } = require("child_process");
+
+// --- claude: pure env-var redirection, no file touched. -------------------------
+// Documented by Anthropic (code.claude.com/docs/en/llm-gateway-connect):
+// ANTHROPIC_BASE_URL redirects every outbound call; the existing credential
+// (OAuth session from `claude login`, or ANTHROPIC_API_KEY if set) is sent to that
+// URL unchanged, which is why the proxy can just forward whatever auth header
+// arrives rather than minting its own.
+function launchClaude(port) {
+  const env = { ...process.env, ANTHROPIC_BASE_URL: `http://127.0.0.1:${port}` };
+  return spawn("claude", [], { stdio: "inherit", env });
+}
+
+// --- opencode: pure env-var redirection, no file touched. ------------------------
+// OpenCode has no ANTHROPIC_BASE_URL-style override of its default provider; it
+// takes an entirely new provider via config. OPENCODE_CONFIG_CONTENT (inline JSON)
+// injects one at launch without writing anything to disk. Caveat, confirmed by
+// research (opencode.ai/docs/config + anomalyco/opencode#13219): this content mode
+// skips {env:}/{file:} substitution, so the API key must be a literal value in the
+// generated JSON — it lives only in the child process's environment, never on disk.
+// This also means the wrapped session is NOT a transparent redirect: the user must
+// select a model under the injected `arbr/<model-id>` namespace for traffic to
+// actually flow through the proxy. v1 only wires up an OpenAI-backed model list;
+// see README for that limitation.
+function launchOpenCode(port) {
+  const apiKey = process.env.OPENAI_API_KEY || "arbr-local-placeholder";
+  const config = {
+    provider: {
+      arbr: {
+        npm: "@ai-sdk/openai-compatible",
+        name: "Arbr (local wrap proxy)",
+        options: { baseURL: `http://127.0.0.1:${port}/v1` },
+        apiKey,
+        models: {
+          "gpt-4o": {}, "gpt-4o-mini": {},
+        },
+      },
+    },
+  };
+  console.log('In the OpenCode session, select a model under "arbr/" (e.g. "arbr/gpt-4o-mini") to route it through Arbr — other providers are not observed in this session.');
+  const env = { ...process.env, OPENCODE_CONFIG_CONTENT: JSON.stringify(config) };
+  return spawn("opencode", [], { stdio: "inherit", env });
+}
+
+// --- codex: no confirmed env-var override; needs a config.toml edit. ------------
+// UNVERIFIED against a real Codex CLI install (see clients/cli/README.md) — a past
+// GitHub issue reported config.toml overrides not being respected in an older
+// version. Implemented defensively: back up the original file to a sibling
+// timestamped path *and* keep it in memory, patch only the minimum needed (root-level
+// `model_provider` key + a freshly-appended `[model_providers.arbr_wrap]` table —
+// appending a whole new table is always TOML-safe; inserting a bare key is NOT safe
+// after any `[section]` header has already opened, hence the root/rest split below),
+// and restore unconditionally in a `finally` plus SIGINT/SIGTERM handlers so a killed
+// process can't leave the user's real config patched.
+function patchCodexConfig(configPath, port) {
+  const existed = fs.existsSync(configPath);
+  const original = existed ? fs.readFileSync(configPath, "utf8") : "";
+
+  let backupPath = null;
+  if (existed) {
+    backupPath = `${configPath}.arbr-backup-${Date.now()}`;
+    fs.writeFileSync(backupPath, original);
+  }
+
+  const lines = existed ? original.split("\n") : [];
+  const firstSectionIdx = lines.findIndex((l) => /^\s*\[/.test(l));
+  const rootLines = firstSectionIdx === -1 ? lines : lines.slice(0, firstSectionIdx);
+  const restLines = firstSectionIdx === -1 ? [] : lines.slice(firstSectionIdx);
+
+  const filteredRoot = rootLines.filter((l) => !/^\s*model_provider\s*=/.test(l));
+  const newRoot = [...filteredRoot, 'model_provider = "arbr_wrap"'];
+
+  const patched =
+    [...newRoot, ...restLines].join("\n") +
+    "\n\n[model_providers.arbr_wrap]\n" +
+    'name = "Arbr (local wrap proxy)"\n' +
+    `base_url = "http://127.0.0.1:${port}/v1"\n` +
+    'env_key = "ARBR_WRAP_KEY"\n' +
+    'wire_api = "chat"\n';
+
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.writeFileSync(configPath, patched);
+
+  const restore = () => {
+    if (existed) fs.writeFileSync(configPath, original);
+    else if (fs.existsSync(configPath)) fs.unlinkSync(configPath);
+  };
+  return { restore, backupPath };
+}
+
+function launchCodex(port, { codexHome } = {}) {
+  const configPath = path.join(codexHome || path.join(os.homedir(), ".codex"), "config.toml");
+  const { restore, backupPath } = patchCodexConfig(configPath, port);
+
+  const cleanup = () => {
+    try { restore(); } catch (err) {
+      console.error(`arbr wrap: failed to restore ${configPath} — recover manually from ${backupPath}: ${err.message}`);
+    }
+  };
+  const onSignal = () => { cleanup(); process.exit(1); };
+  process.once("SIGINT", onSignal);
+  process.once("SIGTERM", onSignal);
+
+  const env = { ...process.env, ARBR_WRAP_KEY: process.env.OPENAI_API_KEY || "" };
+  const child = spawn("codex", [], { stdio: "inherit", env });
+  child.on("exit", () => {
+    process.removeListener("SIGINT", onSignal);
+    process.removeListener("SIGTERM", onSignal);
+    cleanup();
+  });
+  return child;
+}
+
+// --- cursor: no automation path today (confirmed: Cursor CLI's --endpoint/--api-key
+// flags are reported broken; headroom's own README independently marks Cursor as
+// manual-only for the same reason). Print instructions instead of spawning anything.
+function printCursorInstructions(port) {
+  console.log(`
+Cursor's CLI doesn't currently support redirecting its API traffic reliably, so
+this can't be automated the way Claude Code/Codex/OpenCode are. To route Cursor's
+IDE traffic through Arbr manually:
+
+  1. Open Cursor → Settings → Models → "Override OpenAI Base URL"
+  2. Set it to: http://127.0.0.1:${port}/v1
+  3. Use Cursor as normal — this proxy stays running and reports stats on Ctrl-C.
+`);
+}
+
+module.exports = { launchClaude, launchOpenCode, launchCodex, patchCodexConfig, printCursorInstructions };

--- a/clients/cli/test/audit.test.js
+++ b/clients/cli/test/audit.test.js
@@ -94,3 +94,21 @@ test("renderReport handles the zero-recommendations case", () => {
   }, { generatedAt: new Date("2026-07-23T00:00:00Z") });
   assert.match(html, /No premium-model overuse found/);
 });
+
+test("renderReport in wrap mode skips the overuse empty-state and shows a per-model breakdown", () => {
+  const html = renderReport({
+    totalRequests: 12, totalCost: 3.5,
+    groups: [
+      { taskType: "unknown", model: "claude-opus-4-8", requests: 8, currentCost: 3 },
+      { taskType: "unknown", model: "claude-haiku-4-5", requests: 4, currentCost: 0.5 },
+    ],
+    recommendations: [], flaggedCost: 0, flaggedSavings: 0, overusePct: 0,
+  }, { mode: "wrap", generatedAt: new Date("2026-07-23T00:00:00Z") });
+
+  assert.match(html, /Arbr Wrap Report/);
+  assert.doesNotMatch(html, /No premium-model overuse found/);
+  assert.match(html, /isn't task-classified/);
+  assert.match(html, /claude-opus-4-8/);
+  assert.match(html, /claude-haiku-4-5/);
+  assert.match(html, /2<\/div>\s*<div class="stat-label">models used this session/);
+});

--- a/clients/cli/test/wrap.test.js
+++ b/clients/cli/test/wrap.test.js
@@ -1,0 +1,159 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const http = require("node:http");
+const {
+  startProxy, parseAnthropicSSE, parseOpenAISSE, parseNonStreamingUsage,
+} = require("../src/wrap");
+
+// --- pure SSE/usage parsing --------------------------------------------------
+
+test("parseAnthropicSSE takes input_tokens from message_start and output_tokens from message_delta", () => {
+  const sse = [
+    'event: message_start',
+    'data: {"type":"message_start","message":{"id":"msg_1","model":"claude-opus-4-8","usage":{"input_tokens":120,"output_tokens":1}}}',
+    "",
+    'event: content_block_delta',
+    'data: {"type":"content_block_delta","delta":{"text":"hi"}}',
+    "",
+    'event: message_delta',
+    'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":42}}',
+    "",
+    'event: message_stop',
+    'data: {"type":"message_stop"}',
+    "",
+  ].join("\n");
+  const usage = parseAnthropicSSE(sse);
+  assert.equal(usage.promptTokens, 120);
+  assert.equal(usage.completionTokens, 42);
+});
+
+test("parseOpenAISSE reads usage only from the final chunk (stream_options.include_usage)", () => {
+  const sse = [
+    'data: {"id":"1","choices":[{"delta":{"content":"a"}}],"usage":null}',
+    "",
+    'data: {"id":"1","choices":[{"delta":{"content":"b"}}],"usage":null}',
+    "",
+    'data: {"id":"1","choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":80,"completion_tokens":12}}',
+    "",
+    "data: [DONE]",
+    "",
+  ].join("\n");
+  const usage = parseOpenAISSE(sse);
+  assert.equal(usage.promptTokens, 80);
+  assert.equal(usage.completionTokens, 12);
+});
+
+test("parseOpenAISSE returns zeros when the client never requested usage", () => {
+  const sse = 'data: {"id":"1","choices":[{"delta":{"content":"a"}}]}\n\ndata: [DONE]\n';
+  const usage = parseOpenAISSE(sse);
+  assert.equal(usage.promptTokens, 0);
+  assert.equal(usage.completionTokens, 0);
+});
+
+test("parseNonStreamingUsage reads Anthropic and OpenAI response shapes", () => {
+  assert.deepEqual(
+    parseNonStreamingUsage("anthropic", { usage: { input_tokens: 10, output_tokens: 5 } }),
+    { promptTokens: 10, completionTokens: 5 }
+  );
+  assert.deepEqual(
+    parseNonStreamingUsage("openai", { usage: { prompt_tokens: 20, completion_tokens: 8 } }),
+    { promptTokens: 20, completionTokens: 8 }
+  );
+});
+
+// --- full proxy round trip, against a mocked upstream (never a real API) ----
+
+function fakeSSEResponse(lines) {
+  const body = lines.join("\n") + "\n";
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(body));
+      controller.close();
+    },
+  });
+  return new Response(stream, { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+async function postJson(port, path, payload) {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify(payload);
+    const req = http.request(
+      { host: "127.0.0.1", port, path, method: "POST", headers: { "content-type": "application/json", "content-length": Buffer.byteLength(body) } },
+      (res) => {
+        let data = "";
+        res.on("data", (c) => (data += c));
+        res.on("end", () => resolve({ status: res.statusCode, body: data }));
+      }
+    );
+    req.on("error", reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+test("proxy forwards a streaming Anthropic request and records usage/cost", async (t) => {
+  const originalFetch = global.fetch;
+  t.after(() => { global.fetch = originalFetch; });
+
+  global.fetch = async () => fakeSSEResponse([
+    'data: {"type":"message_start","message":{"usage":{"input_tokens":100,"output_tokens":1}}}',
+    'data: {"type":"message_delta","usage":{"output_tokens":50}}',
+  ]);
+
+  const records = [];
+  const server = await startProxy({ wire: "anthropic", onRecord: (r) => records.push(r) });
+  const port = server.address().port;
+  try {
+    const res = await postJson(port, "/v1/messages", { model: "claude-opus-4-8", stream: true, messages: [] });
+    assert.equal(res.status, 200);
+    assert.match(res.body, /message_start/); // bytes passed through untouched
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+
+  assert.equal(records.length, 1);
+  assert.equal(records[0].model, "claude-opus-4-8");
+  assert.equal(records[0].provider, "anthropic");
+  assert.equal(records[0].promptTokens, 100);
+  assert.equal(records[0].completionTokens, 50);
+  assert.ok(records[0].totalCost > 0);
+});
+
+test("proxy forwards a non-streaming OpenAI request and records usage/cost", async (t) => {
+  const originalFetch = global.fetch;
+  t.after(() => { global.fetch = originalFetch; });
+
+  global.fetch = async () => new Response(
+    JSON.stringify({ id: "x", choices: [{ message: { content: "hi" } }], usage: { prompt_tokens: 30, completion_tokens: 6 } }),
+    { status: 200, headers: { "content-type": "application/json" } }
+  );
+
+  const records = [];
+  const server = await startProxy({ wire: "openai", onRecord: (r) => records.push(r) });
+  const port = server.address().port;
+  try {
+    const res = await postJson(port, "/chat/completions", { model: "gpt-4o-mini", stream: false, messages: [] });
+    assert.equal(res.status, 200);
+    const parsed = JSON.parse(res.body);
+    assert.equal(parsed.id, "x"); // untouched passthrough
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+
+  assert.equal(records.length, 1);
+  assert.equal(records[0].model, "gpt-4o-mini");
+  assert.equal(records[0].provider, "openai");
+  assert.equal(records[0].promptTokens, 30);
+  assert.equal(records[0].completionTokens, 6);
+});
+
+test("proxy binds to 127.0.0.1 only, not 0.0.0.0", async () => {
+  const server = await startProxy({ wire: "anthropic", onRecord: () => {} });
+  try {
+    assert.equal(server.address().address, "127.0.0.1");
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});

--- a/clients/cli/test/wrapAgents.test.js
+++ b/clients/cli/test/wrapAgents.test.js
@@ -1,0 +1,91 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
+const { patchCodexConfig } = require("../src/wrapAgents");
+
+// Every test here operates on a throwaway temp directory — never the real
+// ~/.codex — so this suite can never touch a developer's actual Codex config.
+function tempConfigPath() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "arbr-cli-codex-test-"));
+  return path.join(dir, "config.toml");
+}
+
+test("patchCodexConfig backs up and can restore an existing config unchanged", () => {
+  const configPath = tempConfigPath();
+  const original = [
+    'model = "gpt-5.6-sol"',
+    'model_reasoning_effort = "high"',
+    "",
+    '[projects."/some/path"]',
+    'trust_level = "trusted"',
+    "",
+  ].join("\n");
+  fs.writeFileSync(configPath, original);
+
+  const { restore, backupPath } = patchCodexConfig(configPath, 54321);
+
+  assert.ok(fs.existsSync(backupPath));
+  assert.equal(fs.readFileSync(backupPath, "utf8"), original);
+
+  const patched = fs.readFileSync(configPath, "utf8");
+  assert.match(patched, /model_provider = "arbr_wrap"/);
+  assert.match(patched, /\[model_providers\.arbr_wrap\]/);
+  assert.match(patched, /base_url = "http:\/\/127\.0\.0\.1:54321\/v1"/);
+  // The root-level override must land BEFORE the first [section], not after —
+  // appending it after an existing [section] would silently belong to that
+  // section instead of the root table in real TOML.
+  const providerLine = patched.indexOf('model_provider = "arbr_wrap"');
+  const firstSection = patched.indexOf('[projects');
+  assert.ok(providerLine < firstSection, "model_provider must precede the first [section]");
+  // Original content must still be present, untouched.
+  assert.match(patched, /model = "gpt-5\.6-sol"/);
+  assert.match(patched, /trust_level = "trusted"/);
+
+  restore();
+  assert.equal(fs.readFileSync(configPath, "utf8"), original);
+});
+
+test("patchCodexConfig replaces a pre-existing model_provider line instead of duplicating it", () => {
+  const configPath = tempConfigPath();
+  const original = 'model_provider = "openai"\nmodel = "gpt-5"\n';
+  fs.writeFileSync(configPath, original);
+
+  const { restore } = patchCodexConfig(configPath, 1234);
+  const patched = fs.readFileSync(configPath, "utf8");
+  const matches = patched.match(/model_provider\s*=/g) || [];
+  assert.equal(matches.length, 1, "must not leave two model_provider keys");
+  assert.match(patched, /model_provider = "arbr_wrap"/);
+
+  restore();
+  assert.equal(fs.readFileSync(configPath, "utf8"), original);
+});
+
+test("patchCodexConfig creates then fully removes a config that didn't exist before", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "arbr-cli-codex-test-"));
+  const configPath = path.join(dir, "config.toml");
+  assert.ok(!fs.existsSync(configPath));
+
+  const { restore, backupPath } = patchCodexConfig(configPath, 999);
+  assert.ok(fs.existsSync(configPath));
+  assert.equal(backupPath, null); // nothing to back up if there was no original file
+
+  restore();
+  assert.ok(!fs.existsSync(configPath), "restore must remove a file arbr created from nothing");
+});
+
+test("patchCodexConfig handles a config with no [section] headers at all", () => {
+  const configPath = tempConfigPath();
+  const original = 'model = "gpt-5"\n';
+  fs.writeFileSync(configPath, original);
+
+  const { restore } = patchCodexConfig(configPath, 4321);
+  const patched = fs.readFileSync(configPath, "utf8");
+  assert.match(patched, /model_provider = "arbr_wrap"/);
+  assert.match(patched, /\[model_providers\.arbr_wrap\]/);
+
+  restore();
+  assert.equal(fs.readFileSync(configPath, "utf8"), original);
+});


### PR DESCRIPTION
## What

Recovers PR #216's content, which GitHub reports as \`merged: true\` but never actually reached
\`main\`. Same stacked-PR-squash trap that's recurred repeatedly in this project: #216's base was
\`feat/arbr-audit-cli\` (PR #215's branch), not \`main\`. When #215 merged into main, #216's base
was never retargeted, so merging #216 landed its commit on the now-orphaned
\`feat/arbr-audit-cli\` branch instead of \`main\`.

Verified before recovering: \`git log origin/main..origin/feat/arbr-wrap-cli\` showed exactly one
stranded commit; \`git cat-file -e origin/main:clients/cli/src/wrap.js\` confirmed it was
genuinely absent from main, not just my misreading the PR list.

## Recovery

\`git cherry-pick 6957eb6\` onto a fresh branch off current \`origin/main\` — clean pick, no
conflicts.

## Verification

- \`npm run docs:build\` — clean.
- \`node --test clients/cli/test/wrap.test.js clients/cli/test/wrapAgents.test.js\` — 11/11 pass.

## Follow-up

Opening a separate discussion on preventing this mechanically going forward (it's recurred
enough times now that "be more careful" clearly isn't sufficient) — likely a required CI check
that fails any PR whose base isn't \`main\`, plus enabling auto-delete-head-branches so GitHub's
own base-retargeting kicks in automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)