### PR TITLE
chore(dependabot): add update coverage for the clients/cli (arbr-audit) manifest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,19 @@ updates:
       js-sdk-deps:
         patterns: ["*"]
 
+  # CLI (arbr-audit) npm dependencies — all bumps in one PR. Zero runtime
+  # dependencies today, but covered so base-image/dev-dep bumps get a PR if
+  # that changes, matching the other client manifests.
+  - package-ecosystem: "npm"
+    directory: "/clients/cli"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    labels: ["dependencies"]
+    groups:
+      cli-deps:
+        patterns: ["*"]
+
   # Python SDK dependencies — all bumps in one PR
   - package-ecosystem: "pip"
     directory: "/clients/python"


### PR DESCRIPTION
## What does this PR do?

`.github/dependabot.yml` covers every npm/pip/docker/actions manifest on disk **except** `clients/cli/package.json`. That manifest shipped with the `arbr-audit` CLI (#215, #220) and was never added, so it is currently the only manifest without update coverage — the same gap the docker ecosystem had before #200.

This adds an `npm` entry for `/clients/cli`, mirroring the existing `/clients/js` block (weekly, grouped, `dependencies` label).

Note: `clients/cli` has **zero runtime dependencies** today, so this produces no Dependabot PRs right now. It's preventative — if the CLI later gains a dependency (or a dev-dependency needs a security bump), it will get a PR the same way the other client manifests do, rather than silently drifting.

Found during a scheduled open-source-hygiene audit (dependabot manifest coverage check).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] CI / build

## Checklist

- [ ] I've tested this locally with `npm run dev`
- [x] No API keys, `.env` values, or secrets are committed
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format (`feat:`, `fix:`, etc.)
- [x] I've updated docs if the change affects user-facing behaviour

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TC5tEdn2ov1YTwPMCWQn12

---
_Generated by [Claude Code](https://claude.ai/code/session_01TC5tEdn2ov1YTwPMCWQn12)_