### PR TITLE
fix(routing): stop the AI policy picking unpriced junk over an explicit assignment

### DIFF
--- a/server/src/routing/aiPolicy.js
+++ b/server/src/routing/aiPolicy.js
@@ -169,14 +169,26 @@ function resolveModel({ map, taskType, difficulty, eff }) {
   if (difficulty === catalogTier) return base;
   try {
     const liveIdSet = new Set(eff.liveIds);
-    const liveModels = pricing.listModels()
-      .filter((m) => liveIdSet.has(m.provider) && m.chatCapable !== false)
+    const liveModels = pricedPool(pricing.listModels()
+      .filter((m) => liveIdSet.has(m.provider) && m.chatCapable !== false))
       .sort((a, b) => (b.inputPer1M || 0) - (a.inputPer1M || 0));
     if (!liveModels.length) return base;
     const catalogMap = Object.fromEntries(TASK_CATALOG.map((t) => [t.id, t]));
     const id = _scoringFallback(tt, liveModels, catalogMap, eff, difficulty);
     const m = pricing.getModel(id);
-    if (m && liveIdSet.has(m.provider)) return { provider: m.provider, model: id };
+    if (!m || !liveIdSet.has(m.provider)) return base;
+
+    // Honor the operator's explicit assignment. The difficulty re-pick may stand in
+    // for the base ONLY when it is a genuinely CHEAPER real model — a cost downgrade
+    // for an easier-than-usual instance. A lateral or pricier pick keeps the explicit
+    // choice, so "document analysis" stays on the assigned model instead of being
+    // swapped for something unrelated. The base is the operator's ceiling; difficulty
+    // can save cost, not override the pick upward.
+    const basePrice = pricing.getModel(base.model)?.inputPer1M ?? null;
+    const newPrice  = m.inputPer1M ?? null;
+    if (basePrice != null && newPrice != null && newPrice < basePrice) {
+      return { provider: m.provider, model: id };
+    }
     return base;
   } catch { return base; }
 }
@@ -257,6 +269,18 @@ function scoreModel(taskCaps, model, cheapestCost) {
   return { capScore, costScore };
 }
 
+// Models with a known, positive input price. An unpriced model (absent from the
+// pricing catalog) otherwise scores as if free — scoreModel treats a null price as
+// $0.001, so cheapestCost/price → the maximum cost score — and wins any
+// cost-weighted pick despite being unpriced and often unsuited (a 4B content-safety
+// model beating "document analysis"). Excluding them from auto-selection also keeps
+// cost tracking honest. Falls back to the full list only if nothing is priced, so
+// the pool is never emptied.
+function pricedPool(models) {
+  const priced = models.filter((m) => (m.inputPer1M || 0) > 0);
+  return priced.length ? priced : models;
+}
+
 // Core scoring engine — shared by regenerate() and computeAssignments().
 // excludeModels: array of model IDs to exclude from consideration.
 async function _computeAssignments({ router, eff, excludeModels = [], goal = "balanced" }) {
@@ -264,8 +288,8 @@ async function _computeAssignments({ router, eff, excludeModels = [], goal = "ba
 
   const excludeSet = new Set(excludeModels);
   const liveIdSet  = new Set(eff.liveIds);
-  const liveModels = pricing.listModels()
-    .filter((m) => liveIdSet.has(m.provider) && !excludeSet.has(m.id) && m.chatCapable !== false)
+  const liveModels = pricedPool(pricing.listModels()
+    .filter((m) => liveIdSet.has(m.provider) && !excludeSet.has(m.id) && m.chatCapable !== false))
     .sort((a, b) => (b.inputPer1M || 0) - (a.inputPer1M || 0));
 
   if (!liveModels.length) throw new Error("no live models available after exclusions");
@@ -443,4 +467,4 @@ async function describe() {
   };
 }
 
-module.exports = { getEffective, lookup, resolveModel, setAssignments, regenerate, computeAssignments: _computeAssignments, simulate, describe, invalidate, CAPABILITY_VERSION, _goalWeight: goalWeight };
+module.exports = { getEffective, lookup, resolveModel, setAssignments, regenerate, computeAssignments: _computeAssignments, simulate, describe, invalidate, CAPABILITY_VERSION, _goalWeight: goalWeight, _pricedPool: pricedPool };

--- a/server/test/unit/aiPolicy.test.js
+++ b/server/test/unit/aiPolicy.test.js
@@ -29,3 +29,33 @@ test("goal unset (undefined) behaves like balanced", () => {
   assert.equal(_goalWeight(undefined, "light"), 0.20);
   assert.equal(_goalWeight(undefined, "unknown"), 0.25);
 });
+
+// Regression: a model with no/zero price used to score as free (cheapestCost/0.001
+// → max cost score) and win cost-weighted selection, which is how a 4B content-safety
+// model beat an explicitly-assigned claude for "document analysis". pricedPool keeps
+// unpriced models out of auto-selection.
+const { _pricedPool } = require("../../src/routing/aiPolicy");
+
+test("pricedPool drops models with null or zero input price", () => {
+  const models = [
+    { id: "claude-sonnet-4-6", inputPer1M: 3.0 },
+    { id: "nova-lite", inputPer1M: 0.06 },
+    { id: "nvidia/nemotron-content-safety-reasoning-4b", inputPer1M: null }, // unpriced
+    { id: "free-junk", inputPer1M: 0 },
+  ];
+  const out = _pricedPool(models).map((m) => m.id);
+  assert.deepEqual(out.sort(), ["claude-sonnet-4-6", "nova-lite"]);
+});
+
+test("pricedPool falls back to the full list when nothing is priced (never empties)", () => {
+  const models = [
+    { id: "a", inputPer1M: null },
+    { id: "b", inputPer1M: 0 },
+  ];
+  assert.equal(_pricedPool(models).length, 2, "an all-unpriced pool is returned intact rather than empty");
+});
+
+test("pricedPool keeps every priced model", () => {
+  const models = [{ id: "a", inputPer1M: 0.1 }, { id: "b", inputPer1M: 5 }];
+  assert.equal(_pricedPool(models).length, 2);
+});


### PR DESCRIPTION
Follow-up to the vision investigation (#231). #231 rejects the *symptom* (a vision request on a non-vision model → 400); **this fixes the root cause** — why the policy picked `nvidia/nemotron-content-safety-reasoning-4b` over the explicitly-assigned `claude-sonnet-4-6` in the first place.

## The report

"Document analysis" was explicitly set to `claude-sonnet-4-6`, yet requests were served the nvidia 4B content-safety model. The request detail showed exactly how:

> base pick was **claude-sonnet-4-6**; difficulty (mid) adjusted it to **nvidia/nemotron-content-safety-reasoning-4b**

## Two compounding defects

**1. Unpriced models score as free and win.** [`scoreModel`](server/src/routing/aiPolicy.js) prices an unknown model as `$0.001` (`inputPer1M || 0.001`). The nvidia model isn't in the LiteLLM catalog, so it has no price → scores as the *cheapest possible* → maximum cost score → wins any cost-weighted pick, regardless of fit. That's how a 4B safety model beat claude. (It's also why these requests log **$0.00**.)

Fix: `pricedPool` drops models with no positive price from auto-selection, in **both** the policy generator and the difficulty re-scorer. Falls back to the full list only if nothing is priced, so the pool is never empty. The generator prompt already *told the LLM* "do NOT choose a model purely because its price is zero" — now it's actually enforced.

**2. Difficulty adjustment overrode the explicit pick.** When the classifier rated an instance easier than the task's tier, the re-score could replace the operator's assignment with an unrelated model. It now **honors the explicit pick**: a re-pick stands in only when it's a genuinely *cheaper real model* (a cost downgrade for an easy instance). A lateral or pricier pick keeps the assignment — so "document analysis" stays on `claude-sonnet-4-6` unless a cheaper capable model exists.

## Behavior change worth noting
The difficulty system no longer *upgrades* past an explicit assignment (a harder-than-usual instance keeps the operator's pick rather than jumping to a pricier model). The explicit assignment is treated as the ceiling; difficulty can only save cost. This matches "honor explicit picks."

## Verification
- 3 new unit tests on `pricedPool` (drops null/zero-price, never empties, keeps priced); existing aiPolicy tests still pass
- The narration's `adjustedByDifficulty` derives from whether the model actually changed, so keeping the base reads correctly — no UI change
- Full suite 325/326 (the one failure is the env-dependent `assertProductionReady`, reproduces on clean main); lint 0 errors

## Relationship to #231
Independent files (this: `aiPolicy.js`; #231: `handler.js`/`openaiCompat.js`/`registry.js`). Land both: this stops the bad pick, #231 is the safety net if any vision request still lands on a non-vision model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)