### PR TITLE
fix(routing): stop silently discarding the configured default model

### DIFF
--- a/server/src/gateway/explain.js
+++ b/server/src/gateway/explain.js
@@ -1,0 +1,18 @@
+// Helpers for the routing "why" record (RequestRecord.routingExplain).
+//
+// Overrides chain: a model swapped in by the allowed-set check can itself be
+// opted out, a budget cap can downgrade whatever routing chose, and a failure can
+// then move it again. A single `override` field kept only the last of those, so
+// every earlier step vanished from the request detail and a model nobody asked for
+// appeared with nothing explaining how it got there.
+//
+// `overrides` is the full ordered chain. `override` is kept pointing at the last
+// entry so records written before this change, the OTel attributes, and any other
+// existing reader keep working untouched.
+function pushOverride(explain, ov) {
+  if (!explain) return;
+  (explain.overrides = explain.overrides || []).push(ov);
+  explain.override = ov;
+}
+
+module.exports = { pushOverride };

--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -26,6 +26,7 @@ const logger = require("../logging/logger");
 const Settings = require("../models/Settings");
 const ApplicationConfig = require("../models/ApplicationConfig");
 const { createBoundedTtlCache } = require("../utils/boundedTtlCache");
+const { pushOverride } = require("./explain");
 
 // Short-lived cache to avoid a DB hit per request for app configs.
 //
@@ -234,7 +235,7 @@ async function resolveRoute(body, { router, eff, application, workflow, userId =
           evalRunId: canary.experiment.evalRunId ? String(canary.experiment.evalRunId) : null,
           fromModel: served.model, toModel: canary.toModel, rolloutPct: canary.experiment.rolloutPct,
         };
-        explain.override = { type: "canary", from: served.model, to: canary.toModel };
+        pushOverride(explain, { type: "canary", from: served.model, to: canary.toModel });
         served = { provider, model: canary.toModel };
         routingDecision = "canary";
       }
@@ -250,7 +251,7 @@ async function resolveRoute(body, { router, eff, application, workflow, userId =
   if (appConfig.allowedModels?.length > 0 && !appConfig.allowedModels.includes(served.model)) {
     const fallbackKnown = appConfig.defaultModel ? pricing.getModel(appConfig.defaultModel) : null;
     if (fallbackKnown && eff.liveIds.includes(fallbackKnown.provider)) {
-      explain.override = { type: "allowed", from: served.model, to: appConfig.defaultModel };
+      pushOverride(explain, { type: "allowed", from: served.model, to: appConfig.defaultModel });
       served = { provider: fallbackKnown.provider, model: appConfig.defaultModel, knownPricing: true };
       routingDecision = "passthrough";
     } else {
@@ -266,10 +267,20 @@ async function resolveRoute(body, { router, eff, application, workflow, userId =
   if (appDbConfig?.modelOptOut?.length > 0 && appDbConfig.modelOptOut.includes(served.model)) {
     const fallback = resolveDefault(body, eff);
     if (!appDbConfig.modelOptOut.includes(fallback.model)) {
-      explain.override = { type: "optout", from: served.model, to: fallback.model };
+      pushOverride(explain, { type: "optout", from: served.model, to: fallback.model });
       served = fallback;
       routingDecision = "passthrough";
     }
+  }
+
+  // The opt-out fallback resolves from the GLOBAL defaults, which know nothing about
+  // this key's allowed set, so it can land back on the very model the allowed-check
+  // just rejected (allowed → key default → opted out → global default). That used to
+  // pass silently, so a key restricted to one model could still be served another.
+  // Serving is preserved deliberately, so a policy conflict never breaks live traffic,
+  // but the violation is recorded and the dashboard flags it.
+  if (appConfig.allowedModels?.length > 0 && !appConfig.allowedModels.includes(served.model)) {
+    explain.allowedViolation = { model: served.model, allowed: appConfig.allowedModels };
   }
 
   // qualityGate: only set when a human-approved rule (or canary promote path) chose the model.
@@ -385,8 +396,8 @@ async function handleChat(req, res) {
   const enf = await capEngine.enforcement({ application: meta.application, provider: served.provider });
   if (enf) {
     if (enf.action === "block") {
-      explain.override = { type: "budget", action: "block",
-        cap: { scope: capEngine.describeScope(enf.cap), period: enf.cap.period, limit: enf.cap.limit } };
+      pushOverride(explain, { type: "budget", action: "block",
+        cap: { scope: capEngine.describeScope(enf.cap), period: enf.cap.period, limit: enf.cap.limit } });
       setImmediate(() =>
         logger.write({
           requestId, timestamp, ...meta,
@@ -403,8 +414,8 @@ async function handleChat(req, res) {
     // downgrade
     const target = pricing.suggestLightTarget(served.model);
     if (target) {
-      explain.override = { type: "budget", action: "downgrade", from: served.model, to: target.model,
-        cap: { scope: capEngine.describeScope(enf.cap), period: enf.cap.period, limit: enf.cap.limit } };
+      pushOverride(explain, { type: "budget", action: "downgrade", from: served.model, to: target.model,
+        cap: { scope: capEngine.describeScope(enf.cap), period: enf.cap.period, limit: enf.cap.limit } });
       served = { provider: target.provider, model: target.model };
       routingDecision = "budget";
       qualityGate = null; // budget override is not eval-gated
@@ -550,7 +561,7 @@ async function handleChat(req, res) {
   const { result, usedFallback } = invocation;
   if (usedFallback) {
     routingDecision = "fallback";
-    explain.override = { type: "fallback", from: served.model, to: result.modelId };
+    pushOverride(explain, { type: "fallback", from: served.model, to: result.modelId });
     qualityGate = null;
   }
 

--- a/server/src/gateway/openaiCompat.js
+++ b/server/src/gateway/openaiCompat.js
@@ -16,6 +16,7 @@ const { PROVIDERS } = require("../config");
 const Settings = require("../models/Settings");
 const outputGuardrail = require("./outputGuardrail");
 const promptInjection = require("./promptInjection");
+const { pushOverride } = require("./explain");
 
 // Providers whose wire protocol IS the OpenAI chat API. For these we transparently proxy the
 // raw request/response (preserving tools, tool_calls, vision content, response_format, and
@@ -395,8 +396,8 @@ async function handleOpenAICompat(req, res) {
     }
     const target = pricing.suggestLightTarget(served.model);
     if (target) {
-      if (explain) explain.override = { type: "budget", action: "downgrade", from: served.model, to: target.model,
-        cap: { scope: capEngine.describeScope(enf.cap), period: enf.cap.period, limit: enf.cap.limit } };
+      pushOverride(explain, { type: "budget", action: "downgrade", from: served.model, to: target.model,
+        cap: { scope: capEngine.describeScope(enf.cap), period: enf.cap.period, limit: enf.cap.limit } });
       served = { provider: target.provider, model: target.model }; routingDecision = "budget";
       qualityGate = null;
     }
@@ -675,7 +676,7 @@ async function handleOpenAICompat(req, res) {
     }
 
     const { result, usedFallback } = invocation;
-    if (usedFallback) { routingDecision = "fallback"; qualityGate = null; if (explain) explain.override = { type: "fallback", from: served.model, to: result.modelId }; }
+    if (usedFallback) { routingDecision = "fallback"; qualityGate = null; pushOverride(explain, { type: "fallback", from: served.model, to: result.modelId }); }
 
     const promptTokens = result.usage?.inputTokens || 0;
     const completionTokens = result.usage?.outputTokens || 0;
@@ -773,7 +774,7 @@ async function handleOpenAICompat(req, res) {
   }
 
   const { result, usedFallback } = invocation;
-  if (usedFallback) { routingDecision = "fallback"; qualityGate = null; if (explain) explain.override = { type: "fallback", from: served.model, to: result.modelId }; }
+  if (usedFallback) { routingDecision = "fallback"; qualityGate = null; pushOverride(explain, { type: "fallback", from: served.model, to: result.modelId }); }
 
   if (settings.outputGuardrailsEnabled && settings.outputGuardrailRules?.length) {
     const { blocked, ruleName } = outputGuardrail.check(result.text, settings.outputGuardrailRules, meta.application);

--- a/server/src/pricing/registry.js
+++ b/server/src/pricing/registry.js
@@ -59,6 +59,25 @@ async function init() {
   }
   await _load();
   console.log(`[registry] ${Object.keys(_cache).length} models loaded`);
+  startAutoRefresh();
+}
+
+// reload() only refreshes the process that served the write. On a multi-replica
+// deploy every other replica kept a cache from boot forever, so a model imported
+// or enabled elsewhere stayed invisible to getModel() until restart — which then
+// silently downgraded anything resolved through it, like the default model. The
+// accessors are synchronous (hot path), so the refresh runs on a timer instead.
+const REFRESH_MS = Number(process.env.ARBR_REGISTRY_REFRESH_MS) || 60_000;
+let _timer = null;
+function startAutoRefresh(ms = REFRESH_MS) {
+  if (_timer || !(ms > 0)) return;
+  _timer = setInterval(() => {
+    _load().catch((e) => console.warn("[registry] background refresh failed:", e.message));
+  }, ms);
+  if (_timer.unref) _timer.unref();
+}
+function stopAutoRefresh() {
+  if (_timer) { clearInterval(_timer); _timer = null; }
 }
 
 // Call after any write to /api/models to keep cache current.
@@ -125,6 +144,8 @@ module.exports = {
   // Lifecycle
   init,
   reload,
+  startAutoRefresh,
+  stopAutoRefresh,
   // Sync accessors
   getModel,
   listModels,

--- a/server/src/providers/connections.js
+++ b/server/src/providers/connections.js
@@ -21,6 +21,48 @@ const TTL_MS = 3000;
 let _cache = { value: null, at: 0 };
 function invalidate() { _cache.at = 0; }
 
+// effective() recomputes every few seconds, so warn at most once a minute per
+// distinct problem. Silence here is what made the fallback so hard to diagnose.
+const WARN_EVERY_MS = 60_000;
+const _warned = new Map(); // signature → last logged at
+function warnDiscardedDefault(issue) {
+  const sig = `${issue.configured}|${issue.defaultProvider}|${issue.reason}`;
+  const last = _warned.get(sig) || 0;
+  if (Date.now() - last < WARN_EVERY_MS) return;
+  _warned.set(sig, Date.now());
+  const detail = issue.reason === "provider-mismatch"
+    ? `it belongs to provider "${issue.modelProvider}", not the default provider "${issue.defaultProvider}"`
+    : `it is not in this instance's model registry (disabled, never synced, or the registry cache is stale)`;
+  console.warn(
+    `[connections] default model "${issue.configured}" is being ignored because ${detail}. ` +
+    `Serving "${issue.serving}" instead. Fix it in Settings, or run Sync Models.`
+  );
+}
+
+// Decide which model the default provider actually serves, and report when the
+// operator's configured choice cannot be honored. The fallback itself is not the
+// bug — serving the provider's built-in default is reasonable — but doing it
+// silently is, so the caller gets an `issue` to log and surface. Pure; exported
+// for tests.
+function decideDefaultModel({ configured, defaultProvider, lookup, providerDefaults }) {
+  const fallback = defaultProvider ? providerDefaults[defaultProvider] || null : null;
+  if (!configured) return { defaultModel: fallback, issue: null };
+  const m = lookup(configured);
+  if (m && m.provider === defaultProvider) return { defaultModel: configured, issue: null };
+  return {
+    defaultModel: fallback,
+    issue: {
+      configured,
+      serving: fallback,
+      defaultProvider,
+      // not-in-registry usually means the model is disabled, was never synced, or
+      // this replica's registry cache predates the import.
+      reason: m ? "provider-mismatch" : "not-in-registry",
+      modelProvider: m ? m.provider : null,
+    },
+  };
+}
+
 // Decrypt a stored credential doc into a credential object. Handles the legacy
 // shape where the ciphertext was a bare API-key string.
 function decodeStored(doc) {
@@ -85,13 +127,23 @@ async function compute() {
 
   // The chosen default model applies to the default provider; otherwise that
   // provider's built-in default. Falls back if the stored choice no longer fits.
-  let defaultModel = defaultProvider ? DEFAULT_MODELS[defaultProvider] : null;
-  if (settings.defaultModel) {
-    const m = pricing.getModel(settings.defaultModel);
-    if (m && m.provider === defaultProvider) defaultModel = settings.defaultModel;
-  }
+  //
+  // A fallback used to happen silently: the operator saw their model in Settings
+  // while the gateway served the provider's hardcoded default, with nothing
+  // anywhere saying so. The mismatch is now reported (defaultModelIssue) and
+  // logged, so it is visible instead of being inferred from odd routing.
+  const { defaultModel, issue: defaultModelIssue } = decideDefaultModel({
+    configured: settings.defaultModel,
+    defaultProvider,
+    lookup: (id) => pricing.getModel(id),
+    providerDefaults: DEFAULT_MODELS,
+  });
+  if (defaultModelIssue) warnDiscardedDefault(defaultModelIssue);
 
-  return { providers, liveIds, demoMode: liveIds.length === 0, defaultProvider, defaultModel };
+  return {
+    providers, liveIds, demoMode: liveIds.length === 0,
+    defaultProvider, defaultModel, defaultModelIssue,
+  };
 }
 
 async function effective() {
@@ -142,7 +194,10 @@ async function statuses() {
   return {
     providers: list,
     defaultProvider: eff.defaultProvider,
+    // The model actually served. When it differs from what was configured,
+    // defaultModelIssue explains why so the dashboard can say so out loud.
     defaultModel: eff.defaultModel,
+    defaultModelIssue: eff.defaultModelIssue || null,
     settingsDefault: settings.defaultProvider || null,
     demoMode: eff.demoMode,
   };
@@ -189,7 +244,23 @@ async function setDefaultProvider(provider) {
 }
 
 async function setDefaultModel(model) {
-  if (model != null && !pricing.getModel(model)) throw new Error(`unknown model "${model}"`);
+  if (model != null) {
+    const m = pricing.getModel(model);
+    if (!m) throw new Error(`unknown model "${model}"`);
+    // Reject a model the gateway would then refuse to use. Without this the save
+    // succeeds, Settings shows the model, and requests quietly get the provider's
+    // built-in default instead.
+    const { defaultProvider } = await effective();
+    if (defaultProvider && m.provider !== defaultProvider) {
+      throw Object.assign(
+        new Error(
+          `Model "${model}" belongs to provider "${m.provider}", but the default provider is ` +
+          `"${defaultProvider}". Change the default provider first, or pick a model from "${defaultProvider}".`
+        ),
+        { code: "default_model_provider_mismatch", status: 400 }
+      );
+    }
+  }
   const s = await Settings.get();
   s.defaultModel = model || null;
   await s.save();
@@ -199,4 +270,5 @@ async function setDefaultModel(model) {
 module.exports = {
   effective, statuses, setCredential, removeCredential, setDefaultProvider, setDefaultModel, invalidate,
   KNOWN: KNOWN_PROVIDERS,
+  decideDefaultModel, // pure, exported for tests
 };

--- a/server/test/unit/defaultModelResolution.test.js
+++ b/server/test/unit/defaultModelResolution.test.js
@@ -1,0 +1,92 @@
+"use strict";
+// Regression tests for the silent default-model swap.
+//
+// Reported symptom: Settings showed a default of moonshotai.kimi-k2.5 on
+// bedrock-nova, but the gateway served us.amazon.nova-lite-v1:0 — the provider's
+// hardcoded built-in default — with nothing logged or surfaced anywhere.
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { decideDefaultModel } = require("../../src/providers/connections");
+const { pushOverride } = require("../../src/gateway/explain");
+
+const PROVIDER_DEFAULTS = {
+  "bedrock-nova": "us.amazon.nova-lite-v1:0",
+  openai: "gpt-4o-mini",
+  moonshot: "moonshot-v1-8k",
+};
+const lookupFrom = (byId) => (id) => byId[id] || null;
+
+test("a configured model on the default provider is honored", () => {
+  const r = decideDefaultModel({
+    configured: "moonshotai.kimi-k2.5",
+    defaultProvider: "bedrock-nova",
+    lookup: lookupFrom({ "moonshotai.kimi-k2.5": { provider: "bedrock-nova" } }),
+    providerDefaults: PROVIDER_DEFAULTS,
+  });
+  assert.equal(r.defaultModel, "moonshotai.kimi-k2.5");
+  assert.equal(r.issue, null);
+});
+
+test("a model missing from the registry falls back BUT reports why", () => {
+  const r = decideDefaultModel({
+    configured: "moonshotai.kimi-k2.5",
+    defaultProvider: "bedrock-nova",
+    lookup: lookupFrom({}), // disabled, unsynced, or a stale replica cache
+    providerDefaults: PROVIDER_DEFAULTS,
+  });
+  assert.equal(r.defaultModel, "us.amazon.nova-lite-v1:0");
+  assert.equal(r.issue.reason, "not-in-registry");
+  assert.equal(r.issue.configured, "moonshotai.kimi-k2.5");
+  assert.equal(r.issue.serving, "us.amazon.nova-lite-v1:0", "the issue must name what is actually served");
+});
+
+test("a model belonging to another provider falls back BUT reports why", () => {
+  const r = decideDefaultModel({
+    configured: "moonshotai.kimi-k2.5",
+    defaultProvider: "bedrock-nova",
+    lookup: lookupFrom({ "moonshotai.kimi-k2.5": { provider: "moonshot" } }),
+    providerDefaults: PROVIDER_DEFAULTS,
+  });
+  assert.equal(r.defaultModel, "us.amazon.nova-lite-v1:0");
+  assert.equal(r.issue.reason, "provider-mismatch");
+  assert.equal(r.issue.modelProvider, "moonshot");
+});
+
+test("no configured default is not an issue, just the provider default", () => {
+  const r = decideDefaultModel({
+    configured: null,
+    defaultProvider: "bedrock-nova",
+    lookup: lookupFrom({}),
+    providerDefaults: PROVIDER_DEFAULTS,
+  });
+  assert.equal(r.defaultModel, "us.amazon.nova-lite-v1:0");
+  assert.equal(r.issue, null, "an unset default is normal, not a misconfiguration");
+});
+
+test("an unknown provider yields no model rather than throwing", () => {
+  const r = decideDefaultModel({
+    configured: null,
+    defaultProvider: "nope",
+    lookup: lookupFrom({}),
+    providerDefaults: PROVIDER_DEFAULTS,
+  });
+  assert.equal(r.defaultModel, null);
+});
+
+// The reported request showed only "gpt-4o-mini is opted out…", with no trace of
+// the allowed-set swap that introduced gpt-4o-mini in the first place.
+test("pushOverride keeps the whole chain, not just the last step", () => {
+  const explain = {};
+  pushOverride(explain, { type: "allowed", from: "us.amazon.nova-lite-v1:0", to: "gpt-4o-mini" });
+  pushOverride(explain, { type: "optout", from: "gpt-4o-mini", to: "us.amazon.nova-lite-v1:0" });
+
+  assert.equal(explain.overrides.length, 2);
+  assert.equal(explain.overrides[0].type, "allowed");
+  assert.equal(explain.overrides[1].type, "optout");
+  // Back-compat: existing readers (OTel attributes, older records) use `override`.
+  assert.equal(explain.override.type, "optout");
+});
+
+test("pushOverride tolerates a missing explain object", () => {
+  assert.doesNotThrow(() => pushOverride(null, { type: "fallback" }));
+});

--- a/web/src/components/RequestsTable.jsx
+++ b/web/src/components/RequestsTable.jsx
@@ -61,17 +61,28 @@ function explainRouting(r) {
       : `No model was pinned and no rule or policy matched, so Arbr served the default model, ${r.model}.`);
   }
 
-  const ov = x.override;
-  if (ov?.type === "budget" && ov.action === "downgrade") {
-    lines.push(`Budget override: cap "${ov.cap?.scope}" (${ov.cap?.period}, $${ov.cap?.limit}) was over limit, so ${ov.from} was downgraded to ${ov.to}.`);
-  } else if (ov?.type === "budget" && ov.action === "block") {
-    lines.push(`Budget cap "${ov.cap?.scope}" (${ov.cap?.period}, $${ov.cap?.limit}) was over limit; the request was blocked.`);
-  } else if (ov?.type === "fallback") {
-    lines.push(`Fallback: ${ov.from} failed, so Arbr retried on ${ov.to}.`);
-  } else if (ov?.type === "allowed") {
-    lines.push(`${ov.from} is not in this API key's allowed-model set, so Arbr served the key's default, ${ov.to}.`);
-  } else if (ov?.type === "optout") {
-    lines.push(`${ov.from} is opted out for this application, so Arbr served ${ov.to} instead.`);
+  // Overrides chain. Older records carry only the single `override`; newer ones
+  // carry the whole ordered `overrides`. Narrating every step is what makes a
+  // model the caller never asked for traceable back to the rule that picked it.
+  const chain = x.overrides?.length ? x.overrides : (x.override ? [x.override] : []);
+  for (const ov of chain) {
+    if (ov?.type === "budget" && ov.action === "downgrade") {
+      lines.push(`Budget override: cap "${ov.cap?.scope}" (${ov.cap?.period}, $${ov.cap?.limit}) was over limit, so ${ov.from} was downgraded to ${ov.to}.`);
+    } else if (ov?.type === "budget" && ov.action === "block") {
+      lines.push(`Budget cap "${ov.cap?.scope}" (${ov.cap?.period}, $${ov.cap?.limit}) was over limit; the request was blocked.`);
+    } else if (ov?.type === "fallback") {
+      lines.push(`Fallback: ${ov.from} failed, so Arbr retried on ${ov.to}.`);
+    } else if (ov?.type === "allowed") {
+      lines.push(`${ov.from} is not in this API key's allowed-model set, so Arbr served the key's default, ${ov.to}.`);
+    } else if (ov?.type === "optout") {
+      lines.push(`${ov.from} is opted out for this application, so Arbr served ${ov.to} instead.`);
+    } else if (ov?.type === "canary") {
+      lines.push(`A canary experiment routed this from ${ov.from} to ${ov.to}.`);
+    }
+  }
+
+  if (x.allowedViolation) {
+    lines.push(`Warning: ${x.allowedViolation.model} was served even though it is not in this key's allowed-model set (${(x.allowedViolation.allowed || []).join(", ")}). The opt-out fallback resolves from the global default, which does not know about the key's allowed set. Narrow the opt-out list or set an allowed key default so the two cannot disagree.`);
   }
 
   if (x.classificationUsed === false && r.taskType && (d === "explicit" || d === "passthrough" || d === "cache")) {

--- a/web/src/pages/Settings.jsx
+++ b/web/src/pages/Settings.jsx
@@ -365,6 +365,24 @@ export default function Settings({ onChange }) {
                 </select>
               </div>
             </div>
+            {/* The saved model is not always the served one. Saying so here is the
+                difference between a five-minute fix and hunting through routing. */}
+            {data.defaultModelIssue && (
+              <div className="mt-4 rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
+                <div className="font-medium">Your saved default model is not being used.</div>
+                <div className="mt-1">
+                  <span className="font-mono">{data.defaultModelIssue.configured}</span>{" "}
+                  {data.defaultModelIssue.reason === "provider-mismatch" ? (
+                    <>belongs to provider <span className="font-mono">{data.defaultModelIssue.modelProvider}</span>, not the
+                    default provider <span className="font-mono">{data.defaultModelIssue.defaultProvider}</span>.</>
+                  ) : (
+                    <>is not in this instance&apos;s model registry. It may be disabled, never synced, or imported after this
+                    server last refreshed. Try <span className="font-medium">Sync Models</span> on the Models page.</>
+                  )}{" "}
+                  Requests are being served <span className="font-mono">{data.defaultModelIssue.serving}</span> instead.
+                </div>
+              </div>
+            )}
           </Card>
 
           <Card title="Security">


### PR DESCRIPTION
Diagnosed from a prod report: Settings showed a default of `moonshotai.kimi-k2.5` on Amazon Bedrock, but requests were served `us.amazon.nova-lite-v1:0`, and the request detail blamed a `gpt-4o-mini` nobody had asked for.

**Neither mystery model name came from any config.** Both are hardcoded built-in defaults — `bedrock-nova` → `us.amazon.nova-lite-v1:0`, `openai` → `gpt-4o-mini` ([config.js](server/src/config.js)). Three defects compounded.

## The observed request, step by step

| Step | Result |
|---|---|
| Resolve default | `nova-lite` ← **should have been kimi-k2.5** (bug 1) |
| Allowed-models check | not allowed → swap to key default `gpt-4o-mini` |
| Opt-out check | opted out → swap **back** to `nova-lite` (bug 2) |
| Narration | only the last override survived (bug 3) |

## 1. The configured default was silently discarded

`effective()` replaced the operator's default with the provider's built-in default whenever the model was missing from the registry or belonged to another provider — no log, no UI indication, Settings still showing the configured value.

The fallback is reasonable; the silence is not. The decision moves into a pure `decideDefaultModel()` that also returns an `issue`, now **logged** (rate-limited, since `effective()` recomputes every 3s) and **surfaced as a warning on the Settings page**. `setDefaultModel` now rejects a model that doesn't belong to the default provider, so the state can't be saved in the first place.

## 2. The allowed-models restriction failed open

The opt-out fallback resolves from the *global* default, which knows nothing about the key's allowed set — so it could land back on the model the allowed-check had just rejected. A key restricted to one model could be served another, silently.

Per the chosen fail mode, serving is **preserved** so a policy conflict never breaks live traffic, but the violation is recorded on the request and flagged in the dashboard.

## 3. The override chain overwrote itself

`explain.override` held a single override, so every step but the last vanished — which is exactly why `gpt-4o-mini` appeared unexplained. Overrides now append to `explain.overrides` across both gateways; `override` still points at the last entry so **older records and the OTel attributes are unaffected**.

## Also: registry cache refresh

`reload()` only refreshed the process that served the write. On a multi-replica deploy every other replica held its boot-time cache **indefinitely**, so a model imported elsewhere stayed invisible to `getModel()` until restart — the most likely trigger for (1). Added a background refresh (`ARBR_REGISTRY_REFRESH_MS`, default 60s); accessors stay synchronous on the hot path.

## Verification
- 7 new unit tests reproducing the exact reported scenario (kimi-k2.5 on bedrock-nova → nova-lite) for both `not-in-registry` and `provider-mismatch`, plus the override-chain back-compat
- Full unit suite 317/318; the one failure (`assertProductionReady`) is env-dependent and reproduces on clean `main`
- `npm run lint` 0 errors; `npm run web:build` compiles

## For the reporter
Restarting the control plane should restore kimi-k2.5 immediately if this was the stale registry cache. To confirm which sub-case you hit:
```js
db.modelentries.findOne({ id: "moonshotai.kimi-k2.5" }, { id:1, provider:1, enabled:1 })
```
After this change, either case says so out loud on the Settings page and in the logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)