### PR TITLE
feat(usage): scoped read-only usage tokens — self-serve per-user usage

### DIFF
--- a/docs/usage-api.md
+++ b/docs/usage-api.md
@@ -1,0 +1,54 @@
+# Scoped usage API (read tokens)
+
+Lets a partner app — or an end user directly — read **only their own** usage, without
+the admin key and without proxying through a backend. A **read token** is a
+scoped, read-only credential: it can read one application's (and optionally one
+user's) analytics, and nothing else. It cannot run inference.
+
+## Create a read token
+
+In the console: **Settings → API keys → Type: "Read token (usage only)"**, set the
+Application (and optionally a User ID) it is scoped to. The full token is shown once,
+prefixed `ab_read_…`.
+
+Via the admin API:
+
+```sh
+curl -X POST $ARBR/api/keys \
+  -H "Authorization: Bearer $ARBR_ADMIN_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{ "kind": "read", "name": "alice usage", "application": "acme", "userId": "alice@co" }'
+# → { ..., "kind": "read", "key": "ab_read_…" }   (key shown ONCE)
+```
+
+Omit `userId` for an application-wide read token.
+
+## Read usage
+
+Authenticate with the read token. The scope is **fixed by the token** — query params
+cannot widen it.
+
+```sh
+curl https://models.example.com/v1/usage/overview \
+  -H "Authorization: Bearer ab_read_…"
+```
+
+| Endpoint | Returns |
+|---|---|
+| `GET /v1/usage/overview` | Headline stats for the scope: total cost, requests, tokens, success rate, cache hit rate. |
+| `GET /v1/usage/timeseries?bucket=day` | Cost / request trend. `bucket` ∈ `hour` \| `day` \| `month`. |
+| `GET /v1/usage/by-model` | Spend and usage broken down by model. |
+| `GET /v1/usage/scope` | The token's own `{ application, userId }`. |
+
+The numbers are the same aggregation the console shows (`analytics/aggregate.js`),
+restricted to the token's scope and to customer traffic (Arbr's own internal
+overhead is excluded).
+
+## Guarantees
+
+- A read token on the data plane (`/v1/chat`, `/v1/chat/completions`) is rejected
+  `401 read_token_on_data_plane` — it can never serve a completion.
+- A gateway key on `/v1/usage/*` is rejected `401 invalid_read_token`.
+- The scope is server-forced; passing `?application=…&userId=…` does not change what a
+  token can see.
+- Revoke or rotate a read token exactly like a gateway key (Settings → API keys).

--- a/server/src/api/routes/keys.js
+++ b/server/src/api/routes/keys.js
@@ -12,6 +12,7 @@ const router = express.Router();
 function keyView(d) {
   return {
     _id: d._id, name: d.name, application: d.application, prefix: d.prefix,
+    kind: d.kind || "gateway",
     enabled: d.enabled, rpm: d.rpm, createdAt: d.createdAt, lastUsedAt: d.lastUsedAt,
     userId: d.userId || null, department: d.department || null,
     expiresAt: d.expiresAt || null,
@@ -31,22 +32,27 @@ router.post("/keys", requireRole("operator"), async (req, res, next) => {
     const { name, application, rpm, allowedModels, defaultModel, userId, department, expiresAt } = req.body || {};
     if (!name || !String(name).trim()) return res.status(400).json({ error: "name is required" });
     if (!application || !String(application).trim()) return res.status(400).json({ error: "application is required" });
-    const secret = "ab_" + crypto.randomBytes(16).toString("hex");
+    // A "read" token is a scoped, read-only usage token (see ApiKey.kind); anything
+    // else is a normal data-plane gateway key. The prefix advertises which it is.
+    const kind = req.body?.kind === "read" ? "read" : "gateway";
+    const secret = (kind === "read" ? "ab_read_" : "ab_") + crypto.randomBytes(16).toString("hex");
     const parsedExpiry = expiresAt ? new Date(expiresAt) : null;
     const doc = await ApiKey.create({
       name: String(name).trim(),
       application: String(application).trim(),
+      kind,
       keyHash: auth.hashKey(secret),
-      prefix: `ab_…${secret.slice(-4)}`,
-      rpm: Number(rpm) > 0 ? Number(rpm) : null,
+      prefix: `${kind === "read" ? "ab_read_…" : "ab_…"}${secret.slice(-4)}`,
+      // Data-plane knobs are meaningless for a read token; leave them at defaults.
+      rpm: kind === "gateway" && Number(rpm) > 0 ? Number(rpm) : null,
       userId: userId ? String(userId).trim() || null : null,
       department: department ? String(department).trim() || null : null,
-      allowedModels: Array.isArray(allowedModels) ? allowedModels.filter(Boolean) : [],
-      defaultModel: defaultModel ? String(defaultModel).trim() || null : null,
+      allowedModels: kind === "gateway" && Array.isArray(allowedModels) ? allowedModels.filter(Boolean) : [],
+      defaultModel: kind === "gateway" && defaultModel ? String(defaultModel).trim() || null : null,
       expiresAt: parsedExpiry && !isNaN(parsedExpiry) ? parsedExpiry : null,
     });
     auth.invalidate();
-    setImmediate(() => logAction("key.create", "key", doc._id, { name: doc.name, application: doc.application, userId: doc.userId }, req.user));
+    setImmediate(() => logAction("key.create", "key", doc._id, { name: doc.name, application: doc.application, userId: doc.userId, kind }, req.user));
     // The ONLY time the full secret is ever returned.
     res.json({ ...keyView(doc.toObject()), key: secret });
   } catch (e) { next(e); }

--- a/server/src/api/routes/usage.js
+++ b/server/src/api/routes/usage.js
@@ -1,0 +1,45 @@
+// Scoped, read-only usage API (/v1/usage/*).
+//
+// Authenticated by a "read" token (see gateway/readTokenAuth.js), which sets
+// req.readScope = { application, userId }. Every query is FORCED to that scope, so a
+// token can only ever read its own application (+ optional user) — the caller cannot
+// widen it by passing query params. This is the self-serve, per-end-user usage view
+// a partner app needs without proxying through the admin key.
+//
+// Mounted OUTSIDE the /api adminAuth gate (see index.js). Reuses the same analytics
+// aggregation the console uses, so numbers match exactly.
+const express = require("express");
+const analytics = require("../../analytics/aggregate");
+
+const router = express.Router();
+
+const BUCKETS = new Set(["hour", "day", "month"]);
+
+// Headline stats for this token's scope: cost, requests, tokens, success rate, cache.
+router.get("/overview", async (req, res, next) => {
+  try {
+    res.json(await analytics.overview(req.readScope));
+  } catch (e) { next(e); }
+});
+
+// Cost / request trend over time, for a chart. bucket ∈ hour | day | month.
+router.get("/timeseries", async (req, res, next) => {
+  try {
+    const bucket = BUCKETS.has(req.query.bucket) ? req.query.bucket : "day";
+    res.json(await analytics.timeseries(req.readScope, bucket));
+  } catch (e) { next(e); }
+});
+
+// Spend + usage broken down by model, within this token's scope.
+router.get("/by-model", async (req, res, next) => {
+  try {
+    res.json(await analytics.byModel(req.readScope));
+  } catch (e) { next(e); }
+});
+
+// Echo the token's own scope, so a client knows what it is allowed to see.
+router.get("/scope", (req, res) => {
+  res.json({ application: req.readScope.application, userId: req.readScope.userId });
+});
+
+module.exports = router;

--- a/server/src/gateway/auth.js
+++ b/server/src/gateway/auth.js
@@ -71,6 +71,11 @@ async function resolveKey(authHeader) {
     err.statusCode = 401;
     throw err;
   }
+  if (doc.kind === "read") {
+    const err = new Error("This is a read-only usage token; it cannot run inference. Use a gateway key.");
+    err.statusCode = 401;
+    throw err;
+  }
   if (doc.expiresAt && doc.expiresAt < new Date()) {
     const err = new Error(`API key "${doc.name}" expired on ${doc.expiresAt.toISOString().slice(0, 10)}.`);
     err.statusCode = 401;
@@ -110,6 +115,9 @@ async function middleware(req, res, next) {
       if (!doc) {
         return res.status(401).json({ error: "invalid_api_key", message: "Unknown, disabled, or revoked API key." });
       }
+      if (doc.kind === "read") {
+        return res.status(401).json({ error: "read_token_on_data_plane", message: "This is a read-only usage token; it cannot run inference. Use a gateway key for /v1/chat." });
+      }
       if (doc.expiresAt && doc.expiresAt < new Date()) {
         return res.status(401).json({ error: "expired_api_key", message: `API key "${doc.name}" expired on ${doc.expiresAt.toISOString().slice(0, 10)}.` });
       }
@@ -136,4 +144,33 @@ async function middleware(req, res, next) {
   }
 }
 
-module.exports = { middleware, resolveKey, hashKey, invalidate, requireApiKeyOn, setRequireApiKey };
+// Validate a READ token (the scoped usage credential). Mirrors resolveKey but
+// requires kind === "read" and applies no rpm limit (reads are cheap). Returns the
+// key doc (whose application + userId are the forced analytics scope), or throws
+// with .statusCode. Used by gateway/readTokenAuth.js.
+async function resolveReadToken(authHeader) {
+  const raw = authHeader && authHeader.startsWith("Bearer ")
+    ? authHeader.slice(7).trim()
+    : null;
+  if (!raw) {
+    const err = new Error("A read token is required (Authorization: Bearer ab_read_…).");
+    err.statusCode = 401;
+    throw err;
+  }
+  const keys = await _keysByHash();
+  const doc = keys.get(hashKey(raw));
+  if (!doc || doc.kind !== "read") {
+    const err = new Error("Unknown, revoked, or non-read token.");
+    err.statusCode = 401;
+    throw err;
+  }
+  if (doc.expiresAt && doc.expiresAt < new Date()) {
+    const err = new Error(`Read token "${doc.name}" expired on ${doc.expiresAt.toISOString().slice(0, 10)}.`);
+    err.statusCode = 401;
+    throw err;
+  }
+  stampLastUsed(doc);
+  return doc;
+}
+
+module.exports = { middleware, resolveKey, resolveReadToken, hashKey, invalidate, requireApiKeyOn, setRequireApiKey };

--- a/server/src/gateway/readTokenAuth.js
+++ b/server/src/gateway/readTokenAuth.js
@@ -1,0 +1,24 @@
+// Express middleware for the scoped, read-only usage API (/v1/usage/*).
+//
+// Validates a "read" token and attaches its forced analytics scope to the request:
+//   req.readScope = { application, userId }
+// The scope comes from the token (set at creation, trusted), never from the request,
+// so a token can only ever read its own application (+ optional user). This is what
+// lets a partner app expose per-end-user usage without the admin key.
+const auth = require("./auth");
+
+async function middleware(req, res, next) {
+  try {
+    const doc = await auth.resolveReadToken(req.headers.authorization || "");
+    req.readScope = { application: doc.application, userId: doc.userId || null };
+    req.readToken = doc;
+    return next();
+  } catch (err) {
+    if (err.statusCode) {
+      return res.status(err.statusCode).json({ error: "invalid_read_token", message: err.message });
+    }
+    return next(err);
+  }
+}
+
+module.exports = { middleware };

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -12,6 +12,8 @@ const registry = require("./pricing/registry");
 const { TASK_CATALOG } = require("./classify/classifier");
 const { handleChat } = require("./gateway/handler");
 const { handleOpenAICompat } = require("./gateway/openaiCompat");
+const readTokenAuth = require("./gateway/readTokenAuth");
+const usageRoutes = require("./api/routes/usage");
 const { handleEmbeddings } = require("./gateway/embeddings");
 const { handleIngest } = require("./gateway/ingest");
 const { handleUpgrade, closeAll: closeRealtimeSessions } = require("./gateway/wsAuth");
@@ -123,6 +125,11 @@ async function start() {
 
   // OpenAI-compatible endpoint — any client that speaks the OpenAI spec can use Arbr.
   app.post("/v1/chat/completions", auth.middleware, handleOpenAICompat);
+
+  // Scoped, read-only usage API — a "read" token sees ONLY its own application
+  // (+ optional user) analytics. Guarded by readTokenAuth (not the admin key), so a
+  // partner app can expose per-end-user usage without proxying through ARBR_ADMIN_KEY.
+  app.use("/v1/usage", adminRateLimit.middleware, readTokenAuth.middleware, usageRoutes);
 
   // OpenAI-compatible embeddings endpoint — routes to the appropriate provider
   // (Gemini or OpenAI-compat) based on the model ID, with full observability.

--- a/server/src/models/ApiKey.js
+++ b/server/src/models/ApiKey.js
@@ -7,6 +7,12 @@ const apiKeySchema = new mongoose.Schema(
   {
     name: { type: String, required: true },
     application: { type: String, required: true, index: true },
+    // "gateway" (default) — a data-plane key that runs inference at /v1/chat, bound
+    // to this application for trusted attribution. "read" — a scoped, read-only usage
+    // token: it can read ONLY this application's (+ optional userId's) analytics via
+    // /v1/usage, and is rejected on the data plane. Lets a partner app expose
+    // self-serve per-user usage without proxying through the admin key.
+    kind: { type: String, enum: ["gateway", "read"], default: "gateway", index: true },
     keyHash: { type: String, required: true, unique: true },
     // Display-only identifier, e.g. "ka_…a1b2" (never enough to reconstruct).
     prefix: { type: String, required: true },

--- a/server/test/integration/usageToken.test.js
+++ b/server/test/integration/usageToken.test.js
@@ -1,0 +1,112 @@
+"use strict";
+// Integration: the scoped read-only usage token (#2 keystone).
+// Proves a "read" token sees ONLY its own application (+ user) analytics, cannot
+// widen its scope via query params, is rejected on the data plane, and that a normal
+// gateway key is rejected on /v1/usage. Uses MongoMemoryServer; skips if unavailable.
+const { test, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const mongoose = require("mongoose");
+
+let mongod, skip = false;
+let agent, RAW = {};
+
+before(async () => {
+  try {
+    const { MongoMemoryServer } = require("mongodb-memory-server");
+    mongod = await MongoMemoryServer.create();
+    await mongoose.connect(mongod.getUri());
+  } catch (err) {
+    skip = true;
+    console.warn("[usageToken] skipping — no in-memory Mongo:", err.message);
+    return;
+  }
+  const express = require("express");
+  const supertest = require("supertest");
+  const ApiKey = require("../../src/models/ApiKey");
+  const RequestRecord = require("../../src/models/RequestRecord");
+  const auth = require("../../src/gateway/auth");
+  const readTokenAuth = require("../../src/gateway/readTokenAuth");
+  const usageRoutes = require("../../src/api/routes/usage");
+
+  await ApiKey.deleteMany({});
+  await RequestRecord.deleteMany({});
+
+  // A read token scoped to acme / userA, a read token scoped to acme (app-wide),
+  // and a normal gateway key. Create with known secrets via hashKey.
+  RAW = { userA: "ab_read_" + "a".repeat(32), app: "ab_read_" + "b".repeat(32), gw: "ab_" + "c".repeat(32) };
+  await ApiKey.create([
+    { name: "userA usage", application: "acme", kind: "read", userId: "userA", keyHash: auth.hashKey(RAW.userA), prefix: "ab_read_…aaaa" },
+    { name: "acme usage", application: "acme", kind: "read", keyHash: auth.hashKey(RAW.app), prefix: "ab_read_…bbbb" },
+    { name: "acme gateway", application: "acme", kind: "gateway", keyHash: auth.hashKey(RAW.gw), prefix: "ab_…cccc" },
+  ]);
+  // Customer records: userA spent $3 on acme, userB spent $7 on acme, and another
+  // app "other" spent $99. internalKind null = customer traffic (counts in overview).
+  await RequestRecord.create([
+    { requestId: "r1", application: "acme", userId: "userA", model: "gpt-4o", totalCost: 3, totalTokens: 100, status: "success", internalKind: null },
+    { requestId: "r2", application: "acme", userId: "userB", model: "gpt-4o", totalCost: 7, totalTokens: 200, status: "success", internalKind: null },
+    { requestId: "r3", application: "other", userId: "userC", model: "gpt-4o", totalCost: 99, totalTokens: 900, status: "success", internalKind: null },
+  ]);
+
+  const app = express();
+  app.use(express.json());
+  app.use("/v1/usage", readTokenAuth.middleware, usageRoutes);
+  // Minimal data-plane surface: just the auth guard, then OK.
+  app.post("/v1/chat", auth.middleware, (req, res) => res.json({ ok: true }));
+  agent = supertest(app);
+});
+
+after(async () => {
+  if (skip) return;
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+const bearer = (t) => ({ Authorization: `Bearer ${t}` });
+
+test("a user-scoped read token sees ONLY its own user's spend", async (t) => {
+  if (skip) return t.skip("no mongo");
+  const res = await agent.get("/v1/usage/overview").set(bearer(RAW.userA));
+  assert.equal(res.status, 200);
+  assert.equal(res.body.totalCost, 3, "userA sees only their $3, not userB's $7 or other-app's $99");
+});
+
+test("an app-scoped read token sees the whole application, not other apps", async (t) => {
+  if (skip) return t.skip("no mongo");
+  const res = await agent.get("/v1/usage/overview").set(bearer(RAW.app));
+  assert.equal(res.status, 200);
+  assert.equal(res.body.totalCost, 10, "acme app = $3 + $7, excludes other-app's $99");
+});
+
+test("scope cannot be widened via query params (forced from the token)", async (t) => {
+  if (skip) return t.skip("no mongo");
+  // Try to read another app / user — the endpoint ignores query and uses the token scope.
+  const res = await agent.get("/v1/usage/overview?application=other&userId=userB").set(bearer(RAW.userA));
+  assert.equal(res.status, 200);
+  assert.equal(res.body.totalCost, 3, "query params must not override the token's scope");
+});
+
+test("the scope endpoint reports the token's own scope", async (t) => {
+  if (skip) return t.skip("no mongo");
+  const res = await agent.get("/v1/usage/scope").set(bearer(RAW.userA));
+  assert.deepEqual(res.body, { application: "acme", userId: "userA" });
+});
+
+test("a read token is rejected on the data plane (/v1/chat)", async (t) => {
+  if (skip) return t.skip("no mongo");
+  const res = await agent.post("/v1/chat").set(bearer(RAW.userA)).send({ messages: [] });
+  assert.equal(res.status, 401);
+  assert.equal(res.body.error, "read_token_on_data_plane");
+});
+
+test("a gateway key is rejected on /v1/usage", async (t) => {
+  if (skip) return t.skip("no mongo");
+  const res = await agent.get("/v1/usage/overview").set(bearer(RAW.gw));
+  assert.equal(res.status, 401);
+  assert.equal(res.body.error, "invalid_read_token");
+});
+
+test("no token is rejected on /v1/usage", async (t) => {
+  if (skip) return t.skip("no mongo");
+  const res = await agent.get("/v1/usage/overview");
+  assert.equal(res.status, 401);
+});

--- a/web/src/pages/Settings.jsx
+++ b/web/src/pages/Settings.jsx
@@ -42,7 +42,12 @@ function KeyRow({ k, onToggle, onRevoke, onSave, onRotate }) {
 
   return (
     <tr className="border-t border-gray-100">
-      <td className="py-2 font-mono text-xs text-gray-600">{k.prefix}</td>
+      <td className="py-2 font-mono text-xs text-gray-600">
+        <div className="flex items-center gap-2">
+          {k.prefix}
+          {k.kind === "read" && <Badge tone="charcoal">read</Badge>}
+        </div>
+      </td>
       <td className="py-2">
         {editing ? (
           <div className="space-y-1">
@@ -102,6 +107,7 @@ function KeyRow({ k, onToggle, onRevoke, onSave, onRotate }) {
 function ApiKeys({ onChange }) {
   const [keys, setKeys]               = useState(null);
   const [name, setName]               = useState("");
+  const [kind, setKind]               = useState("gateway");
   const [application, setApplication] = useState("");
   const [userId, setUserId]           = useState("");
   const [department, setDepartment]   = useState("");
@@ -125,6 +131,7 @@ function ApiKeys({ onChange }) {
       const parsedAllowed = allowedModels.split(",").map((s) => s.trim()).filter(Boolean);
       const res = await api.createKey({
         name: name.trim(),
+        kind,
         application: application.trim(),
         userId: userId.trim() || null,
         department: department.trim() || null,
@@ -206,6 +213,13 @@ function ApiKeys({ onChange }) {
 
       <div className="flex flex-wrap items-end gap-3 border-b border-gray-100 pb-5">
         <div>
+          <div className="label mb-1">Type</div>
+          <select className="input w-48" value={kind} onChange={(e) => setKind(e.target.value)}>
+            <option value="gateway">Gateway key (runs inference)</option>
+            <option value="read">Read token (usage only)</option>
+          </select>
+        </div>
+        <div>
           <div className="label mb-1">Name</div>
           <input className="input w-44" placeholder="e.g. tester-laptop" value={name} onChange={(e) => setName(e.target.value)} />
         </div>
@@ -237,8 +251,15 @@ function ApiKeys({ onChange }) {
           <div className="label mb-1">Expires at (optional)</div>
           <input className="input w-40" type="date" value={expiresAt} onChange={(e) => setExpiresAt(e.target.value)} />
         </div>
-        <button className="btn-secondary" disabled={busy} onClick={create}>Create key</button>
+        <button className="btn-secondary" disabled={busy} onClick={create}>Create {kind === "read" ? "token" : "key"}</button>
         {err && <div className="w-full text-xs text-red-600">{err}</div>}
+        {kind === "read" && (
+          <div className="w-full text-xs text-gray-500">
+            A read token reads only this application {userId.trim() ? `and user "${userId.trim()}"` : "(all users)"}
+            's usage via <code className="rounded bg-gray-100 px-1">GET /v1/usage/overview</code>. It cannot run
+            inference, and rate limit / default model / allowed models do not apply.
+          </div>
+        )}
       </div>
 
       {keys === null ? <Spinner /> : keys.length === 0 ? (


### PR DESCRIPTION
**Keystone of the self-service initiative** (roadmap in the plan). Addresses gap #2 — no end-user credential — and unblocks #3 (self-rotation), #4 (per-user alerts), and #5 (embeddable chart).

## The problem
The entire analytics API is gated by `ARBR_ADMIN_KEY`. So any partner app that wants to show a signup user *their own* usage must proxy every call through its own backend with the admin key. There is no lower-privilege "let me see my own usage" credential.

## The fix: a scoped read token
A new **`read`** token — a scoped, read-only credential that returns **only** its own application (+ optional `userId`) analytics, and **cannot run inference**.

Almost entirely composition of existing parts:
- `ApiKey` already has hashing / prefix / one-time reveal / revoke / rotate and `userId`+`application` attribution
- `analytics/aggregate.js` already filters by `application`+`userId` via `buildMatch` (`overview` / `timeseries` / `byModel` all take the filter)

What's new:
- **`ApiKey.kind`** (`gateway` | `read`, default `gateway`). `keys.js` mints a read token (`ab_read_…`).
- **`gateway/auth.js`** rejects a read token on `/v1/chat*` (`401 read_token_on_data_plane`) and adds `resolveReadToken`; **`gateway/readTokenAuth.js`** validates it and forces `req.readScope = { application, userId }`.
- **`/v1/usage/{overview,timeseries,by-model,scope}`** — mounted **outside** the `/api` admin gate, guarded by the read token, **scope forced from the token** so a caller cannot widen it with query params.
- **Settings → API keys**: a Type selector + a `read` badge; **`docs/usage-api.md`**.

## Security proof (7 integration tests, MongoMemoryServer)
- A user-scoped token sees **only its own** spend (`$3`), not another user's (`$7`) or another app's (`$99`)
- An app-scoped token sees the whole app (`$10`), not other apps
- **Scope cannot be widened** via `?application=…&userId=…` (forced from the token)
- A read token is **401 on `/v1/chat`**; a gateway key is **401 on `/v1/usage`**; no token is 401

## Verification
- Full server suite 352/353 (the one failure is the env-dependent `assertProductionReady`, reproduces on clean main); lint 0 errors; web build compiles

## Next (per the roadmap)
#3 self-service rotation reuses this token's auth; #5 embeddable chart consumes `/v1/usage/timeseries`; #4 per-user alerts use the same per-user identity; #1 currency (live FX) runs in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)