### PR TITLE
ci: add a required check that fails any PR whose base isn't main

### DIFF
--- a/.github/workflows/base-branch-check.yml
+++ b/.github/workflows/base-branch-check.yml
@@ -1,0 +1,25 @@
+name: Base branch check
+
+# Guards against the stacked-PR-squash trap: PR B based on PR A's feature
+# branch instead of main. If A gets squash-merged and merged into as its
+# own PR, B's commits land on the (now-orphaned) branch A, never on main,
+# even though GitHub reports B as "merged: true". Recurred repeatedly in
+# this project before delete_branch_on_merge + this check were added.
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+
+jobs:
+  check-base:
+    name: Base branch is main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify base branch is main
+        run: |
+          if [ "${{ github.event.pull_request.base.ref }}" != "main" ]; then
+            echo "::error::This PR's base branch is '${{ github.event.pull_request.base.ref }}', not 'main'."
+            echo "::error::Retarget it before merging: gh pr edit ${{ github.event.pull_request.number }} --base main"
+            echo "::error::A stacked base can silently strand your commits off main even after GitHub reports the PR as merged."
+            exit 1
+          fi
+          echo "Base branch is main. OK."


### PR DESCRIPTION
## What

Structural fix for the stacked-PR-squash trap that's recurred repeatedly in this project
(most recently: #216, "merged" but never reached \`main\`, recovered via #218). Two layers:

1. **\`delete_branch_on_merge\` enabled on the repo** (done directly via \`gh api\`, not part of
   this diff) — GitHub auto-retargets any other open PR based on a branch to the default branch
   once that branch is deleted. Would have caught both prior incidents. Not airtight alone —
   depends on deletion actually completing before the dependent PR is merged.
2. **This workflow** — the hard gate. Runs on every PR regardless of base, passes if
   \`base == main\`, fails loudly (with the exact \`gh pr edit --base main\` fix) otherwise.

## Why it's shaped this way

Deliberately triggers on every \`pull_request\` event rather than filtering by
\`branches-ignore\` in the \`on:\` block. A filtered trigger would mean the job never runs at all
for a correctly-based PR — which is exactly the "required check that never fires, blocks
everything forever" trap this repo already hit once with \`Publish image (green main)\`. This
job always runs and always produces a real pass/fail from the actual base ref.

## Rollout (please don't add to required checks yet)

This PR itself is the first real test — its base is \`main\`, so the new check should show green
on it. **Once merged and confirmed working**, add \`Base branch is main\` to
\`required_status_checks.contexts\` on \`main\`'s branch protection (remember: that's a full
PUT/replace, carry forward the existing 6 contexts). I'll do that as a small follow-up once this
is confirmed green, not bundled into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)