### PR TITLE
docs(readme): add semantic_cache to the routingDecision value list

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,9 @@ curl -X POST http://localhost:4100/v1/chat \
 ```
 
 Response fields: `model` (served), `modelRequested`, `routingDecision`
-(`explicit` | `passthrough` | `rule` | `auto` | `ai` | `cache` | `fallback` | `budget` |
-`canary` | `external`), `classifiedBy`, `cacheHit`, and token `usage` (including
+(`explicit` | `passthrough` | `rule` | `auto` | `ai` | `cache` | `semantic_cache` |
+`fallback` | `budget` | `canary` | `external`), `classifiedBy`, `cacheHit`, and token
+`usage` (including
 `cachedReadTokens` / `cacheWriteTokens` when the provider reported prompt-cache usage).
 Every call is logged to MongoDB as a **RequestRecord**.
 


### PR DESCRIPTION
## What does this PR do?

The README documents the `routingDecision` response field with a list of its possible
values, but that list is missing `semantic_cache`. The value is real and shipped:

- It's in the schema enum — `server/src/models/RequestRecord.js:106`:
  `["passthrough", "explicit", "rule", "auto", "ai", "budget", "cache", "semantic_cache", "fallback", "canary", "external"]`
- The gateway emits it — `server/src/gateway/handler.js` (semantic-cache hit path).
- It's already documented in `docs/routing.md` (the "Semantic cache" case).

Only the README's list was stale. This adds `semantic_cache` immediately after `cache`,
matching the schema's ordering. Documentation only; no code or behaviour changes.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] CI / build

## Checklist

- [ ] I've tested this locally with `npm run dev`
- [x] No API keys, `.env` values, or secrets are committed
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format (`feat:`, `fix:`, etc.)
- [x] I've updated docs if the change affects user-facing behaviour

---
_Generated by [Claude Code](https://claude.ai/code/session_01UphgurchkEPRyzEGo2Kj55)_