### PR TITLE
feat(keys): self-service key rotate/revoke — a key manages itself

### DIFF
--- a/docs/usage-api.md
+++ b/docs/usage-api.md
@@ -52,3 +52,25 @@ overhead is excluded).
 - The scope is server-forced; passing `?application=…&userId=…` does not change what a
   token can see.
 - Revoke or rotate a read token exactly like a gateway key (Settings → API keys).
+
+## Self-service rotate / revoke
+
+A key's own holder can manage it with the key itself as proof of possession — no admin
+role. Works for both read tokens and gateway keys. Useful when a key may be
+compromised and the holder is not an operator.
+
+```sh
+# What am I holding?
+curl https://models.example.com/v1/key -H "Authorization: Bearer $KEY"
+
+# Rotate: the old key stops working immediately; the new secret is returned once,
+# with identical settings (kind, application, userId, limits).
+curl -X POST https://models.example.com/v1/key/rotate -H "Authorization: Bearer $KEY"
+# → { ..., "key": "ab_… (or ab_read_…)" }
+
+# Revoke: disable this key immediately (irreversible).
+curl -X POST https://models.example.com/v1/key/revoke -H "Authorization: Bearer $KEY"
+```
+
+Note: whoever holds the key can rotate or revoke it, so treat rotation as the
+response to a suspected compromise — rotate first, from a trusted copy.

--- a/server/src/api/keyRotation.js
+++ b/server/src/api/keyRotation.js
@@ -1,0 +1,32 @@
+// Rotate an API key: revoke the old one and mint a replacement with identical
+// settings — including its kind ("gateway" | "read") and scope (application, userId).
+// Shared by the operator rotate endpoint (routes/keys.js) and the self-service rotate
+// endpoint (routes/selfKey.js) so the two can never drift — an earlier copy of this
+// logic forgot `kind`, which would silently downgrade a rotated read token to a
+// gateway key. Returns { doc, secret }; the secret is shown exactly once.
+const crypto = require("crypto");
+const ApiKey = require("../models/ApiKey");
+const auth = require("../gateway/auth");
+
+async function rotateKey(old) {
+  await ApiKey.findByIdAndUpdate(old._id, { enabled: false, revokedAt: new Date() });
+  const isRead = old.kind === "read";
+  const secret = (isRead ? "ab_read_" : "ab_") + crypto.randomBytes(16).toString("hex");
+  const doc = await ApiKey.create({
+    name: old.name,
+    application: old.application,
+    kind: old.kind || "gateway",
+    keyHash: auth.hashKey(secret),
+    prefix: `${isRead ? "ab_read_…" : "ab_…"}${secret.slice(-4)}`,
+    rpm: old.rpm,
+    userId: old.userId || null,
+    department: old.department || null,
+    allowedModels: old.allowedModels || [],
+    defaultModel: old.defaultModel || null,
+    expiresAt: old.expiresAt || null,
+  });
+  auth.invalidate();
+  return { doc, secret };
+}
+
+module.exports = { rotateKey };

--- a/server/src/api/routes/keys.js
+++ b/server/src/api/routes/keys.js
@@ -4,6 +4,7 @@ const ApiKey = require("../../models/ApiKey");
 const auth = require("../../gateway/auth");
 const { logAction } = require("../auditLogger");
 const { requireRole } = require("../rbac");
+const { rotateKey } = require("../keyRotation");
 const crypto = require("crypto");
 
 const router = express.Router();
@@ -94,21 +95,7 @@ router.post("/keys/:id/rotate", requireRole("operator"), async (req, res, next) 
   try {
     const old = await ApiKey.findById(req.params.id).lean();
     if (!old || old.revokedAt) return res.status(404).json({ error: "Key not found or already revoked." });
-    await ApiKey.findByIdAndUpdate(req.params.id, { enabled: false, revokedAt: new Date() });
-    const secret = "ab_" + crypto.randomBytes(16).toString("hex");
-    const doc = await ApiKey.create({
-      name: old.name,
-      application: old.application,
-      keyHash: auth.hashKey(secret),
-      prefix: `ab_…${secret.slice(-4)}`,
-      rpm: old.rpm,
-      userId: old.userId || null,
-      department: old.department || null,
-      allowedModels: old.allowedModels || [],
-      defaultModel: old.defaultModel || null,
-      expiresAt: old.expiresAt || null,
-    });
-    auth.invalidate();
+    const { doc, secret } = await rotateKey(old); // preserves kind + scope
     setImmediate(() => logAction("key.rotate", "key", doc._id, { replacedId: old._id, name: doc.name, application: doc.application }, req.user));
     res.json({ ...keyView(doc.toObject()), key: secret });
   } catch (e) { next(e); }

--- a/server/src/api/routes/selfKey.js
+++ b/server/src/api/routes/selfKey.js
@@ -1,0 +1,51 @@
+// Self-service key management (/v1/key/*).
+//
+// The caller authenticates with the key itself (see gateway/selfKeyAuth.js) and can
+// view, rotate, or revoke ONLY that key — no operator/admin role needed. This closes
+// the gap where a plain end user could not rotate their own (possibly compromised)
+// key without asking an admin. Mounted OUTSIDE the /api admin gate.
+const express = require("express");
+const ApiKey = require("../../models/ApiKey");
+const auth = require("../../gateway/auth");
+const { rotateKey } = require("../keyRotation");
+const { logAction } = require("../auditLogger");
+
+const router = express.Router();
+
+// Non-secret view of the caller's own key.
+function selfView(d) {
+  return {
+    name: d.name, application: d.application, kind: d.kind || "gateway",
+    prefix: d.prefix, userId: d.userId || null, department: d.department || null,
+    enabled: d.enabled, expiresAt: d.expiresAt || null,
+    createdAt: d.createdAt, lastUsedAt: d.lastUsedAt,
+  };
+}
+
+// GET /v1/key — what am I holding?
+router.get("/", (req, res) => res.json(selfView(req.selfKey)));
+
+// POST /v1/key/rotate — revoke this key, mint a replacement with identical settings.
+// The old key stops working immediately; the new secret is returned exactly once.
+router.post("/rotate", async (req, res, next) => {
+  try {
+    const old = req.selfKey;
+    const { doc, secret } = await rotateKey(old);
+    // actor is the key itself (no admin user); audit the self-rotation.
+    setImmediate(() => logAction("key.rotate.self", "key", doc._id, { replacedId: old._id, application: doc.application, kind: doc.kind }, null));
+    res.json({ ...selfView(doc.toObject ? doc.toObject() : doc), key: secret });
+  } catch (e) { next(e); }
+});
+
+// POST /v1/key/revoke — disable this key immediately. Irreversible.
+router.post("/revoke", async (req, res, next) => {
+  try {
+    const old = req.selfKey;
+    await ApiKey.findByIdAndUpdate(old._id, { enabled: false, revokedAt: new Date() });
+    auth.invalidate();
+    setImmediate(() => logAction("key.revoke.self", "key", old._id, { application: old.application, kind: old.kind }, null));
+    res.json({ revoked: true });
+  } catch (e) { next(e); }
+});
+
+module.exports = router;

--- a/server/src/gateway/auth.js
+++ b/server/src/gateway/auth.js
@@ -173,4 +173,33 @@ async function resolveReadToken(authHeader) {
   return doc;
 }
 
-module.exports = { middleware, resolveKey, resolveReadToken, hashKey, invalidate, requireApiKeyOn, setRequireApiKey };
+// Validate ANY valid key (gateway or read) for self-management (rotate/revoke a key
+// using the key itself as proof of possession). No kind restriction and no rpm limit
+// — the caller is only touching its own credential, not the data plane. Returns the
+// key doc, or throws with .statusCode. Used by gateway/selfKeyAuth.js.
+async function resolveAnyKey(authHeader) {
+  const raw = authHeader && authHeader.startsWith("Bearer ")
+    ? authHeader.slice(7).trim()
+    : null;
+  if (!raw) {
+    const err = new Error("A key is required (Authorization: Bearer ab_… or ab_read_…).");
+    err.statusCode = 401;
+    throw err;
+  }
+  const keys = await _keysByHash();
+  const doc = keys.get(hashKey(raw));
+  if (!doc) {
+    const err = new Error("Unknown, disabled, or revoked key.");
+    err.statusCode = 401;
+    throw err;
+  }
+  if (doc.expiresAt && doc.expiresAt < new Date()) {
+    const err = new Error(`Key "${doc.name}" expired on ${doc.expiresAt.toISOString().slice(0, 10)}.`);
+    err.statusCode = 401;
+    throw err;
+  }
+  stampLastUsed(doc);
+  return doc;
+}
+
+module.exports = { middleware, resolveKey, resolveReadToken, resolveAnyKey, hashKey, invalidate, requireApiKeyOn, setRequireApiKey };

--- a/server/src/gateway/selfKeyAuth.js
+++ b/server/src/gateway/selfKeyAuth.js
@@ -1,0 +1,18 @@
+// Express middleware for self-service key management (/v1/key/*). The presented key
+// authenticates itself (proof of possession); the request may then view, rotate, or
+// revoke ONLY that key. Works for both gateway keys and read tokens.
+const auth = require("./auth");
+
+async function middleware(req, res, next) {
+  try {
+    req.selfKey = await auth.resolveAnyKey(req.headers.authorization || "");
+    return next();
+  } catch (err) {
+    if (err.statusCode) {
+      return res.status(err.statusCode).json({ error: "invalid_key", message: err.message });
+    }
+    return next(err);
+  }
+}
+
+module.exports = { middleware };

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -14,6 +14,8 @@ const { handleChat } = require("./gateway/handler");
 const { handleOpenAICompat } = require("./gateway/openaiCompat");
 const readTokenAuth = require("./gateway/readTokenAuth");
 const usageRoutes = require("./api/routes/usage");
+const selfKeyAuth = require("./gateway/selfKeyAuth");
+const selfKeyRoutes = require("./api/routes/selfKey");
 const { handleEmbeddings } = require("./gateway/embeddings");
 const { handleIngest } = require("./gateway/ingest");
 const { handleUpgrade, closeAll: closeRealtimeSessions } = require("./gateway/wsAuth");
@@ -130,6 +132,11 @@ async function start() {
   // (+ optional user) analytics. Guarded by readTokenAuth (not the admin key), so a
   // partner app can expose per-end-user usage without proxying through ARBR_ADMIN_KEY.
   app.use("/v1/usage", adminRateLimit.middleware, readTokenAuth.middleware, usageRoutes);
+
+  // Self-service key management — the caller authenticates with the key itself and can
+  // view / rotate / revoke ONLY that key, no admin role. Lets a key's own holder rotate
+  // a compromised key without an operator.
+  app.use("/v1/key", adminRateLimit.middleware, selfKeyAuth.middleware, selfKeyRoutes);
 
   // OpenAI-compatible embeddings endpoint — routes to the appropriate provider
   // (Gemini or OpenAI-compat) based on the model ID, with full observability.

--- a/server/test/integration/selfKey.test.js
+++ b/server/test/integration/selfKey.test.js
@@ -1,0 +1,86 @@
+"use strict";
+// Integration: self-service key management (#3). A key's own holder can view, rotate,
+// and revoke it with the key itself as proof of possession — no admin role. Rotation
+// preserves kind + scope and invalidates the old key. Uses MongoMemoryServer.
+const { test, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const mongoose = require("mongoose");
+
+let mongod, skip = false, agent, ApiKey, auth, RAW = {};
+
+before(async () => {
+  try {
+    const { MongoMemoryServer } = require("mongodb-memory-server");
+    mongod = await MongoMemoryServer.create();
+    await mongoose.connect(mongod.getUri());
+  } catch (err) { skip = true; console.warn("[selfKey] skipping — no mongo:", err.message); return; }
+  const express = require("express");
+  const supertest = require("supertest");
+  ApiKey = require("../../src/models/ApiKey");
+  auth = require("../../src/gateway/auth");
+  const selfKeyAuth = require("../../src/gateway/selfKeyAuth");
+  const selfKeyRoutes = require("../../src/api/routes/selfKey");
+
+  await ApiKey.deleteMany({});
+  RAW = { gw: "ab_" + "a".repeat(32), read: "ab_read_" + "b".repeat(32) };
+  await ApiKey.create([
+    { name: "gw", application: "acme", kind: "gateway", userId: "alice", rpm: 60, keyHash: auth.hashKey(RAW.gw), prefix: "ab_…aaaa" },
+    { name: "usage", application: "acme", kind: "read", userId: "alice", keyHash: auth.hashKey(RAW.read), prefix: "ab_read_…bbbb" },
+  ]);
+
+  const app = express();
+  app.use(express.json());
+  app.use("/v1/key", selfKeyAuth.middleware, selfKeyRoutes);
+  agent = supertest(app);
+});
+
+after(async () => { if (skip) return; await mongoose.disconnect(); await mongod.stop(); });
+
+const bearer = (t) => ({ Authorization: `Bearer ${t}` });
+
+test("GET /v1/key returns the caller's own key metadata", async (t) => {
+  if (skip) return t.skip("no mongo");
+  const res = await agent.get("/v1/key").set(bearer(RAW.gw));
+  assert.equal(res.status, 200);
+  assert.equal(res.body.application, "acme");
+  assert.equal(res.body.kind, "gateway");
+});
+
+test("no key is 401", async (t) => {
+  if (skip) return t.skip("no mongo");
+  assert.equal((await agent.get("/v1/key")).status, 401);
+});
+
+test("rotating a READ token preserves kind + scope and returns a read secret", async (t) => {
+  if (skip) return t.skip("no mongo");
+  const res = await agent.post("/v1/key/rotate").set(bearer(RAW.read));
+  assert.equal(res.status, 200);
+  assert.equal(res.body.kind, "read", "rotation must NOT downgrade a read token to gateway");
+  assert.equal(res.body.application, "acme");
+  assert.equal(res.body.userId, "alice");
+  assert.ok(res.body.key.startsWith("ab_read_"), "new secret keeps the read prefix");
+  // The OLD read token no longer authenticates.
+  auth.invalidate();
+  assert.equal((await agent.get("/v1/key").set(bearer(RAW.read))).status, 401);
+  // The NEW one does, and is still a read token.
+  const again = await agent.get("/v1/key").set(bearer(res.body.key));
+  assert.equal(again.body.kind, "read");
+});
+
+test("rotating a GATEWAY key preserves its settings", async (t) => {
+  if (skip) return t.skip("no mongo");
+  const res = await agent.post("/v1/key/rotate").set(bearer(RAW.gw));
+  assert.equal(res.status, 200);
+  assert.equal(res.body.kind, "gateway");
+  assert.ok(res.body.key.startsWith("ab_") && !res.body.key.startsWith("ab_read_"));
+  RAW.gw = res.body.key; // keep for the revoke test
+});
+
+test("self-revoke disables the key immediately", async (t) => {
+  if (skip) return t.skip("no mongo");
+  const res = await agent.post("/v1/key/revoke").set(bearer(RAW.gw));
+  assert.equal(res.status, 200);
+  assert.equal(res.body.revoked, true);
+  auth.invalidate();
+  assert.equal((await agent.get("/v1/key").set(bearer(RAW.gw))).status, 401);
+});


### PR DESCRIPTION
**Feature #3 of the self-service initiative** (builds on the #243 read-token auth).

## The gap
Rotating or revoking a key required **operator/administrator** role. A plain end user holding a key — a gateway key, or a read token from #243 — had no way to rotate a compromised key without asking an admin.

## The fix
`/v1/key`, mounted **outside** the admin gate and authenticated by the **key itself** (proof of possession — `gateway/selfKeyAuth.js` + `auth.resolveAnyKey`):

| Endpoint | Does |
|---|---|
| `GET /v1/key` | Returns the caller's own key metadata |
| `POST /v1/key/rotate` | Revokes this key, mints a replacement — old stops immediately, new secret returned once, identical settings |
| `POST /v1/key/revoke` | Disables this key immediately |

Works for both gateway keys and read tokens.

## Bonus: fixed a latent rotation bug
Rotation logic is extracted to **`api/keyRotation.js`** and shared with the operator rotate endpoint. That surfaced (and fixes) a latent bug: **the operator rotate path didn't preserve `kind`**, so rotating a read token silently downgraded it to a gateway key. The shared helper preserves kind + scope, and a test asserts a rotated read token stays a read token.

## Verification
- 5 integration tests: view own key, 401 without a key, rotate a **read** token (kind preserved, old key dies, new is still read), rotate a gateway key, self-revoke disables immediately
- Full server suite 352/353 (the one failure is the env-dependent `assertProductionReady`, reproduces on clean main); lint 0 errors
- API-only, no web change

## Security note
Whoever holds the key can rotate/revoke it — that's the point (self-service response to a suspected compromise: rotate first from a trusted copy). Documented in `docs/usage-api.md`. Rate-limited per IP via the existing `adminRateLimit`; Bearer-authenticated so CSRF doesn't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)