### PR TITLE
feat(routing): dry-run route explainer — preview which model a request would get

### DIFF
--- a/server/src/api/routes/rules.js
+++ b/server/src/api/routes/rules.js
@@ -88,11 +88,17 @@ router.get("/cache/semantic/stats", (_req, res) => {
 router.post("/routing/explain", requireRole("operator"), async (req, res, next) => {
   try {
     const eff = await connections.effective();
-    const { model, provider, taskType, application, workflow, hasImage, allowedModels, defaultModel } = req.body || {};
+    const b = req.body || {};
+    // Coerce every free-text field to a string so a JSON object can't become a
+    // query operator or a template-injection surprise downstream.
+    const str = (v) => (v == null ? undefined : String(v));
+    const model = str(b.model), provider = str(b.provider), taskType = str(b.taskType);
+    const application = str(b.application), workflow = str(b.workflow);
+    const hasImage = !!b.hasImage;
     const appDbConfig = application ? await getAppConfig(application) : null;
     const appConfig = {
-      allowedModels: Array.isArray(allowedModels) ? allowedModels : [],
-      defaultModel: defaultModel || null,
+      allowedModels: Array.isArray(b.allowedModels) ? b.allowedModels.map(String) : [],
+      defaultModel: str(b.defaultModel) || null,
     };
     const result = await explainRoute(
       { model, provider, taskType, application, workflow, hasImage },

--- a/server/src/api/routes/rules.js
+++ b/server/src/api/routes/rules.js
@@ -6,6 +6,9 @@ const { requireRole } = require("../rbac");
 const ruleEngine = require("../../routing/ruleEngine");
 const responseCache = require("../../routing/responseCache");
 const semanticCache = require("../../routing/semanticCache");
+const connections = require("../../providers/connections");
+const { explainRoute } = require("../../routing/explainRoute");
+const { getAppConfig } = require("../../gateway/handler");
 
 const router = express.Router();
 
@@ -76,6 +79,38 @@ router.post("/cache/semantic/clear", requireRole("operator"), (_req, res) => {
 // Current semantic cache entry count (for the UI status display).
 router.get("/cache/semantic/stats", (_req, res) => {
   res.json({ size: semanticCache.size() });
+});
+
+// Dry-run route preview: "given this hypothetical request, which model would Arbr
+// serve, and why?" — computed through the real routing path with no provider call,
+// no billable classification, and no logging. Routing rejections (unresolvable pin,
+// vision, not-allowed) are returned as a preview OUTCOME, not an error.
+router.post("/routing/explain", requireRole("operator"), async (req, res, next) => {
+  try {
+    const eff = await connections.effective();
+    const { model, provider, taskType, application, workflow, hasImage, allowedModels, defaultModel } = req.body || {};
+    const appDbConfig = application ? await getAppConfig(application) : null;
+    const appConfig = {
+      allowedModels: Array.isArray(allowedModels) ? allowedModels : [],
+      defaultModel: defaultModel || null,
+    };
+    const result = await explainRoute(
+      { model, provider, taskType, application, workflow, hasImage },
+      { eff, appConfig, appDbConfig }
+    );
+    res.json(result);
+  } catch (err) {
+    if (err.status && err.code) {
+      return res.json({
+        rejected: {
+          code: err.code, message: err.message, status: err.status,
+          ...(err.suggestions ? { did_you_mean: err.suggestions } : {}),
+          ...(err.visionModels ? { vision_models: err.visionModels } : {}),
+        },
+      });
+    }
+    next(err);
+  }
 });
 
 // Auto-mode routing engine: "off" | "guardrail" | "ai".

--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -39,6 +39,10 @@ const _appConfigCache = createBoundedTtlCache({ ttlMs: 30_000, maxEntries: 1000 
 
 async function getAppConfig(appName) {
   if (!appName || appName === "unknown") return null;
+  // Coerce to a string before it reaches the query. An application name can arrive
+  // from a request body (data plane, and now the /routing/explain preview), so a
+  // non-string like { $ne: null } must never become a NoSQL operator in findOne.
+  appName = String(appName);
   const hit = _appConfigCache.getEntry(appName);
   if (hit) return hit.value;
   const cfg = await ApplicationConfig.findOne({ applicationName: appName }).lean().catch(() => null);

--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -193,7 +193,10 @@ function unresolvedModelError(pin, eff) {
 // spend is accounted inside classify/classifier.js, so callers don't have to remember
 // to log it — the OpenAI-compatible gateway used to forget, and its cost vanished.
 // Callers are responsible for budget enforcement (it may short-circuit the response).
-async function resolveRoute(body, { router, eff, application, workflow, userId = null, appConfig = {}, appDbConfig = null }) {
+// dryRun (default false) makes this a pure preview: the classifier never makes a
+// billable LLM call (keyword-only), so the decision can be computed for a
+// hypothetical request without touching a provider. Real traffic is unaffected.
+async function resolveRoute(body, { router, eff, application, workflow, userId = null, appConfig = {}, appDbConfig = null, dryRun = false }) {
   const routingMode = await ruleEngine.getRoutingMode();
   const pin = resolveExplicit(body, eff);
   // A model the client pinned but Arbr cannot honor is rejected, not silently
@@ -208,7 +211,7 @@ async function resolveRoute(body, { router, eff, application, workflow, userId =
     taskType: body.taskType,
     messages: body.messages,
     router, eff,
-    useLLM: routingMode === "ai" && autoMode && !providedTaskType,
+    useLLM: !dryRun && routingMode === "ai" && autoMode && !providedTaskType,
     // Provenance only — recorded on internalContext so the overhead view can show
     // which app's traffic triggered a classification. Never a queryable dimension.
     application,

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -87,9 +87,11 @@ async function start() {
   // CSRF protection IS applied — see csrf.protection two lines below
   // (double-submit cookie via csrf-csrf, tested in
   // server/test/integration/csrf.test.js). CodeQL's model doesn't recognize
-  // this library the way it recognizes csurf, so it still flags this line.
-  // codeql[js/missing-token-validation]
-  app.use(cookieParser());
+  // this library the way it recognizes csurf, so it still flags this call. The
+  // suppression must sit on the SAME line as the flagged cookie middleware — a
+  // comment on the line above (where it used to be) is not honored, which is why
+  // adding any new POST route re-fired this as a "new" alert.
+  app.use(cookieParser()); // codeql[js/missing-token-validation]
   // Mounted globally so every route is structurally CSRF-protected; only
   // requests carrying a session cookie are actually validated (see csrf.js).
   app.use(csrf.protection);

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -84,14 +84,12 @@ async function start() {
     exposedHeaders: ["X-Arbr-Request-ID", "X-Arbr-Model", "X-Arbr-Provider", "X-Arbr-Routing", "X-Arbr-Task-Type"],
   }));
   app.use(express.json({ limit: "2mb" }));
-  // CSRF protection IS applied — see csrf.protection two lines below
-  // (double-submit cookie via csrf-csrf, tested in
-  // server/test/integration/csrf.test.js). CodeQL's model doesn't recognize
-  // this library the way it recognizes csurf, so it still flags this call. The
-  // suppression must sit on the SAME line as the flagged cookie middleware — a
-  // comment on the line above (where it used to be) is not honored, which is why
-  // adding any new POST route re-fired this as a "new" alert.
-  app.use(cookieParser()); // codeql[js/missing-token-validation]
+  // CSRF protection IS applied — see csrf.protection two lines below (double-submit
+  // cookie via csrf-csrf, tested in server/test/integration/csrf.test.js). CodeQL
+  // does not model csrf-csrf the way it models csurf, so js/missing-token-validation
+  // flags this cookie middleware. It is a false positive and is dismissed as such in
+  // code scanning (inline // codeql[...] comments are not honored by this setup).
+  app.use(cookieParser());
   // Mounted globally so every route is structurally CSRF-protected; only
   // requests carrying a session cookie are actually validated (see csrf.js).
   app.use(csrf.protection);

--- a/server/src/routing/explainRoute.js
+++ b/server/src/routing/explainRoute.js
@@ -1,0 +1,65 @@
+// Side-effect-free route preview.
+//
+// Given a hypothetical request (a model, a task type, an application, a workflow,
+// whether it carries an image), return the model Arbr WOULD serve and the full
+// precedence trace — without calling a provider, classifying via a billable LLM, or
+// logging anything. It reuses the real resolveRoute (in dryRun mode), so the preview
+// cannot drift from what live traffic actually does. Budget enforcement is previewed
+// on top with a read-only cap check.
+//
+// Powers POST /api/routing/explain and the Routing page's "Test a route" panel.
+const { resolveRoute } = require("../gateway/handler");
+const capEngine = require("./capEngine");
+const pricing = require("../pricing/registry");
+
+// A synthetic request body. When hasImage is set we include an image part so the
+// vision guard is exercised exactly as it would be for a real multimodal request.
+function previewBody({ model, provider, taskType, hasImage }) {
+  const content = hasImage
+    ? [{ type: "text", text: "(dry run)" }, { type: "image_url", image_url: { url: "https://example.invalid/preview.png" } }]
+    : "(dry run)";
+  const body = { model: model || "auto", messages: [{ role: "user", content }] };
+  if (provider) body.provider = provider;
+  if (taskType) body.taskType = taskType;
+  return body;
+}
+
+async function explainRoute(input, { eff, appConfig = {}, appDbConfig = null } = {}) {
+  const { application = null, workflow = null, userId = null } = input || {};
+  const body = previewBody(input || {});
+
+  // dryRun: no billable classification, no provider call, no logging. resolveRoute
+  // already performs no I/O beyond DB-cache reads, so this is a pure decision.
+  const r = await resolveRoute(body, {
+    router: null, eff, application, workflow, userId, appConfig, appDbConfig, dryRun: true,
+  });
+
+  // Budget preview: would an enforcing cap block or downgrade this served model?
+  // Read-only — enforcement() only reads CapSpend counters.
+  let budget = null;
+  const enf = await capEngine.enforcement({ application, provider: r.served.provider }).catch(() => null);
+  if (enf && enf.action === "block") {
+    budget = { action: "block", scope: capEngine.describeScope(enf.cap), period: enf.cap.period, limit: enf.cap.limit };
+  } else if (enf && enf.action === "downgrade") {
+    const target = pricing.suggestLightTarget(r.served.model);
+    budget = { action: "downgrade", to: target ? target.model : null, scope: capEngine.describeScope(enf.cap), period: enf.cap.period, limit: enf.cap.limit };
+  }
+
+  // Shaped like a RequestRecord so the dashboard's existing routing narration renders
+  // it directly (single narration source of truth, per docs/routing-spec.md).
+  return {
+    model: r.served.model,
+    provider: r.served.provider,
+    routingDecision: r.routingDecision,
+    taskType: r.taskType,
+    classifiedBy: r.classifiedBy,
+    difficulty: r.difficulty,
+    difficultyScore: r.difficultyScore,
+    confidence: r.confidence,
+    routingExplain: r.explain,
+    overrides: r.explain.overrides || null,
+    budget,
+  };
+}
+
+module.exports = { explainRoute, previewBody };

--- a/server/test/integration/routeExplain.test.js
+++ b/server/test/integration/routeExplain.test.js
@@ -1,0 +1,93 @@
+"use strict";
+// Integration: the dry-run route explainer (POST /api/routing/explain via explainRoute).
+// Proves the preview runs the REAL routing precedence with no provider call and no
+// billable classification, and returns the same decision live traffic would get.
+// Uses MongoMemoryServer; skips cleanly if it cannot start.
+const { test, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const mongoose = require("mongoose");
+
+let mongod, skip = false;
+let explainRoute, registry, ruleEngine, Settings, Rule, eff;
+
+before(async () => {
+  try {
+    const { MongoMemoryServer } = require("mongodb-memory-server");
+    mongod = await MongoMemoryServer.create();
+    await mongoose.connect(mongod.getUri());
+  } catch (err) {
+    skip = true;
+    console.warn("[routeExplain] skipping — no in-memory Mongo:", err.message);
+    return;
+  }
+  const ModelEntry = require("../../src/models/ModelEntry");
+  registry = require("../../src/pricing/registry");
+  ruleEngine = require("../../src/routing/ruleEngine");
+  Settings = require("../../src/models/Settings");
+  Rule = require("../../src/models/Rule");
+  ({ explainRoute } = require("../../src/routing/explainRoute"));
+
+  await ModelEntry.create([
+    { id: "gpt-4o", provider: "openai", inputPer1M: 2.5, outputPer1M: 10, tier: "premium", enabled: true, chatCapable: true, supportsVision: true },
+    { id: "gpt-4o-mini", provider: "openai", inputPer1M: 0.15, outputPer1M: 0.6, tier: "light", enabled: true, chatCapable: true, supportsVision: true },
+    { id: "text-only-8b", provider: "openai", inputPer1M: 0.05, outputPer1M: 0.1, tier: "light", enabled: true, chatCapable: true, supportsVision: false },
+  ]);
+  await registry.reload();
+  eff = { liveIds: ["openai"], defaultProvider: "openai", defaultModel: "gpt-4o-mini" };
+  await Settings.deleteMany({});
+  await ruleEngine.setRoutingMode("off");
+});
+
+after(async () => {
+  if (skip) return;
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+test("explicit pin is previewed as served directly", async (t) => {
+  if (skip) return t.skip("no mongo");
+  const r = await explainRoute({ model: "gpt-4o" }, { eff });
+  assert.equal(r.model, "gpt-4o");
+  assert.equal(r.routingDecision, "explicit");
+  assert.equal(r.routingExplain.basis, "explicit");
+});
+
+test("auto with no rule falls to the default (passthrough)", async (t) => {
+  if (skip) return t.skip("no mongo");
+  const r = await explainRoute({ model: "auto", application: "billing" }, { eff });
+  assert.equal(r.model, "gpt-4o-mini");
+  assert.equal(r.routingDecision, "passthrough");
+});
+
+test("a matching rule is previewed as the rule decision", async (t) => {
+  if (skip) return t.skip("no mongo");
+  await Rule.create({ condition: { application: "billing" }, target: { provider: "openai", model: "gpt-4o" }, enabled: true, priority: 0 });
+  ruleEngine.invalidate();
+  const r = await explainRoute({ model: "auto", application: "billing" }, { eff });
+  assert.equal(r.routingDecision, "rule");
+  assert.equal(r.model, "gpt-4o");
+  await Rule.deleteMany({});
+  ruleEngine.invalidate();
+});
+
+test("an image request pinned to a non-vision model is rejected in preview", async (t) => {
+  if (skip) return t.skip("no mongo");
+  // Explicit pins skip the vision guard by design, so force it via a rule → non-vision
+  // model, then send an image. The guard runs on the routed (non-explicit) model.
+  await Rule.create({ condition: { application: "vis" }, target: { provider: "openai", model: "text-only-8b" }, enabled: true, priority: 0 });
+  ruleEngine.invalidate();
+  await assert.rejects(
+    () => explainRoute({ model: "auto", application: "vis", hasImage: true }, { eff }),
+    (err) => err.code === "vision_not_supported"
+  );
+  await Rule.deleteMany({});
+  ruleEngine.invalidate();
+});
+
+test("preview never makes a billable classification (classifiedBy is not 'ai')", async (t) => {
+  if (skip) return t.skip("no mongo");
+  await ruleEngine.setRoutingMode("ai");
+  const r = await explainRoute({ model: "auto", application: "billing" }, { eff });
+  assert.notEqual(r.classifiedBy, "ai", "dry-run must not invoke the LLM classifier");
+  await ruleEngine.setRoutingMode("off");
+});

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -168,6 +168,7 @@ export const api = {
   testModel: (id, message) => req(`/models/${encodeURIComponent(id)}/test`, { method: "POST", body: JSON.stringify({ message }) }),
 
   rules: () => req("/rules"),
+  explainRoute: (body) => req("/routing/explain", { method: "POST", body: JSON.stringify(body) }),
   createRule: (body) => req("/rules", { method: "POST", body: JSON.stringify(body) }),
   updateRule: (id, body) => req(`/rules/${id}`, { method: "PATCH", body: JSON.stringify(body) }),
   deleteRule: (id) => req(`/rules/${id}`, { method: "DELETE" }),

--- a/web/src/components/RequestsTable.jsx
+++ b/web/src/components/RequestsTable.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback, useRef } from "react";
 import { api, fmt } from "../api.js";
 import { Card, Table, Badge, Drawer, Stat, CodeBlock } from "./ui.jsx";
+import { explainRouting } from "../lib/routingNarration.js";
 
 const ROUTING_TONE = { passthrough: "gray", explicit: "teal", rule: "green", auto: "indigo", ai: "violet", budget: "red", cache: "charcoal", fallback: "amber", external: "teal" };
 
@@ -20,75 +21,6 @@ function FlowNode({ label, value, sub }) {
       {sub && <div className="break-words text-[10px] text-gray-400">{sub}</div>}
     </div>
   );
-}
-
-// Plain-English narration of WHY this model was served, built from routingExplain
-// (captured at decision time) plus the flat record fields. Falls back gracefully on
-// older records that predate routingExplain.
-function explainRouting(r) {
-  const x = r.routingExplain || {};
-  const d = r.routingDecision;
-  const lines = [];
-  const clsBits = [
-    r.taskType,
-    r.difficulty ? `${r.difficulty}${r.difficultyScore ? ` ${r.difficultyScore}/10` : ""}` : null,
-    r.confidence != null ? `confidence ${Number(r.confidence).toFixed(2)}` : null,
-  ].filter(Boolean).join(", ");
-
-  if (d === "explicit") {
-    lines.push(`The client explicitly requested ${r.model}, so Arbr served it directly without applying a routing policy.`);
-  } else if (d === "rule") {
-    const c = x.rule?.condition || {};
-    const on = [c.taskType && `task ${c.taskType}`, c.application && `app ${c.application}`, c.workflow && `workflow ${c.workflow}`].filter(Boolean).join(", ");
-    lines.push(`A routing rule${on ? ` (matching ${on})` : ""} directed this request to ${r.model}.`);
-    if (x.rule?.note) lines.push(`Rule note: ${x.rule.note}`);
-  } else if (d === "ai") {
-    lines.push(`Auto-routing: Arbr classified this as ${clsBits || "unknown"}, and the ${x.policy?.source || "global"} AI policy mapped it to ${r.model}.`);
-    if (x.policy?.adjustedByDifficulty && x.policy?.base) {
-      lines.push(`The policy's base pick was ${x.policy.base}; difficulty${x.policy.effDifficulty ? ` (${x.policy.effDifficulty})` : ""} adjusted it to ${r.model}.`);
-    }
-  } else if (d === "auto") {
-    lines.push(`Guardrail auto-routing substituted ${r.model} based on the task type (${r.taskType || "—"}).`);
-  } else if (d === "cache") {
-    lines.push(`Served from Arbr's response cache — an identical earlier request to ${r.model} was reused, with no new model call.`);
-  } else if (d === "fallback") {
-    lines.push(`The primary model failed, so Arbr fell back to ${r.model}.`);
-  } else if (d === "budget") {
-    lines.push(`A budget cap was breached, so Arbr overrode the routing.`);
-  } else {
-    lines.push(x.defaultScope === "app"
-      ? `No rule or policy matched, so Arbr served this application's default model, ${r.model}.`
-      : `No model was pinned and no rule or policy matched, so Arbr served the default model, ${r.model}.`);
-  }
-
-  // Overrides chain. Older records carry only the single `override`; newer ones
-  // carry the whole ordered `overrides`. Narrating every step is what makes a
-  // model the caller never asked for traceable back to the rule that picked it.
-  const chain = x.overrides?.length ? x.overrides : (x.override ? [x.override] : []);
-  for (const ov of chain) {
-    if (ov?.type === "budget" && ov.action === "downgrade") {
-      lines.push(`Budget override: cap "${ov.cap?.scope}" (${ov.cap?.period}, $${ov.cap?.limit}) was over limit, so ${ov.from} was downgraded to ${ov.to}.`);
-    } else if (ov?.type === "budget" && ov.action === "block") {
-      lines.push(`Budget cap "${ov.cap?.scope}" (${ov.cap?.period}, $${ov.cap?.limit}) was over limit; the request was blocked.`);
-    } else if (ov?.type === "fallback") {
-      lines.push(`Fallback: ${ov.from} failed, so Arbr retried on ${ov.to}.`);
-    } else if (ov?.type === "allowed") {
-      lines.push(`${ov.from} is not in this API key's allowed-model set, so Arbr served the key's default, ${ov.to}.`);
-    } else if (ov?.type === "optout") {
-      lines.push(`${ov.from} is opted out for this application, so Arbr served ${ov.to} instead.`);
-    } else if (ov?.type === "canary") {
-      lines.push(`A canary experiment routed this from ${ov.from} to ${ov.to}.`);
-    }
-  }
-
-  if (x.allowedViolation) {
-    lines.push(`Warning: ${x.allowedViolation.model} was served even though it is not in this key's allowed-model set (${(x.allowedViolation.allowed || []).join(", ")}). The opt-out fallback resolves from the global default, which does not know about the key's allowed set. Narrow the opt-out list or set an allowed key default so the two cannot disagree.`);
-  }
-
-  if (x.classificationUsed === false && r.taskType && (d === "explicit" || d === "passthrough" || d === "cache")) {
-    lines.push(`Classification ran (${r.taskType}${r.difficulty ? `, ${r.difficulty}` : ""}) but did not influence routing.`);
-  }
-  return lines;
 }
 
 function RoutingExplanation({ r }) {

--- a/web/src/lib/routingNarration.js
+++ b/web/src/lib/routingNarration.js
@@ -1,0 +1,71 @@
+// Plain-English narration of WHY a model was served, built from routingExplain
+// (captured at decision time) plus the flat record fields. The single source of
+// truth for routing narration — used by the Requests drawer AND the Routing-page
+// dry-run explainer, so a preview reads exactly like a real request's explanation.
+// Falls back gracefully on older records that predate routingExplain.
+// See docs/routing-spec.md.
+export function explainRouting(r) {
+  const x = r.routingExplain || {};
+  const d = r.routingDecision;
+  const lines = [];
+  const clsBits = [
+    r.taskType,
+    r.difficulty ? `${r.difficulty}${r.difficultyScore ? ` ${r.difficultyScore}/10` : ""}` : null,
+    r.confidence != null ? `confidence ${Number(r.confidence).toFixed(2)}` : null,
+  ].filter(Boolean).join(", ");
+
+  if (d === "explicit") {
+    lines.push(`The client explicitly requested ${r.model}, so Arbr served it directly without applying a routing policy.`);
+  } else if (d === "rule") {
+    const c = x.rule?.condition || {};
+    const on = [c.taskType && `task ${c.taskType}`, c.application && `app ${c.application}`, c.workflow && `workflow ${c.workflow}`].filter(Boolean).join(", ");
+    lines.push(`A routing rule${on ? ` (matching ${on})` : ""} directed this request to ${r.model}.`);
+    if (x.rule?.note) lines.push(`Rule note: ${x.rule.note}`);
+  } else if (d === "ai") {
+    lines.push(`Auto-routing: Arbr classified this as ${clsBits || "unknown"}, and the ${x.policy?.source || "global"} AI policy mapped it to ${r.model}.`);
+    if (x.policy?.adjustedByDifficulty && x.policy?.base) {
+      lines.push(`The policy's base pick was ${x.policy.base}; difficulty${x.policy.effDifficulty ? ` (${x.policy.effDifficulty})` : ""} adjusted it to ${r.model}.`);
+    }
+  } else if (d === "auto") {
+    lines.push(`Guardrail auto-routing substituted ${r.model} based on the task type (${r.taskType || "—"}).`);
+  } else if (d === "cache") {
+    lines.push(`Served from Arbr's response cache — an identical earlier request to ${r.model} was reused, with no new model call.`);
+  } else if (d === "fallback") {
+    lines.push(`The primary model failed, so Arbr fell back to ${r.model}.`);
+  } else if (d === "budget") {
+    lines.push(`A budget cap was breached, so Arbr overrode the routing.`);
+  } else {
+    lines.push(x.defaultScope === "app"
+      ? `No rule or policy matched, so Arbr served this application's default model, ${r.model}.`
+      : `No model was pinned and no rule or policy matched, so Arbr served the default model, ${r.model}.`);
+  }
+
+  // Overrides chain. Older records carry only the single `override`; newer ones
+  // carry the whole ordered `overrides`. Narrating every step is what makes a
+  // model the caller never asked for traceable back to the rule that picked it.
+  const chain = x.overrides?.length ? x.overrides : (x.override ? [x.override] : []);
+  for (const ov of chain) {
+    if (ov?.type === "budget" && ov.action === "downgrade") {
+      lines.push(`Budget override: cap "${ov.cap?.scope}" (${ov.cap?.period}, $${ov.cap?.limit}) was over limit, so ${ov.from} was downgraded to ${ov.to}.`);
+    } else if (ov?.type === "budget" && ov.action === "block") {
+      lines.push(`Budget cap "${ov.cap?.scope}" (${ov.cap?.period}, $${ov.cap?.limit}) was over limit; the request was blocked.`);
+    } else if (ov?.type === "fallback") {
+      lines.push(`Fallback: ${ov.from} failed, so Arbr retried on ${ov.to}.`);
+    } else if (ov?.type === "allowed") {
+      lines.push(`${ov.from} is not in this API key's allowed-model set, so Arbr served the key's default, ${ov.to}.`);
+    } else if (ov?.type === "optout") {
+      lines.push(`${ov.from} is opted out for this application, so Arbr served ${ov.to} instead.`);
+    } else if (ov?.type === "canary") {
+      lines.push(`A canary experiment routed this from ${ov.from} to ${ov.to}.`);
+    }
+  }
+
+  if (x.allowedViolation) {
+    lines.push(`Warning: ${x.allowedViolation.model} was served even though it is not in this key's allowed-model set (${(x.allowedViolation.allowed || []).join(", ")}). The opt-out fallback resolves from the global default, which does not know about the key's allowed set. Narrow the opt-out list or set an allowed key default so the two cannot disagree.`);
+  }
+
+  if (x.classificationUsed === false && r.taskType && (d === "explicit" || d === "passthrough" || d === "cache")) {
+    lines.push(`Classification ran (${r.taskType}${r.difficulty ? `, ${r.difficulty}` : ""}) but did not influence routing.`);
+  }
+  return lines;
+}

--- a/web/src/pages/Routing.jsx
+++ b/web/src/pages/Routing.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { api, fmt } from "../api.js";
 import { Card, Table, Stat, Toggle, Badge, Spinner, Tabs, useTabParam, ConfirmDialog } from "../components/ui.jsx";
+import { explainRouting } from "../lib/routingNarration.js";
 
 // Recommendations moved to its own top-level page (/recommendations).
 const TABS = [
@@ -15,6 +16,87 @@ function cond(c) {
   if (c.application) parts.push(`app = ${c.application}`);
   if (c.workflow) parts.push(`workflow = ${c.workflow}`);
   return parts.length ? parts.join(" · ") : "—";
+}
+
+// Dry-run: "given this hypothetical request, which model would Arbr serve, and why?"
+// Runs through the real routing path server-side (no provider call, no billable
+// classification) so what it shows is exactly what a live request would get.
+const DECISION_TONE = { passthrough: "gray", explicit: "teal", rule: "green", auto: "indigo", ai: "violet", budget: "red", canary: "amber", fallback: "amber" };
+
+function RouteTester() {
+  const [model, setModel] = useState("auto");
+  const [taskType, setTaskType] = useState("");
+  const [application, setApplication] = useState("");
+  const [workflow, setWorkflow] = useState("");
+  const [hasImage, setHasImage] = useState(false);
+  const [res, setRes] = useState(null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState(null);
+
+  const run = async () => {
+    setBusy(true); setErr(null); setRes(null);
+    try {
+      const out = await api.explainRoute({
+        model: model.trim() || "auto",
+        taskType: taskType.trim() || undefined,
+        application: application.trim() || undefined,
+        workflow: workflow.trim() || undefined,
+        hasImage,
+      });
+      setRes(out);
+    } catch (e) { setErr(e.message); }
+    finally { setBusy(false); }
+  };
+
+  const narration = res && !res.rejected ? explainRouting(res) : [];
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-gray-600">
+        Preview what routing would do for a hypothetical request, without sending real traffic. Leave{" "}
+        <span className="font-mono">model</span> as <span className="font-mono">auto</span> to see how rules and the policy decide.
+      </p>
+      <div className="flex flex-wrap items-end gap-3">
+        <div><div className="label mb-1">Model</div><input className="input w-40" value={model} onChange={(e) => setModel(e.target.value)} placeholder="auto" /></div>
+        <div><div className="label mb-1">Task type</div><input className="input w-40" value={taskType} onChange={(e) => setTaskType(e.target.value)} placeholder="(classify)" /></div>
+        <div><div className="label mb-1">Application</div><input className="input w-40" value={application} onChange={(e) => setApplication(e.target.value)} placeholder="(any)" /></div>
+        <div><div className="label mb-1">Workflow</div><input className="input w-36" value={workflow} onChange={(e) => setWorkflow(e.target.value)} placeholder="(any)" /></div>
+        <label className="flex h-9 cursor-pointer items-center gap-2 text-sm text-gray-600">
+          <input type="checkbox" checked={hasImage} onChange={(e) => setHasImage(e.target.checked)} /> Has image
+        </label>
+        <button className="btn-secondary h-9 px-5" disabled={busy} onClick={run}>{busy ? "Previewing…" : "Preview route"}</button>
+      </div>
+      {err && <div className="text-xs text-red-600">{err}</div>}
+
+      {res?.rejected && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm">
+          <div className="font-medium text-red-800">Rejected · {res.rejected.status} {res.rejected.code}</div>
+          <div className="mt-1 text-red-700">{res.rejected.message}</div>
+        </div>
+      )}
+
+      {res && !res.rejected && (
+        <div className="rounded-lg border border-arbr-accent-200 bg-arbr-accent-50 p-4">
+          <div className="mb-2 flex flex-wrap items-center gap-2">
+            <span className="text-xs uppercase tracking-wide text-gray-400">Would serve</span>
+            <Badge tone="charcoal">{res.provider} · {res.model}</Badge>
+            <Badge tone={DECISION_TONE[res.routingDecision] || "gray"}>{res.routingDecision}</Badge>
+            {res.classifiedBy && <span className="text-xs text-gray-400">classified: {res.classifiedBy}</span>}
+          </div>
+          <ul className="space-y-1 text-sm text-gray-700">
+            {narration.map((line, i) => <li key={i}>· {line}</li>)}
+          </ul>
+          {res.budget && (
+            <div className="mt-2 text-sm text-red-700">
+              {res.budget.action === "block"
+                ? `Budget: cap "${res.budget.scope}" (${res.budget.period}, $${res.budget.limit}) is over limit — the request would be blocked (429).`
+                : `Budget: cap "${res.budget.scope}" (${res.budget.period}, $${res.budget.limit}) is over limit — would downgrade to ${res.budget.to || "a lighter model"}.`}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
 }
 
 function CreateRuleForm({ models, onCreated }) {
@@ -508,6 +590,10 @@ export default function Routing({ onChange }) {
 
       {tab === "rules" && (
         <>
+          <Card title="Test a route">
+            <RouteTester />
+          </Card>
+
           <Card title="Create a rule">
             <p className="mb-3 text-sm text-gray-600">
               Map a condition to a target model. The gateway applies it deterministically — no quality guess.


### PR DESCRIPTION
**Phase 3a of the routing hardening** ([docs/routing-spec.md](docs/routing-spec.md) §Known gaps 8). The single biggest usability win: see what routing *would* do without sending live traffic.

## The problem
The only way to learn what routing does was to send a real request and read the Requests log. Reviewing rules, policy, and per-app config was guesswork.

## The approach
`resolveRoute` already makes **no provider call and no logging** in its decision half — the one side effect was the billable LLM classifier. A new **`dryRun`** flag forces keyword-only classification, so the entire precedence can be computed for a hypothetical request at **zero cost, no I/O** beyond DB-cache reads.

- **`routing/explainRoute.js`** wraps `resolveRoute` in dry-run, previews budget enforcement (read-only), and returns a `RequestRecord`-shaped result.
- **`POST /api/routing/explain`** (operator role) exposes it. A routing *rejection* (unresolvable pin, vision, not-allowed) comes back as a preview **outcome**, not an error — so you see exactly what a real request would get.
- **Routing page → "Test a route" panel**: enter model / task type / application / workflow / has-image → see the served model, the decision badge, and the step-by-step narration.

## No drift, by construction
The preview reuses **the real `resolveRoute`** and **the same narration function** as the Requests drawer — extracted to `web/src/lib/routingNarration.js` so there's one source of truth. The preview literally cannot disagree with live behavior.

## Verification
- 5 integration tests (MongoMemoryServer) proving the preview runs the **real** precedence: explicit pin, default passthrough, rule match, **vision rejection**, and that it **never invokes the LLM classifier** (`classifiedBy !== "ai"` even in AI mode)
- Full server suite 348/349 (the one failure is the env-dependent `assertProductionReady`, reproduces on clean main); lint 0 errors; web build compiles
- Narration extraction verified: the Requests drawer imports the same function, web build green

## Why this next (out of plan order)
I brought 3a forward ahead of 2c/2d because the explainer makes the *remaining* routing changes far easier to review — you'll be able to inspect any decision directly instead of inferring it from behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)