### PR TITLE
docs(roadmap): correct stale Docker base image (node:20 → node:26-alpine)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ Want to help? Look for [`good first issue`][gfi] and [`help wanted`][hw] labels.
 
 ### Hardening & contributor experience
 Make the project safe and easy to contribute to: reproducible Docker builds (the current
-Dockerfile floats on `node:20-alpine` and runs `apk upgrade` at build time, so images
+Dockerfile floats on `node:26-alpine` and runs `apk upgrade` at build time, so images
 aren't byte-for-byte reproducible across builds).
 
 ### Observability


### PR DESCRIPTION
## What does this PR do?

`ROADMAP.md` (the "Hardening & contributor experience" theme) states that the Dockerfile "floats on `node:20-alpine`". That is no longer accurate: #203 bumped the base image to `node:26-alpine`, and both stages of the current `Dockerfile` now use `node:26-alpine`. `.github/dependabot.yml` also refers to `node:26-alpine`.

This updates the ROADMAP citation to `node:26-alpine`. The reproducibility point being made (the image floats on a tag and runs `apk upgrade`, so builds aren't byte-for-byte reproducible) is unchanged — only the version number is corrected.

Found during a scheduled documentation-accuracy audit.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] CI / build

## Checklist

- [ ] I've tested this locally with `npm run dev`
- [x] No API keys, `.env` values, or secrets are committed
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format (`feat:`, `fix:`, etc.)
- [x] I've updated docs if the change affects user-facing behaviour

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TC5tEdn2ov1YTwPMCWQn12

---
_Generated by [Claude Code](https://claude.ai/code/session_01TC5tEdn2ov1YTwPMCWQn12)_