### PR TITLE
feat(routing): surface rule-target health + a taskType-pinning hint

### DIFF
--- a/docs/routing-spec.md
+++ b/docs/routing-spec.md
@@ -200,10 +200,12 @@ reflects both today's behavior and the intended end state.
    *Target:* validate every fallback candidate; skip a violating one.
 2. **Budget-downgrade** (`suggestLightTarget`) skips the same re-validation.
    *Target:* validate the downgrade target too.
-3. ~~**Rule targets are served unvalidated**~~ — **closed (#2b).** `findRoute` now
+3. ~~**Rule targets are served unvalidated**~~ — **closed (#2b, #3c).** `findRoute`
    skips a rule whose target provider is offline (routing falls through instead of
    dead-ending on a 502) and warns. An unknown model on a *live* provider is left
-   servable as a legitimate pass-through, matching explicit-pin behavior.
+   servable as a legitimate pass-through, matching explicit-pin behavior. The rules
+   API and console also surface each rule's target health (offline / unknown /
+   unpriced) so a misconfiguration is visible before it bites.
 4. ~~**No rule precedence**~~ — **closed (#2b).** Rules are ordered by priority desc,
    then specificity (condition fields set) desc, then `_id`, so overlapping rules
    resolve deterministically.

--- a/server/src/api/routes/rules.js
+++ b/server/src/api/routes/rules.js
@@ -7,14 +7,28 @@ const ruleEngine = require("../../routing/ruleEngine");
 const responseCache = require("../../routing/responseCache");
 const semanticCache = require("../../routing/semanticCache");
 const connections = require("../../providers/connections");
+const pricing = require("../../pricing/registry");
 const { explainRoute } = require("../../routing/explainRoute");
 const { getAppConfig } = require("../../gateway/handler");
 
 const router = express.Router();
 
+// Annotate each rule with the config-time health of its target, so the console can
+// flag a rule that points at an offline / unknown / unpriced model before it bites.
+async function withHealth(rules) {
+  const eff = await connections.effective();
+  return rules.map((r) => ({
+    ...r,
+    health: ruleEngine.ruleTargetHealth(r.target, {
+      liveIds: eff.liveIds,
+      modelEntry: pricing.getModel(r.target?.model),
+    }),
+  }));
+}
+
 // ── rules ──
 router.get("/rules", async (_req, res, next) => {
-  try { res.json(await Rule.find().sort({ createdAt: -1 }).lean()); } catch (e) { next(e); }
+  try { res.json(await withHealth(await Rule.find().sort({ createdAt: -1 }).lean())); } catch (e) { next(e); }
 });
 
 router.post("/rules", requireRole("operator"), async (req, res, next) => {
@@ -35,7 +49,7 @@ router.post("/rules", requireRole("operator"), async (req, res, next) => {
     });
     ruleEngine.invalidate();
     setImmediate(() => logAction("rule.create", "rule", rule._id, { condition: rule.condition, target, enabled: !!enabled }, req.user));
-    res.json(rule);
+    res.json((await withHealth([rule.toObject()]))[0]);
   } catch (e) { next(e); }
 });
 

--- a/server/src/routing/ruleEngine.js
+++ b/server/src/routing/ruleEngine.js
@@ -58,6 +58,27 @@ function targetServable(rule, eff) {
   return eff.liveIds.includes(rule.target.provider);
 }
 
+// Config-time health of a rule's target, for surfacing misconfiguration in the UI
+// before it bites at request time. Pure — the caller passes the registry entry for
+// the model (or null). Levels:
+//   error — provider offline: the rule will be SKIPPED at runtime (won't route).
+//   warn  — model unknown to the registry (served as pass-through, cost logs $0) or
+//           unpriced (same); works, but attribution/enforcement is blind.
+//   ok    — target is live and priced.
+function ruleTargetHealth(target, { liveIds = [], modelEntry = null } = {}) {
+  const { provider, model } = target || {};
+  if (!liveIds.includes(provider)) {
+    return { level: "error", reason: "provider-offline", detail: `Provider "${provider}" is not connected; this rule is skipped at request time.` };
+  }
+  if (!modelEntry) {
+    return { level: "warn", reason: "model-unknown", detail: `Model "${model}" is not in the registry; it is served as a pass-through and its cost logs as $0.` };
+  }
+  if (!(modelEntry.inputPer1M > 0)) {
+    return { level: "warn", reason: "unpriced", detail: `Model "${model}" has no price; its cost logs as $0 and cannot be enforced by budgets.` };
+  }
+  return { level: "ok" };
+}
+
 function invalidate() {
   _rulesCache.loadedAt = 0;
 }
@@ -125,6 +146,7 @@ module.exports = {
   setRoutingMode,
   invalidate,
   refreshRules,
+  ruleTargetHealth,
   _specificity: specificity, // pure, exported for tests
   _sortRules: sortRules,
   _targetServable: targetServable,

--- a/server/test/unit/ruleEngine.test.js
+++ b/server/test/unit/ruleEngine.test.js
@@ -60,3 +60,29 @@ test("targetServable allows an unknown model on a LIVE provider (pass-through)",
 test("targetServable preserves old behavior when no eff is supplied", () => {
   assert.equal(_targetServable(rule({ target: { provider: "anything", model: "x" } }), null), true);
 });
+
+// Config-time rule health (Phase 3c): surface a misconfigured target before it bites.
+const { ruleTargetHealth } = require("../../src/routing/ruleEngine");
+
+test("ruleTargetHealth: offline provider is an error (rule would be skipped)", () => {
+  const h = ruleTargetHealth({ provider: "cohere", model: "command-r" }, { liveIds: ["openai"], modelEntry: null });
+  assert.equal(h.level, "error");
+  assert.equal(h.reason, "provider-offline");
+});
+
+test("ruleTargetHealth: unknown model on a live provider is a warning (pass-through)", () => {
+  const h = ruleTargetHealth({ provider: "openai", model: "brand-new" }, { liveIds: ["openai"], modelEntry: null });
+  assert.equal(h.level, "warn");
+  assert.equal(h.reason, "model-unknown");
+});
+
+test("ruleTargetHealth: unpriced model is a warning", () => {
+  const h = ruleTargetHealth({ provider: "openai", model: "free-junk" }, { liveIds: ["openai"], modelEntry: { id: "free-junk", inputPer1M: 0 } });
+  assert.equal(h.level, "warn");
+  assert.equal(h.reason, "unpriced");
+});
+
+test("ruleTargetHealth: live + priced target is ok", () => {
+  const h = ruleTargetHealth({ provider: "openai", model: "gpt-4o" }, { liveIds: ["openai"], modelEntry: { id: "gpt-4o", inputPer1M: 2.5 } });
+  assert.equal(h.level, "ok");
+});

--- a/web/src/pages/Routing.jsx
+++ b/web/src/pages/Routing.jsx
@@ -56,6 +56,10 @@ function RouteTester() {
         Preview what routing would do for a hypothetical request, without sending real traffic. Leave{" "}
         <span className="font-mono">model</span> as <span className="font-mono">auto</span> to see how rules and the policy decide.
       </p>
+      <p className="text-xs text-gray-400">
+        Tip for developers: pass <span className="font-mono">taskType</span> in the request body to skip the AI
+        classifier entirely — it is free, deterministic, and avoids a per-request LLM call.
+      </p>
       <div className="flex flex-wrap items-end gap-3">
         <div><div className="label mb-1">Model</div><input className="input w-40" value={model} onChange={(e) => setModel(e.target.value)} placeholder="auto" /></div>
         <div><div className="label mb-1">Task type</div><input className="input w-40" value={taskType} onChange={(e) => setTaskType(e.target.value)} placeholder="(classify)" /></div>
@@ -108,6 +112,7 @@ function CreateRuleForm({ models, onCreated }) {
   const [priority, setPriority] = useState(0);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState(null);
+  const [warn, setWarn] = useState(null);
 
   const providers = [...new Set(models.map((m) => m.provider))];
   const providerModels = models.filter((m) => m.provider === provider);
@@ -116,18 +121,20 @@ function CreateRuleForm({ models, onCreated }) {
   useEffect(() => { if (providerModels.length) setModel(providerModels[0].id); }, [provider]);
 
   const submit = async () => {
-    setErr(null);
+    setErr(null); setWarn(null);
     if (!value.trim()) return setErr("Enter a condition value.");
     if (!provider || !model) return setErr("Pick a target provider and model.");
     setBusy(true);
     try {
-      await api.createRule({
+      const created = await api.createRule({
         condition: { [field]: value.trim() },
         target: { provider, model },
         enabled,
         priority: Number(priority) || 0,
         note: `${field}=${value.trim()} → ${model}`,
       });
+      // Surface a target-health warning immediately (offline / unknown / unpriced).
+      if (created?.health && created.health.level !== "ok") setWarn(created.health.detail);
       setValue("");
       await onCreated();
     } catch (e) { setErr(e.message); }
@@ -173,6 +180,7 @@ function CreateRuleForm({ models, onCreated }) {
         <button className="btn-secondary h-9 px-5" disabled={busy} onClick={submit}>{busy ? "Adding…" : "Add rule"}</button>
       </div>
       {err && <div className="text-xs text-red-600">{err}</div>}
+      {warn && <div className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800">Rule created, but heads up: {warn}</div>}
     </div>
   );
 }
@@ -619,7 +627,15 @@ export default function Routing({ onChange }) {
                   ) },
                   { key: "condition", header: "When", render: (r) => cond(r.condition) },
                   { key: "target", header: "Route to", render: (r) => (
-                    <Badge tone="charcoal">{r.target.provider} · {r.target.model}</Badge>
+                    <div className="flex items-center gap-2">
+                      <Badge tone="charcoal">{r.target.provider} · {r.target.model}</Badge>
+                      {r.health && r.health.level === "error" && (
+                        <span title={r.health.detail}><Badge tone="red">offline</Badge></span>
+                      )}
+                      {r.health && r.health.level === "warn" && (
+                        <span title={r.health.detail}><Badge tone="amber">{r.health.reason === "unpriced" ? "unpriced" : "unknown"}</Badge></span>
+                      )}
+                    </div>
                   ) },
                   { key: "note", header: "Note", render: (r) => <span className="text-gray-500">{r.note || "—"}</span> },
                   { key: "actions", header: "", render: (r) => (


### PR DESCRIPTION
**Phase 3c of the routing hardening** — make misconfiguration *visible before it bites*, the class of problem behind the recent incidents.

## Rule-target health

A new pure `ruleTargetHealth()` (in `ruleEngine`) classifies each rule's target:

| level | meaning |
|---|---|
| **error** | provider offline — the rule is **skipped at request time** (won't route, per #2b) |
| **warn** | model unknown to the registry (pass-through, cost logs $0) or unpriced |
| **ok** | live and priced |

`GET /rules` and the create response are annotated with it. The Routing console shows an **offline / unpriced / unknown** badge next to each rule's target, and an amber notice **immediately after creating a risky rule** — so the operator sees *why* a rule won't behave, without waiting for live traffic to reveal it.

This complements #2b (which already skips an offline-target rule at runtime): #2b fixed the behavior, this makes it observable.

## Developer ergonomics

The "Test a route" panel now surfaces **`taskType` pinning**: passing `taskType` in the request body skips the AI classifier — free, deterministic, and no per-request LLM call. This is the cheapest, most predictable path for a developer who already knows the task.

## Verification
- 4 new unit tests on `ruleTargetHealth` (offline→error, unknown→warn, unpriced→warn, live+priced→ok)
- Full server suite 352/353 (the one failure is the env-dependent `assertProductionReady`, reproduces on clean main); lint 0 errors; web build compiles
- routing-spec.md gap #3 updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)