### PR TITLE
fix(deps)+ci: clear the npm-audit gate (brace-expansion patch + react-router allowlist)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,16 +40,20 @@ jobs:
         with:
           node-version: 20
 
+      # audit-gate.mjs is `npm audit --omit=dev --audit-level=high` plus a small,
+      # documented allowlist (raw npm audit cannot exempt a single advisory). Any
+      # high/critical finding NOT in the allowlist still fails. See the script for
+      # the current entries and their review dates.
       - name: Audit server
-        run: npm audit --omit=dev --audit-level=high
+        run: node scripts/audit-gate.mjs
 
       - name: Audit web
-        run: npm audit --omit=dev --audit-level=high
+        run: node ../scripts/audit-gate.mjs
         working-directory: web
 
       - name: Audit JS SDK
         # the SDK ships without a lockfile; generate one transiently so audit can resolve the tree
-        run: npm i --package-lock-only --ignore-scripts && npm audit --omit=dev --audit-level=high
+        run: npm i --package-lock-only --ignore-scripts && node ../../scripts/audit-gate.mjs
         working-directory: clients/js
 
   image-scan:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3301,16 +3301,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/bson": {
@@ -4722,21 +4722,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/glob/node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
   "overrides": {
     "vite": "^6.4.3",
     "esbuild": "^0.25.0",
-    "shell-quote": "^1.9.0"
+    "shell-quote": "^1.9.0",
+    "brace-expansion": "^5.0.8"
   }
 }

--- a/scripts/audit-gate.mjs
+++ b/scripts/audit-gate.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// Prod-dependency audit gate with a scoped allowlist.
+//
+// Wraps `npm audit --omit=dev --audit-level=high --json` and fails on any
+// high/critical advisory EXCEPT those explicitly allowlisted below, each with a
+// reason and a review date. This exists because a raw `npm audit` cannot exempt a
+// single advisory, and one finding here is a non-applicable, unpatched one:
+// downgrading 7 minor versions to dodge a vulnerability the app cannot reach is a
+// worse outcome than a documented exception.
+//
+// Any advisory NOT in the allowlist still fails the gate, so this does not weaken
+// coverage for real, actionable findings. Run from a package directory:
+//   node ../scripts/audit-gate.mjs   (cwd = the package to audit)
+import { execFileSync } from "node:child_process";
+
+// GHSA id → why it is allowlisted. Keep this list short and revisit the dates.
+const ALLOWLIST = {
+  "GHSA-qwww-vcr4-c8h2": {
+    reason:
+      "react-router RSC-mode CSRF bypass. Arbr's web is a Vite SPA using BrowserRouter; " +
+      "RSC mode is never enabled, so the advisory is not reachable. No forward-fixed " +
+      "react-router has shipped (7.18.1 is latest); the only npm remediation is a " +
+      "7-minor downgrade to 7.11.0. Remove this entry once an upstream fix is published.",
+    review: "2026-10-01",
+  },
+};
+
+function runAudit() {
+  try {
+    // npm audit exits non-zero when it finds anything; we want the JSON regardless.
+    return execFileSync("npm", ["audit", "--omit=dev", "--audit-level=high", "--json"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch (err) {
+    if (err.stdout) return err.stdout; // the report is on stdout even on a non-zero exit
+    throw err;
+  }
+}
+
+const report = JSON.parse(runAudit());
+const vulns = report.vulnerabilities || {};
+
+const ghsaOf = (via) => (via.url || "").replace(/\/+$/, "").split("/").pop();
+const found = new Set();
+for (const v of Object.values(vulns)) {
+  if (v.severity !== "high" && v.severity !== "critical") continue;
+  for (const via of v.via || []) {
+    if (typeof via !== "object") continue; // string vias are parent package names, not advisories
+    if (via.severity !== "high" && via.severity !== "critical") continue;
+    const id = ghsaOf(via);
+    if (id) found.add(id);
+  }
+}
+
+const unexpected = [...found].filter((id) => !(id in ALLOWLIST));
+const allowlistedHit = [...found].filter((id) => id in ALLOWLIST);
+
+for (const id of allowlistedHit) {
+  console.log(`allowlisted: ${id} — ${ALLOWLIST[id].reason} (review ${ALLOWLIST[id].review})`);
+}
+
+if (unexpected.length) {
+  console.error(`\nFAIL: ${unexpected.length} high/critical advisory(ies) not in the allowlist:`);
+  for (const id of unexpected) console.error(`  - https://github.com/advisories/${id}`);
+  console.error("\nRun `npm audit --omit=dev --audit-level=high` for details.");
+  process.exit(1);
+}
+
+console.log(`\nOK: no high/critical advisories outside the allowlist (${allowlistedHit.length} allowlisted).`);


### PR DESCRIPTION
Makes the **npm audit (prod, high+)** and **Trivy** CI checks green. The gate audits three package dirs (server, web, JS SDK); this addresses both findings.

## 1. Server — `brace-expansion` DoS (real fix)

All 7 server findings trace to one advisory, [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (DoS in `brace-expansion`), pulled in transitively by `@google-cloud/secret-manager` → `google-gax` → `rimraf` → `glob` → `minimatch`. The other six are just parents of it.

`npm audit fix` couldn't resolve it (vulnerable version pinned deep under `google-gax`, no in-range parent bump). Fixed with an `overrides` entry pinning `brace-expansion` to **`^5.0.8`** (patched; advisory covers `<=5.0.7`), matching the repo's existing override pattern (`vite`, `esbuild`, `shell-quote`). Dedupes to a single 5.0.8; API unchanged, so `glob`/`minimatch` keep working. **Server audit → 0 vulnerabilities.**

## 2. Web — `react-router` advisory (allowlisted, not applicable)

The web finding is [GHSA-qwww-vcr4-c8h2](https://github.com/advisories/GHSA-qwww-vcr4-c8h2), a react-router **RSC-mode** CSRF bypass. Arbr's web is a **Vite SPA using `<BrowserRouter>`** — no RSC mode, no server components, no `react-router.config`. **The advisory is not reachable here.** And there's no forward fix: `7.18.1` is `latest`, the vulnerable range is `7.12.0–8.2.0`, and npm's only remediation is a 7-minor *downgrade* to `7.11.0`.

Rather than regress the router to dodge a vulnerability the app can't hit, the three audit steps now run **`scripts/audit-gate.mjs`** — the same `npm audit --omit=dev --audit-level=high` plus a small, documented allowlist keyed by GHSA id (reason + review date). **Any high/critical finding not in the allowlist still fails.** Raw `npm audit` has no way to exempt a single advisory; this is the minimal mechanism, no new dependency.

## Verification
- `audit-gate.mjs` run locally in all three dirs: **web passes** (1 allowlisted), **server and JS SDK pass clean** (0 allowlisted)
- Confirmed the gate still *fails* on any non-allowlisted advisory (the filter keys on exact GHSA id)
- `npm audit` (all severities) on server → 0; lockfile diff is a dedupe, no dependency added
- Server unit suite passes (bar the env-dependent `assertProductionReady`); web build compiles

## Follow-up
Remove the `GHSA-qwww-vcr4-c8h2` allowlist entry once react-router ships a fixed release (review date 2026-10-01 in the script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)