### PR TITLE
fix(routing): reject image requests routed to a non-vision model with a clear 400

### DIFF
--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -131,6 +131,33 @@ async function invokeWithFallback(router, eff, { provider, model, messages, temp
   throw lastErr || new Error("all providers failed");
 }
 
+// True when any message carries image content (OpenAI multimodal shape). Same
+// detection the OpenAI-compatible gateway uses before forwarding.
+function hasVisionContent(messages) {
+  return Array.isArray(messages) && messages.some(
+    (m) => Array.isArray(m.content) && m.content.some((c) => c && c.type === "image_url")
+  );
+}
+
+// Vision support is asserted only when the registry says so. A model absent from
+// the registry, or present with a null flag (unknown), counts as NOT known-capable:
+// the reported failure was exactly such a model. Explicit client pins bypass this.
+function isVisionCapable(modelId) {
+  const m = pricing.getModel(modelId);
+  return !!m && m.supportsVision === true;
+}
+
+function visionUnsupportedError(model, eff) {
+  const options = pricing.listVisionModels(eff.liveIds).slice(0, 8);
+  const hint = options.length
+    ? ` Pin a vision-capable model, for example: ${options.join(", ")}.`
+    : " No vision-capable model is currently connected; add one on the Models page.";
+  return Object.assign(
+    new Error(`The request includes an image, but "${model}" is not known to support vision.${hint}`),
+    { code: "vision_not_supported", status: 400, visionModels: options }
+  );
+}
+
 // Shared routing resolution: classify task + decide served {provider, model}.
 // Returns { served, routingDecision, taskType, classifiedBy }. The classifier's own
 // spend is accounted inside classify/classifier.js, so callers don't have to remember
@@ -283,6 +310,16 @@ async function resolveRoute(body, { router, eff, application, workflow, userId =
     explain.allowedViolation = { model: served.model, allowed: appConfig.allowedModels };
   }
 
+  // Vision guard: when Arbr CHOSE the model (not an explicit client pin) and the
+  // request carries an image, a model not known to support vision fails opaquely
+  // downstream — a 502 from an OpenAI-compatible provider, or the image silently
+  // stripped on the native path. Reject early with a 400 that names live
+  // vision-capable models to pin, turning the confusing provider error into an
+  // actionable one. Explicit client pins are left alone: that choice is theirs.
+  if (!explicit && hasVisionContent(body.messages) && !isVisionCapable(served.model)) {
+    throw visionUnsupportedError(served.model, eff);
+  }
+
   // qualityGate: only set when a human-approved rule (or canary promote path) chose the model.
   let qualityGate = null;
   if (routingDecision === "rule" && explain.qualityGate) {
@@ -382,6 +419,9 @@ async function handleChat(req, res) {
   } catch (err) {
     if (err.code === "model_not_allowed") {
       return res.status(403).json({ error: err.message, code: "model_not_allowed" });
+    }
+    if (err.code === "vision_not_supported") {
+      return res.status(400).json({ error: err.message, code: err.code, vision_models: err.visionModels || [] });
     }
     throw err;
   }
@@ -645,4 +685,6 @@ module.exports = {
   invokeWithFallback,
   buildFallbackOrder,
   getAppConfig,
+  hasVisionContent, // pure, exported for tests
+  isVisionCapable,
 };

--- a/server/src/gateway/openaiCompat.js
+++ b/server/src/gateway/openaiCompat.js
@@ -374,6 +374,9 @@ async function handleOpenAICompat(req, res) {
     if (err.code === "model_not_allowed") {
       return res.status(403).json({ error: { message: err.message, type: "invalid_request_error", code: "model_not_allowed" } });
     }
+    if (err.code === "vision_not_supported") {
+      return res.status(400).json({ error: { message: err.message, type: "invalid_request_error", code: err.code, vision_models: err.visionModels || [] } });
+    }
     throw err;
   }
 

--- a/server/src/pricing/registry.js
+++ b/server/src/pricing/registry.js
@@ -95,6 +95,17 @@ function listModels() {
   return Object.values(_cache);
 }
 
+// Vision-capable model IDs, optionally restricted to live providers. Used to tell
+// a caller which models can actually take an image when routing landed on one that
+// cannot. Only affirmatively-flagged models qualify (null = unknown = excluded).
+function listVisionModels(liveIds = null) {
+  const live = liveIds ? new Set(liveIds) : null;
+  return Object.values(_cache)
+    .filter((m) => m.supportsVision === true && (!live || live.has(m.provider)))
+    .map((m) => m.id)
+    .sort();
+}
+
 function isPremium(id) {
   const m = _cache[id];
   return !!m && m.tier === "premium";
@@ -149,6 +160,7 @@ module.exports = {
   // Sync accessors
   getModel,
   listModels,
+  listVisionModels,
   isPremium,
   isCheapTask,
   costFor,

--- a/server/test/unit/visionRouting.test.js
+++ b/server/test/unit/visionRouting.test.js
@@ -1,0 +1,45 @@
+"use strict";
+// Regression tests for vision requests routed to a non-vision model.
+//
+// Reported: images sent to accounti-onboarding were AI-routed to
+// nvidia/nemotron-content-safety-reasoning-4b (a text-only safety model, absent
+// from the LiteLLM catalog so supportsVision is null), which 502'd at the
+// provider. Vision requests Arbr routes itself must now fail fast with a 400.
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { hasVisionContent, isVisionCapable } = require("../../src/gateway/handler");
+
+const imageMsg = {
+  role: "user",
+  content: [
+    { type: "text", text: "What is in this document?" },
+    { type: "image_url", image_url: { url: "data:image/png;base64,AAAA" } },
+  ],
+};
+
+test("hasVisionContent detects the OpenAI multimodal image shape", () => {
+  assert.equal(hasVisionContent([imageMsg]), true);
+});
+
+test("hasVisionContent is false for plain string content", () => {
+  assert.equal(hasVisionContent([{ role: "user", content: "hi" }]), false);
+});
+
+test("hasVisionContent is false for array content with no image part", () => {
+  assert.equal(hasVisionContent([{ role: "user", content: [{ type: "text", text: "hi" }] }]), false);
+});
+
+test("hasVisionContent tolerates missing/empty messages", () => {
+  assert.equal(hasVisionContent(undefined), false);
+  assert.equal(hasVisionContent([]), false);
+  assert.equal(hasVisionContent([{ role: "user" }]), false);
+});
+
+// The crux of the bug: the reported model is absent from the registry, so
+// getModel returns null and isVisionCapable must report NOT capable — the guard
+// then rejects rather than letting it 502 downstream. (Unit cache is empty, so
+// every id is unknown here, which is precisely the "not affirmatively capable" case.)
+test("isVisionCapable is false for a model unknown to the registry", () => {
+  assert.equal(isVisionCapable("nvidia/nemotron-content-safety-reasoning-4b"), false);
+  assert.equal(isVisionCapable("anything-not-synced"), false);
+});


### PR DESCRIPTION
## The report

Vision / document-analysis requests to `accounti-onboarding` were returning **502 `provider_error`**.

## Diagnosis: not a credentials problem

The AI policy classified them as "document analysis" and routed to **`nvidia/nemotron-content-safety-reasoning-4b`** — a text-only *content-safety* model that can't take an image. `nvidia-nim` is OpenAI-compatible, so Arbr forwarded the image raw and the upstream rejected it → 502.

The key/credits/rate-limit theory is ruled out:
- Failing rows show **0ms latency, 0 tokens** — an immediate provider rejection, not a `401`/`429` after a round-trip.
- The rows that **succeeded** did so via `fallback → us.amazon.nova-lite-v1:0` (a vision-capable model), using the **same AWS Bedrock key**. A bad key would have failed those too.

## Root cause

Routing was **blind to vision**. [`resolveRoute`](server/src/gateway/handler.js) never checked for image content, and [`aiPolicy`](server/src/routing/aiPolicy.js) never considered whether a candidate model supports vision — so a multimodal request could land on a text-only model. The registry already tracks `supportsVision`; nothing used it for routing.

## The fix (per the chosen "reject early with a clear 400")

When Arbr **chooses** the model (not an explicit client pin) and the request contains an image, `resolveRoute` now rejects with **400 `vision_not_supported`**, listing live vision-capable models to pin, instead of failing opaquely at the provider:

```json
{ "error": "The request includes an image, but \"nvidia/nemotron-content-safety-reasoning-4b\" is not known to support vision. Pin a vision-capable model, for example: gpt-4o, us.amazon.nova-lite-v1:0, ...",
  "code": "vision_not_supported",
  "vision_models": ["gpt-4o", "us.amazon.nova-lite-v1:0", ...] }
```

Key detail: the reported model is **absent from the LiteLLM catalog**, so its `supportsVision` is `null`, not `false`. Capability is asserted **only** when `supportsVision === true`; absent/null counts as not-capable — which is what makes the guard fire for this exact case. **Explicit client pins are left untouched** — that choice is the caller's.

Mapped in both gateways (native `{ code, vision_models }`, OpenAI-compatible `invalid_request_error`).

## What this does NOT do
- It does not auto-reroute to a vision model (that was the other option; you chose reject-early).
- It does not cover a budget-downgrade landing on a non-vision light model — a rarer secondary path worth a follow-up.

## Immediate operator remedy (no deploy)
Add a routing rule: **task type `document analysis` → a vision model** (`nova-lite` is proven working from the fallback). That stops the silent misroute now.

## Verification
- 5 new unit tests: `hasVisionContent` detection across content shapes, and `isVisionCapable` returning false for a registry-absent model (the reported case)
- Full suite 322/323 (the one failure is the env-dependent `assertProductionReady`, reproduces on clean main); lint 0 errors

## Note
Minor overlap with #229 (both add a branch to the same gateway catch block). Whichever merges first, the other rebases trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)