### PR TITLE
fix(auth): migrate OIDC login to openid-client v6's API

### DIFF
--- a/server/src/api/authProviders/oidc.js
+++ b/server/src/api/authProviders/oidc.js
@@ -5,7 +5,10 @@
 // one round trip (a restart mid-login just means the user retries).
 const crypto = require("crypto");
 const express = require("express");
-const { Issuer, generators } = require("openid-client");
+// v6 dropped the v5 Issuer/Client class API for a functional one — discovery()
+// replaces Issuer.discover()+new issuer.Client(), buildAuthorizationUrl()/
+// authorizationCodeGrant() replace client.authorizationUrl()/client.callback().
+const { discovery, randomPKCECodeVerifier, calculatePKCECodeChallenge, randomState, buildAuthorizationUrl, authorizationCodeGrant } = require("openid-client");
 const { SignJWT, jwtVerify } = require("jose");
 const { config } = require("../../config");
 const User = require("../../models/User");
@@ -26,20 +29,14 @@ function isAllowedEmailDomain(email, allowedDomains) {
   return allowedDomains.includes(domain);
 }
 
-let clientPromise = null;
-function getClient() {
-  if (!clientPromise) {
-    clientPromise = Issuer.discover(config.oidc.issuer).then(
-      (issuer) =>
-        new issuer.Client({
-          client_id: config.oidc.clientId,
-          client_secret: config.oidc.clientSecret,
-          redirect_uris: [config.oidc.redirectUri],
-          response_types: ["code"],
-        })
-    );
+// Discovery result (a Configuration) replaces v5's Client instance — every call
+// site below takes it as the first argument instead of calling methods on it.
+let configPromise = null;
+function getOidcConfig() {
+  if (!configPromise) {
+    configPromise = discovery(new URL(config.oidc.issuer), config.oidc.clientId, config.oidc.clientSecret);
   }
-  return clientPromise;
+  return configPromise;
 }
 
 function requireOidcMode(req, res, next) {
@@ -49,10 +46,10 @@ function requireOidcMode(req, res, next) {
 
 router.get("/login", requireOidcMode, async (req, res, next) => {
   try {
-    const client = await getClient();
-    const code_verifier = generators.codeVerifier();
-    const code_challenge = generators.codeChallenge(code_verifier);
-    const state = generators.state();
+    const oidcConfig = await getOidcConfig();
+    const code_verifier = randomPKCECodeVerifier();
+    const code_challenge = await calculatePKCECodeChallenge(code_verifier);
+    const state = randomState();
     const pending = await new SignJWT({ state, code_verifier })
       .setProtectedHeader({ alg: "HS256" })
       .setExpirationTime("10m")
@@ -63,14 +60,14 @@ router.get("/login", requireOidcMode, async (req, res, next) => {
       sameSite: "lax",
       maxAge: 10 * 60 * 1000,
     });
-    res.redirect(
-      client.authorizationUrl({
-        scope: "openid email profile",
-        state,
-        code_challenge,
-        code_challenge_method: "S256",
-      })
-    );
+    const authUrl = buildAuthorizationUrl(oidcConfig, {
+      redirect_uri: config.oidc.redirectUri,
+      scope: "openid email profile",
+      state,
+      code_challenge,
+      code_challenge_method: "S256",
+    });
+    res.redirect(authUrl.href);
   } catch (err) {
     next(err);
   }
@@ -83,17 +80,23 @@ router.get("/callback", requireOidcMode, async (req, res, next) => {
     res.clearCookie(PENDING_COOKIE);
     const { payload } = await jwtVerify(raw, pendingSecret);
 
-    const client = await getClient();
-    const params = client.callbackParams(req);
-    if (params.state !== payload.state) {
+    // Checked explicitly (not just via authorizationCodeGrant's own expectedState
+    // check below) so a mismatch gets this specific message rather than whatever
+    // generic error the library throws for it.
+    if (req.query.state !== payload.state) {
       return res.status(400).send("Login state mismatch — please try signing in again.");
     }
-    const tokenSet = await client.callback(config.oidc.redirectUri, params, {
-      code_verifier: payload.code_verifier,
-      state: payload.state,
+
+    const oidcConfig = await getOidcConfig();
+    const currentUrl = new URL(req.originalUrl, `${req.protocol}://${req.get("host")}`);
+    const tokens = await authorizationCodeGrant(oidcConfig, currentUrl, {
+      pkceCodeVerifier: payload.code_verifier,
+      expectedState: payload.state,
+    }, {
+      redirect_uri: config.oidc.redirectUri,
     });
-    const claims = tokenSet.claims();
-    if (!claims.email) {
+    const claims = tokens.claims();
+    if (!claims || !claims.email) {
       return res.status(400).send("Your identity provider did not return an email claim.");
     }
     const email = String(claims.email).toLowerCase();

--- a/server/test/integration/oidcLogin.test.js
+++ b/server/test/integration/oidcLogin.test.js
@@ -1,0 +1,199 @@
+"use strict";
+// End-to-end check of the OIDC login/callback flow against openid-client v6's
+// functional API (discovery/buildAuthorizationUrl/authorizationCodeGrant),
+// migrated from the v5 Issuer/Client class API that v6 removed (the removal is
+// exactly what broke /api/auth/login in production: `Cannot read properties of
+// undefined (reading 'discover')`). Runs against a small fake OIDC provider (an
+// https server, self-signed cert, implementing discovery + token endpoints)
+// rather than a real IdP, so this is deterministic and offline, but it
+// exercises the REAL openid-client functions end-to-end, not a mock of them.
+//
+// HTTPS (not plain http) is deliberate: oauth4webapi (which openid-client v6
+// wraps) refuses http:// issuers by default — correctly, since every real IdP
+// (Okta/Auth0/Google Workspace/Keycloak) is HTTPS. Loosening that in
+// oidc.js just to make this fake IDP easier to stand up would weaken
+// production auth code for the sake of a test, so the self-signed cert (and
+// NODE_TLS_REJECT_UNAUTHORIZED=0, scoped to this test file's own process —
+// `node --test` isolates each file in its own worker) lives entirely here.
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+const https = require("node:https");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+const mongoose = require("mongoose");
+const express = require("express");
+const cookieParser = require("cookie-parser");
+const supertest = require("supertest");
+const { SignJWT } = require("jose");
+
+const CLIENT_ID = "test-client";
+const CLIENT_SECRET = "test-secret-at-least-32-bytes-long!!";
+const REDIRECT_URI = "http://localhost/api/auth/callback";
+const USER_EMAIL = "alice@gyde.ai";
+const USER_SUB = "fake-idp-subject-123";
+
+let fakeIdp, fakeIdpUrl, mongod, agent, origTlsReject;
+
+function generateSelfSignedCert() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "arbr-oidc-test-cert-"));
+  const keyPath = path.join(dir, "key.pem");
+  const certPath = path.join(dir, "cert.pem");
+  execFileSync("openssl", [
+    "req", "-x509", "-newkey", "rsa:2048", "-keyout", keyPath, "-out", certPath,
+    "-days", "1", "-nodes", "-subj", "/CN=127.0.0.1",
+  ]);
+  return { key: fs.readFileSync(keyPath), cert: fs.readFileSync(certPath) };
+}
+
+// Minimal OIDC provider: discovery doc + a token endpoint that always returns a
+// valid, freshly-signed ID token — enough for openid-client's real discovery()
+// and authorizationCodeGrant() to run against, without a real browser consent
+// step (the fake token endpoint doesn't need to validate the authorization
+// code's authenticity for this test; it's standing in for the whole IdP).
+function startFakeIdp() {
+  const { key, cert } = generateSelfSignedCert();
+  return new Promise((resolve) => {
+    const server = https.createServer({ key, cert }, async (req, res) => {
+      const url = new URL(req.url, `https://${req.headers.host}`);
+      if (url.pathname === "/.well-known/openid-configuration") {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({
+          issuer: fakeIdpUrl,
+          authorization_endpoint: `${fakeIdpUrl}/authorize`,
+          token_endpoint: `${fakeIdpUrl}/token`,
+          jwks_uri: `${fakeIdpUrl}/jwks`,
+          response_types_supported: ["code"],
+          subject_types_supported: ["public"],
+          id_token_signing_alg_values_supported: ["HS256"],
+          code_challenge_methods_supported: ["S256"],
+          token_endpoint_auth_methods_supported: ["client_secret_post"],
+        }));
+        return;
+      }
+      if (url.pathname === "/token" && req.method === "POST") {
+        const idToken = await new SignJWT({ email: USER_EMAIL })
+          .setProtectedHeader({ alg: "HS256" })
+          .setIssuedAt()
+          .setIssuer(fakeIdpUrl)
+          .setAudience(CLIENT_ID)
+          .setSubject(USER_SUB)
+          .setExpirationTime("5m")
+          .sign(new TextEncoder().encode(CLIENT_SECRET));
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({
+          access_token: "fake-access-token",
+          token_type: "Bearer",
+          expires_in: 3600,
+          id_token: idToken,
+        }));
+        return;
+      }
+      res.writeHead(404); res.end();
+    });
+    server.listen(0, "127.0.0.1", () => {
+      fakeIdpUrl = `https://127.0.0.1:${server.address().port}`;
+      resolve(server);
+    });
+  });
+}
+
+const buildApp = () => {
+  const a = express();
+  a.use(cookieParser());
+  a.use("/api/auth", require("../../src/api/authProviders/oidc"));
+  // eslint-disable-next-line no-unused-vars
+  a.use((err, _req, res, _next) => res.status(500).json({ error: "internal_error", message: err.message }));
+  return a;
+};
+
+before(async () => {
+  origTlsReject = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"; // self-signed fake IDP cert only
+  fakeIdp = await startFakeIdp();
+  process.env.ARBR_AUTH_MODE = "oidc";
+  process.env.ARBR_OIDC_ISSUER = fakeIdpUrl;
+  process.env.ARBR_OIDC_CLIENT_ID = CLIENT_ID;
+  process.env.ARBR_OIDC_CLIENT_SECRET = CLIENT_SECRET;
+  process.env.ARBR_OIDC_REDIRECT_URI = REDIRECT_URI;
+  delete require.cache[require.resolve("../../src/config")];
+  delete require.cache[require.resolve("../../src/api/authProviders/oidc")];
+
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  agent = supertest(buildApp());
+});
+
+after(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+  await new Promise((resolve) => fakeIdp.close(resolve));
+  if (origTlsReject === undefined) delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+  else process.env.NODE_TLS_REJECT_UNAUTHORIZED = origTlsReject;
+});
+
+const User = require("../../src/models/User");
+const Session = require("../../src/models/Session");
+beforeEach(async () => { await Promise.all([User.deleteMany({}), Session.deleteMany({})]); });
+
+test("GET /login performs real discovery and redirects to the IdP's authorization endpoint", async () => {
+  const res = await agent.get("/api/auth/login");
+  assert.equal(res.status, 302);
+  const location = new URL(res.headers.location);
+  assert.equal(location.origin, fakeIdpUrl);
+  assert.equal(location.pathname, "/authorize");
+  assert.equal(location.searchParams.get("client_id"), CLIENT_ID);
+  assert.equal(location.searchParams.get("redirect_uri"), REDIRECT_URI);
+  assert.equal(location.searchParams.get("code_challenge_method"), "S256");
+  assert.ok(location.searchParams.get("state"), "expected a state param");
+  assert.ok(location.searchParams.get("code_challenge"), "expected a PKCE code_challenge");
+
+  const pendingCookie = res.headers["set-cookie"].find((c) => c.startsWith("arbr_oidc_pending="));
+  assert.ok(pendingCookie, "expected the pending-auth cookie to be set");
+});
+
+test("GET /callback exchanges the code via the real token endpoint and creates a session", async () => {
+  const loginRes = await agent.get("/api/auth/login");
+  const location = new URL(loginRes.headers.location);
+  const state = location.searchParams.get("state");
+  const pendingCookie = loginRes.headers["set-cookie"].find((c) => c.startsWith("arbr_oidc_pending="));
+
+  const callbackRes = await agent
+    .get("/api/auth/callback")
+    .set("Cookie", pendingCookie.split(";")[0])
+    .query({ code: "fake-authorization-code", state });
+
+  assert.equal(callbackRes.status, 302);
+  assert.equal(callbackRes.headers.location, "/");
+
+  const sessionCookie = callbackRes.headers["set-cookie"].find((c) => c.startsWith("arbr_session="));
+  assert.ok(sessionCookie, "expected a session cookie to be set");
+
+  const user = await User.findOne({ email: USER_EMAIL });
+  assert.ok(user, "expected a user to be created from the ID token's email claim");
+  assert.equal(user.oidcSubject, USER_SUB);
+
+  const sessionCount = await Session.countDocuments({ userId: user._id });
+  assert.equal(sessionCount, 1);
+});
+
+test("GET /callback rejects a state that doesn't match the pending cookie", async () => {
+  const loginRes = await agent.get("/api/auth/login");
+  const pendingCookie = loginRes.headers["set-cookie"].find((c) => c.startsWith("arbr_oidc_pending="));
+
+  const res = await agent
+    .get("/api/auth/callback")
+    .set("Cookie", pendingCookie.split(";")[0])
+    .query({ code: "fake-authorization-code", state: "wrong-state" });
+
+  assert.equal(res.status, 400);
+  assert.match(res.text, /state mismatch/i);
+});
+
+test("GET /callback without a pending cookie fails cleanly instead of crashing", async () => {
+  const res = await agent.get("/api/auth/callback").query({ code: "x", state: "y" });
+  assert.equal(res.status, 400);
+  assert.match(res.text, /expired/i);
+});


### PR DESCRIPTION
## Summary

Production bug on arbr.gyde.ai: every request to `/api/auth/login` returned `{"error":"internal_error","message":"Cannot read properties of undefined (reading 'discover')"}`.

**Root cause:** a Dependabot PR bumped `openid-client` from `5.7.1` to `6.8.4` (bundled together with unrelated minor bumps to mongoose/jose/opentelemetry). v6 is a major version that removed the entire class-based `Issuer`/`Client` API in favor of a functional one — `server/src/api/authProviders/oidc.js` was never updated to match, so `Issuer` destructured to `undefined` at require time and `Issuer.discover(...)` threw on every single call, regardless of whether `ARBR_OIDC_*` env vars were configured correctly. Not an environment/config issue — a real code bug that's been live since that dependency bump merged.

**Migration** (`oidc.js`):
- `Issuer.discover(issuer)` + `new issuer.Client(...)` → `discovery(issuer, clientId, clientSecret)`
- `generators.codeVerifier/codeChallenge/state` → `randomPKCECodeVerifier`/`calculatePKCECodeChallenge` (now **async**)/`randomState`
- `client.authorizationUrl(...)` → `buildAuthorizationUrl(config, params)`
- `client.callback(redirectUri, params, checks)` → `authorizationCodeGrant(config, currentUrl, checks, tokenEndpointParameters)`

All route logic (state-mismatch handling, allowed-domain check, user/session creation) is unchanged — only the token-fetching mechanism itself was migrated.

## Verification

Didn't stop at "it compiles" given this is production auth:
- `discovery()` and `buildAuthorizationUrl()` checked directly against Google's real OIDC discovery endpoint (real network call, real IdP, not a mock).
- Added `server/test/integration/oidcLogin.test.js` — a full login+callback round trip against a **self-signed-HTTPS** fake OIDC provider. HTTPS is deliberate: `oauth4webapi` (which v6 wraps) correctly refuses `http://` issuers by default, and loosening that in production code just to make a fake test IDP easier to stand up would weaken real auth security for no reason — so the self-signed cert (and `NODE_TLS_REJECT_UNAUTHORIZED=0`, scoped to this test file's own `node --test` worker process) lives entirely in the test. Covers: discovery, the redirect URL's exact query params, the real token-endpoint exchange, user/session creation from ID token claims, and both failure paths (state mismatch, expired/missing pending cookie).
- Full server suite: **456/456 tests pass** (unit + integration).

## Test plan
- [x] `MONGOMS_VERSION=7.0.14 npm run test:server` — 456/456 pass
- [x] Manually verified `discovery()`/`buildAuthorizationUrl()` against Google's real endpoint
- [ ] Recommend a live smoke test against arbr.gyde.ai's actual configured IdP after deploy, given this is the exact path that was broken in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)