### PR TITLE
chore(cli): rename to arbr-audit, normalize bin path before first publish

### DIFF
--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -1,17 +1,17 @@
-# arbr-cli
+# arbr-audit
 
 Audit a log of past LLM requests for premium-model overuse, or wrap a coding agent
 live to see what a session costs — no server, no database, no signup.
 
 ```sh
-npx arbr-cli audit --demo
+npx arbr-audit audit --demo
 ```
 
 That runs against a bundled sample log and writes `arbr-audit-report.html` — open it
 in a browser. On your own data:
 
 ```sh
-npx arbr-cli audit my-usage.jsonl
+npx arbr-audit audit my-usage.jsonl
 ```
 
 ## What it does

--- a/clients/cli/package.json
+++ b/clients/cli/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "arbr-cli",
+  "name": "arbr-audit",
   "version": "0.2.0",
-  "description": "Arbr CLI — audit a log of past LLM requests for premium-model overuse, or wrap a coding agent live to see what a session costs, with zero server, zero database, and zero signup.",
+  "description": "Audit a log of past LLM requests for premium-model overuse, or wrap a coding agent live to see what a session costs, with zero server, zero database, and zero signup.",
   "license": "MIT",
   "bin": {
     "arbr": "bin/arbr.js"

--- a/clients/cli/package.json
+++ b/clients/cli/package.json
@@ -4,7 +4,7 @@
   "description": "Arbr CLI — audit a log of past LLM requests for premium-model overuse, or wrap a coding agent live to see what a session costs, with zero server, zero database, and zero signup.",
   "license": "MIT",
   "bin": {
-    "arbr": "./bin/arbr.js"
+    "arbr": "bin/arbr.js"
   },
   "main": "./src/audit.js",
   "files": [


### PR DESCRIPTION
## What

Two pre-publish fixes to \`clients/cli\`, bundled since both touch \`package.json\`:

1. **Renamed \`arbr-cli\` → \`arbr-audit\`.** "arbr-cli" implied a management CLI for a running
   Arbr instance (like \`stripe-cli\`/\`vercel-cli\`) — misleading, since this tool is explicitly
   standalone and zero-infra ("without needing to run Arbr at all," per its own README). Caught
   before the first publish — the cheapest possible time to fix a package name, since npm names
   are effectively permanent once claimed. The \`arbr\` bin command itself is unaffected — npx
   resolves a package's single bin entry regardless of name match, so \`arbr audit --demo\` /
   \`arbr wrap claude\` stay exactly as documented; only the install/npx lines change.
2. **Normalized the bin path** (\`./bin/arbr.js\` → \`bin/arbr.js\`) — \`npm publish --dry-run\`
   flagged this as auto-corrected; applying \`npm pkg fix\`'s own suggestion rather than
   publishing with a lingering warning.

## Verification

- \`node clients/cli/bin/arbr.js audit --demo\` — still runs correctly after both edits.
- \`npm pack\` + \`npx --package=<tarball> -- arbr audit --demo\` — confirmed the renamed
  package's bin resolves and runs correctly before publishing for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)