### PR TITLE
fix(routing): reject an unresolvable model pin instead of silently swapping it

### DIFF
--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -49,20 +49,38 @@ async function getAppConfig(appName) {
   return cfg;
 }
 
-// An explicit, honorable model pin → { provider, model, knownPricing } to use
-// as-is, or null to defer to the router. Defers when the model is "auto"/absent
-// or the resolved provider is not connected (live).
-// Pass-through: an explicit provider + any non-empty model ID is accepted even
-// when the model is not in the registry — costs are logged as $0 until it's added.
+// Interpret the client's model field. Returns one of:
+//   { kind: "defer" }                            no pin ("auto"/absent) → let the router decide
+//   { kind: "pin", served: {...} }               a usable explicit model
+//   { kind: "unresolved", model, reason, provider? }
+//                                                a concrete model that cannot be honored
+//
+// A pin that cannot be resolved used to collapse to the same null as "no pin", so
+// the request was quietly served the default and the UI claimed "no model was
+// pinned". The two are now distinct: the caller rejects an unresolved pin.
+//
+// Pass-through still holds: an explicit LIVE provider plus any non-empty model ID
+// is accepted even when the model is unknown to the registry (costs log as $0
+// until it is added). Only a pin with no reachable provider is unresolved.
 function resolveExplicit(body, eff) {
   const rawModel = (body.model || "").trim();
   const rawProvider = (body.provider || "").trim();
-  if (!rawModel || rawModel.toLowerCase() === "auto") return null;
+  if (!rawModel || rawModel.toLowerCase() === "auto") return { kind: "defer" };
+
   const known = pricing.getModel(rawModel);
-  const provider = (rawProvider && rawProvider.toLowerCase() !== "auto" ? rawProvider : null)
-    || (known ? known.provider : null);
-  if (!provider || !eff.liveIds.includes(provider)) return null;
-  return { provider, model: rawModel, knownPricing: !!known };
+  const hintedProvider = rawProvider && rawProvider.toLowerCase() !== "auto" ? rawProvider : null;
+  const provider = hintedProvider || (known ? known.provider : null);
+
+  if (!provider) {
+    // Unknown model and no provider hint: nothing tells us where to route it.
+    // This is the bare-ID-for-a-region-scoped-model case.
+    return { kind: "unresolved", model: rawModel, reason: "unknown-model" };
+  }
+  if (!eff.liveIds.includes(provider)) {
+    // We know (or were told) the provider, but it is not connected.
+    return { kind: "unresolved", model: rawModel, reason: "provider-not-connected", provider };
+  }
+  return { kind: "pin", served: { provider, model: rawModel, knownPricing: !!known } };
 }
 
 // The router's base model for auto mode: honor a live provider hint if given,
@@ -152,6 +170,24 @@ function visionUnsupportedError(model, eff) {
   );
 }
 
+// Build the 400 for a pin Arbr cannot honor. Includes "did you mean" IDs so the
+// bare-vs-region-scoped mistake ("deepseek.v3.2" → "ap-southeast-3/deepseek.v3.2")
+// is self-correcting, and mirrors OpenAI's model_not_found shape.
+function unresolvedModelError(pin, eff) {
+  if (pin.reason === "provider-not-connected") {
+    return Object.assign(
+      new Error(`Model "${pin.model}" routes to provider "${pin.provider}", which is not connected. Connect it, or pin a model from a live provider.`),
+      { code: "provider_not_connected", status: 400 }
+    );
+  }
+  const suggestions = pricing.suggestModels(pin.model, { liveIds: eff.liveIds, limit: 5 });
+  const hint = suggestions.length ? ` Did you mean: ${suggestions.join(", ")}?` : "";
+  return Object.assign(
+    new Error(`Unknown model "${pin.model}". It is not in this instance's registry, and no provider was specified.${hint}`),
+    { code: "model_not_found", status: 400, suggestions }
+  );
+}
+
 // Shared routing resolution: classify task + decide served {provider, model}.
 // Returns { served, routingDecision, taskType, classifiedBy }. The classifier's own
 // spend is accounted inside classify/classifier.js, so callers don't have to remember
@@ -159,7 +195,12 @@ function visionUnsupportedError(model, eff) {
 // Callers are responsible for budget enforcement (it may short-circuit the response).
 async function resolveRoute(body, { router, eff, application, workflow, userId = null, appConfig = {}, appDbConfig = null }) {
   const routingMode = await ruleEngine.getRoutingMode();
-  const explicit = resolveExplicit(body, eff);
+  const pin = resolveExplicit(body, eff);
+  // A model the client pinned but Arbr cannot honor is rejected, not silently
+  // swapped for the default. Serving something else behind a 200 corrupts cost
+  // attribution and evals, and is exactly what made "no model was pinned" a lie.
+  if (pin.kind === "unresolved") throw unresolvedModelError(pin, eff);
+  const explicit = pin.kind === "pin" ? pin.served : null;
   const autoMode = !explicit;
   const providedTaskType = !!(body.taskType && String(body.taskType).trim());
 
@@ -416,6 +457,9 @@ async function handleChat(req, res) {
     }
     if (err.code === "vision_not_supported") {
       return res.status(400).json({ error: err.message, code: err.code, vision_models: err.visionModels || [] });
+    }
+    if (err.status === 400 && (err.code === "model_not_found" || err.code === "provider_not_connected")) {
+      return res.status(400).json({ error: err.message, code: err.code, ...(err.suggestions ? { did_you_mean: err.suggestions } : {}) });
     }
     throw err;
   }
@@ -681,6 +725,7 @@ async function handleChat(req, res) {
 module.exports = {
   handleChat,
   resolveRoute,
+  resolveExplicit, // pure, exported for tests
   invokeWithFallback,
   buildFallbackOrder,
   getAppConfig,

--- a/server/src/gateway/openaiCompat.js
+++ b/server/src/gateway/openaiCompat.js
@@ -378,6 +378,18 @@ async function handleOpenAICompat(req, res) {
     if (err.code === "vision_not_supported") {
       return res.status(400).json({ error: { message: err.message, type: "invalid_request_error", code: err.code, vision_models: err.visionModels || [] } });
     }
+    if (err.status === 400 && (err.code === "model_not_found" || err.code === "provider_not_connected")) {
+      // OpenAI-compatible shape: unknown model is invalid_request_error / model_not_found,
+      // which OpenAI SDK clients already surface. did_you_mean is an Arbr extension.
+      return res.status(400).json({
+        error: {
+          message: err.message,
+          type: "invalid_request_error",
+          code: err.code,
+          ...(err.suggestions ? { did_you_mean: err.suggestions } : {}),
+        },
+      });
+    }
     throw err;
   }
 

--- a/server/src/pricing/registry.js
+++ b/server/src/pricing/registry.js
@@ -106,6 +106,38 @@ function listVisionModels(liveIds = null) {
     .sort();
 }
 
+// Suggest registry IDs close to an unresolved one, for a "did you mean" hint.
+// The common miss is a client sending a bare ID for a model the registry stores
+// region-scoped, e.g. "deepseek.v3.2" when the ID is "ap-southeast-3/deepseek.v3.2".
+function suggestModels(query, opts = {}) {
+  return rankSuggestions(query, Object.values(_cache), opts);
+}
+
+// Pure ranker over an explicit model list, so the scoring is testable without a DB.
+// Ranking: exact tail after a "/" or "." first (the region-prefix case), then
+// substring either way. `liveIds` (optional) floats connected providers up, since
+// a suggestion the caller cannot actually reach is not much of a suggestion.
+function rankSuggestions(query, models, { limit = 5, liveIds = null } = {}) {
+  const q = String(query || "").trim().toLowerCase();
+  if (!q) return [];
+  const live = liveIds ? new Set(liveIds) : null;
+  const scored = [];
+  for (const m of models || []) {
+    const id = m.id;
+    const lid = id.toLowerCase();
+    let score = 0;
+    if (lid === q) score = 100;
+    else if (lid.endsWith("/" + q) || lid.endsWith("." + q)) score = 80; // region/prefix variant
+    else if (lid.includes(q)) score = 50;
+    else if (q.includes(lid)) score = 30;
+    if (!score) continue;
+    if (live && live.has(m.provider)) score += 10; // reachable beats unreachable
+    scored.push({ id, score });
+  }
+  scored.sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
+  return scored.slice(0, limit).map((s) => s.id);
+}
+
 function isPremium(id) {
   const m = _cache[id];
   return !!m && m.tier === "premium";
@@ -161,6 +193,8 @@ module.exports = {
   getModel,
   listModels,
   listVisionModels,
+  suggestModels,
+  rankSuggestions, // pure, exported for tests
   isPremium,
   isCheapTask,
   costFor,

--- a/server/test/unit/explicitModelPin.test.js
+++ b/server/test/unit/explicitModelPin.test.js
@@ -1,0 +1,73 @@
+"use strict";
+// Regression tests for the silent model-pin swap.
+//
+// Reported: a client POSTed { "model": "deepseek.v3.2" } — a bare ID for a model
+// the registry stores region-scoped (ap-southeast-3/deepseek.v3.2). Arbr could not
+// resolve it, silently served the default (kimi-k2.5), and told the operator "no
+// model was pinned". A pin that cannot be honored must now be rejected, not swapped.
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { resolveExplicit } = require("../../src/gateway/handler");
+const { rankSuggestions } = require("../../src/pricing/registry");
+
+// resolveExplicit only consults pricing.getModel for models that ARE in the
+// registry; every case below is unknown-to-registry (the empty test cache) or
+// provider-hinted, so no DB is needed.
+const eff = { liveIds: ["bedrock-nova", "openai"] };
+
+test("no model pinned defers to the router", () => {
+  assert.deepEqual(resolveExplicit({}, eff), { kind: "defer" });
+  assert.deepEqual(resolveExplicit({ model: "auto" }, eff), { kind: "defer" });
+  assert.deepEqual(resolveExplicit({ model: "  " }, eff), { kind: "defer" });
+});
+
+// The exact reported payload.
+test("a bare region-scoped model with no provider is unresolved, not deferred", () => {
+  const r = resolveExplicit({ model: "deepseek.v3.2" }, eff);
+  assert.equal(r.kind, "unresolved", "must NOT collapse to defer — that was the bug");
+  assert.equal(r.reason, "unknown-model");
+  assert.equal(r.model, "deepseek.v3.2");
+});
+
+test("an unknown model routed to a LIVE provider is a valid pass-through pin", () => {
+  const r = resolveExplicit({ model: "deepseek.v3.2", provider: "bedrock-nova" }, eff);
+  assert.equal(r.kind, "pin");
+  assert.equal(r.served.provider, "bedrock-nova");
+  assert.equal(r.served.model, "deepseek.v3.2");
+  assert.equal(r.served.knownPricing, false); // unknown to registry, still served
+});
+
+test("a pin to a provider that is not connected is unresolved", () => {
+  const r = resolveExplicit({ model: "some-model", provider: "cohere" }, eff);
+  assert.equal(r.kind, "unresolved");
+  assert.equal(r.reason, "provider-not-connected");
+  assert.equal(r.provider, "cohere");
+});
+
+// The "did you mean" that makes the bare-vs-region-scoped mistake self-correcting.
+test("rankSuggestions floats the region-scoped variants of a bare id", () => {
+  const models = [
+    { id: "ap-southeast-3/deepseek.v3.2", provider: "bedrock-nova" },
+    { id: "us-east-1/deepseek.v3.2", provider: "bedrock-nova" },
+    { id: "gpt-4o-mini", provider: "openai" },
+    { id: "claude-haiku-4-5", provider: "anthropic" },
+  ];
+  const out = rankSuggestions("deepseek.v3.2", models, { liveIds: ["bedrock-nova"] });
+  assert.ok(out.includes("ap-southeast-3/deepseek.v3.2"));
+  assert.ok(out.includes("us-east-1/deepseek.v3.2"));
+  assert.ok(!out.includes("gpt-4o-mini"), "unrelated models must not be suggested");
+});
+
+test("rankSuggestions prefers reachable providers", () => {
+  const models = [
+    { id: "eu-north-1/deepseek.v3.2", provider: "bedrock-offline" }, // not live
+    { id: "ap-southeast-3/deepseek.v3.2", provider: "bedrock-nova" }, // live
+  ];
+  const out = rankSuggestions("deepseek.v3.2", models, { liveIds: ["bedrock-nova"] });
+  assert.equal(out[0], "ap-southeast-3/deepseek.v3.2", "the reachable one ranks first");
+});
+
+test("rankSuggestions returns nothing for an empty query or no matches", () => {
+  assert.deepEqual(rankSuggestions("", [{ id: "x", provider: "p" }]), []);
+  assert.deepEqual(rankSuggestions("zzz", [{ id: "gpt-4o", provider: "openai" }]), []);
+});


### PR DESCRIPTION
Follow-up to #225, from the same investigation.

## The report

A client sent:
```json
{ "model": "deepseek.v3.2", "messages": [{"role":"user","content":"hi"}] }
```
and received a **200** whose body was `moonshotai.kimi-k2.5`, with the request detail saying **"no model was pinned"**. A model *was* pinned.

## Why

The registry stores that model **region-scoped** — `ap-southeast-3/deepseek.v3.2` — because LiteLLM lists it as `bedrock/ap-southeast-3/deepseek.v3.2` and the sync strips only the `bedrock/` prefix. The client's bare `deepseek.v3.2` matched nothing. `resolveExplicit` then collapsed the unresolvable pin into the **same `null` it returns for `"auto"`**, so routing treated it as "no pin", served the default, and narrated it as unpinned.

Confirmed against the live LiteLLM catalog: the bare key and eight `bedrock/<region>/deepseek.v3.2` keys all exist; only the region-scoped ones become registry IDs.

## The fix

Matching stays exact-string. The **failure mode** changes:

- `resolveExplicit` returns a discriminated result: `defer` / `pin` / `unresolved`. An unresolvable pin is no longer indistinguishable from no pin.
- `resolveRoute` rejects an `unresolved` pin with **400 `model_not_found`** (or `provider_not_connected`), including a **`did_you_mean`** list.
- `registry.suggestModels` ranks near IDs, floating the region-scoped variants and preferring live providers — `deepseek.v3.2` → suggests `ap-southeast-3/deepseek.v3.2`, etc.
- Both gateways map it: native as `{ code, did_you_mean }`; OpenAI-compatible as `invalid_request_error` / `model_not_found` (surfaced by OpenAI SDKs).

**Pass-through unchanged:** an explicit *live* provider + any non-empty model is still served even when unknown to the registry.

## ⚠️ Breaking, intentionally

Callers pinning an ID Arbr can't resolve now get a **400 instead of a silent swap**. `gyde-chat-client` sends `deepseek.v3.2` today, so it will error until updated to `ap-southeast-3/deepseek.v3.2`. You approved this — a 200 serving a different model than requested corrupts cost attribution and evals.

## Verification
- 7 new unit tests, including the exact reported payload (bare `deepseek.v3.2` → `unresolved`, not `defer`), pass-through still valid, provider-not-connected, and the suggestion ranking
- Full suite 324/325 (the one failure is the env-dependent `assertProductionReady`, reproduces on clean main); lint 0 errors; web build compiles

## Immediate unblock for prod
Send the exact ID:
```json
{ "model": "ap-southeast-3/deepseek.v3.2", "messages": [{"role":"user","content":"hi"}] }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)