### PR TITLE
feat(embed): embeddable per-user usage chart (iframe widget)

### DIFF
--- a/docs/usage-api.md
+++ b/docs/usage-api.md
@@ -52,3 +52,23 @@ overhead is excluded).
 - The scope is server-forced; passing `?application=…&userId=…` does not change what a
   token can see.
 - Revoke or rotate a read token exactly like a gateway key (Settings → API keys).
+
+## Embeddable usage chart
+
+Drop a live per-user usage chart into your own app with an `<iframe>` — no rebuild,
+no admin key:
+
+```html
+<iframe src="https://models.example.com/embed/usage#token=ab_read_…&metric=cost&bucket=day"
+        style="width:100%;height:220px;border:0"></iframe>
+```
+
+- The read token goes in the URL **fragment** (`#token=…`), which the browser never
+  sends to the server or leaks via `Referer` — so it stays out of access logs.
+- The page is served by Arbr and fetches `/v1/usage/*` **same-origin**, so there is no
+  CORS setup. It renders an inline SVG (no external scripts), scoped to the token.
+- Options in the fragment: `metric` (`cost` | `requests`), `bucket`
+  (`hour` | `day` | `month`).
+
+Because a read token only ever exposes its own scope, embedding one is as safe as the
+token itself.

--- a/server/src/api/routes/embed.js
+++ b/server/src/api/routes/embed.js
@@ -1,0 +1,14 @@
+// Public embeddable widgets (no auth on the page itself — the read token supplied in
+// the URL fragment gates the data). Intentionally framable: no X-Frame-Options is set
+// (the app sets none globally), so a partner can drop it into an <iframe>.
+const express = require("express");
+const { PAGE } = require("../../embed/usageChart");
+
+const router = express.Router();
+
+router.get("/usage", (_req, res) => {
+  res.set("Cache-Control", "public, max-age=300");
+  res.type("html").send(PAGE);
+});
+
+module.exports = router;

--- a/server/src/embed/usageChart.js
+++ b/server/src/embed/usageChart.js
@@ -1,0 +1,83 @@
+// Embeddable usage chart — a self-contained page a partner drops into an <iframe>
+// to show an end user their own usage, no rebuild and no admin key.
+//
+// It is served same-origin by Arbr (GET /embed/usage), so its fetches to /v1/usage
+// have no CORS problem, and it reads the read token from the URL FRAGMENT
+// (#token=ab_read_…), which browsers never send to the server or leak via Referer.
+// The token gates the data; the page itself is public.
+//
+// chartGeometry is pure and unit-tested; the page embeds its exact source via
+// toString(), so the rendered chart and the tested math are one and the same.
+
+// Map timeseries rows to an SVG polyline for one metric within a viewBox. Pure.
+// rows: [{ date, cost, requests, ... }]. Returns { points, max, width, height, pad }.
+function chartGeometry(rows, opts) {
+  const o = opts || {};
+  const metric = o.metric || "cost";
+  const width = o.width || 640;
+  const height = o.height || 180;
+  const pad = o.pad || 28;
+  const n = rows.length;
+  const vals = rows.map(function (r) { return Number(r[metric]) || 0; });
+  const max = Math.max.apply(null, [1e-9].concat(vals));
+  const innerW = width - pad * 2;
+  const innerH = height - pad * 2;
+  const points = rows.map(function (r, i) {
+    const x = pad + (n <= 1 ? innerW / 2 : (i / (n - 1)) * innerW);
+    const y = pad + innerH - ((Number(r[metric]) || 0) / max) * innerH;
+    return x.toFixed(1) + "," + y.toFixed(1);
+  }).join(" ");
+  return { points: points, max: max, width: width, height: height, pad: pad };
+}
+
+const PAGE = `<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Usage</title>
+<style>
+  :root { color-scheme: light dark; }
+  html,body { margin:0; font:14px/1.4 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; }
+  .wrap { padding:14px; }
+  .head { display:flex; justify-content:space-between; align-items:baseline; gap:10px; flex-wrap:wrap; margin-bottom:8px; }
+  .scope { color:#888; font-size:12px; }
+  .total { font-size:20px; font-weight:600; }
+  .total small { font-size:12px; font-weight:400; color:#888; }
+  svg { width:100%; height:auto; display:block; }
+  .line { fill:none; stroke:#2f37ff; stroke-width:2; }
+  .area { fill:#2f37ff; opacity:.08; }
+  .msg { color:#c0392b; padding:14px; }
+  .empty { color:#888; padding:14px; }
+</style></head><body><div class="wrap" id="root">Loading…</div>
+<script>
+${chartGeometry.toString()}
+(function () {
+  var root = document.getElementById("root");
+  var h = new URLSearchParams((location.hash || "").replace(/^#/, ""));
+  var token = h.get("token");
+  var metric = h.get("metric") === "requests" ? "requests" : "cost";
+  var bucket = ["hour","day","month"].indexOf(h.get("bucket")) >= 0 ? h.get("bucket") : "day";
+  if (!token) { root.innerHTML = '<div class="msg">Missing token. Embed with #token=ab_read_…</div>'; return; }
+  var hdr = { Authorization: "Bearer " + token };
+  Promise.all([
+    fetch("/v1/usage/timeseries?bucket=" + bucket, { headers: hdr }).then(function (r) { if (!r.ok) throw new Error("unauthorized"); return r.json(); }),
+    fetch("/v1/usage/scope", { headers: hdr }).then(function (r) { return r.ok ? r.json() : {}; })
+  ]).then(function (res) {
+    var rows = res[0] || [], scope = res[1] || {};
+    if (!rows.length) { root.innerHTML = '<div class="empty">No usage yet.</div>'; return; }
+    var g = chartGeometry(rows, { metric: metric });
+    var total = rows.reduce(function (s, r) { return s + (Number(r[metric]) || 0); }, 0);
+    var totalStr = metric === "cost" ? "$" + total.toFixed(2) : String(Math.round(total));
+    var scopeStr = (scope.application || "") + (scope.userId ? " · " + scope.userId : "");
+    var area = g.points ? ("M" + g.pad + "," + (g.height - g.pad) + " L" + g.points.replace(/ /g, " L") + " L" + (g.width - g.pad) + "," + (g.height - g.pad) + " Z") : "";
+    root.innerHTML =
+      '<div class="head"><div class="total">' + totalStr + ' <small>' + metric + ' · last ' + rows.length + ' ' + bucket + 's</small></div>' +
+      '<div class="scope">' + scopeStr + '</div></div>' +
+      '<svg viewBox="0 0 ' + g.width + ' ' + g.height + '" preserveAspectRatio="none" role="img" aria-label="usage trend">' +
+      '<path class="area" d="' + area + '"/>' +
+      '<polyline class="line" points="' + g.points + '"/></svg>';
+  }).catch(function () {
+    root.innerHTML = '<div class="msg">Could not load usage. Check the read token.</div>';
+  });
+})();
+</script></body></html>`;
+
+module.exports = { chartGeometry, PAGE };

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -14,6 +14,7 @@ const { handleChat } = require("./gateway/handler");
 const { handleOpenAICompat } = require("./gateway/openaiCompat");
 const readTokenAuth = require("./gateway/readTokenAuth");
 const usageRoutes = require("./api/routes/usage");
+const embedRoutes = require("./api/routes/embed");
 const { handleEmbeddings } = require("./gateway/embeddings");
 const { handleIngest } = require("./gateway/ingest");
 const { handleUpgrade, closeAll: closeRealtimeSessions } = require("./gateway/wsAuth");
@@ -130,6 +131,11 @@ async function start() {
   // (+ optional user) analytics. Guarded by readTokenAuth (not the admin key), so a
   // partner app can expose per-end-user usage without proxying through ARBR_ADMIN_KEY.
   app.use("/v1/usage", adminRateLimit.middleware, readTokenAuth.middleware, usageRoutes);
+
+  // Embeddable widgets — a partner iframes /embed/usage#token=ab_read_… to show an end
+  // user their own usage chart. Public page; the read token (in the URL fragment, never
+  // sent to the server) gates the data, and the page fetches /v1/usage same-origin.
+  app.use("/embed", embedRoutes);
 
   // OpenAI-compatible embeddings endpoint — routes to the appropriate provider
   // (Gemini or OpenAI-compat) based on the model ID, with full observability.

--- a/server/test/integration/embed.test.js
+++ b/server/test/integration/embed.test.js
@@ -1,0 +1,28 @@
+"use strict";
+// Integration: the embed route serves the widget page (no auth, no DB needed).
+const { test, before } = require("node:test");
+const assert = require("node:assert/strict");
+
+let agent, skip = false;
+
+before(() => {
+  try {
+    const express = require("express");
+    const supertest = require("supertest");
+    const embedRoutes = require("../../src/api/routes/embed");
+    const app = express();
+    app.use("/embed", embedRoutes);
+    agent = supertest(app);
+  } catch (err) { skip = true; console.warn("[embed] skipping:", err.message); }
+});
+
+test("GET /embed/usage serves a self-contained HTML widget", async (t) => {
+  if (skip) return t.skip("no supertest");
+  const res = await agent.get("/embed/usage");
+  assert.equal(res.status, 200);
+  assert.match(res.headers["content-type"], /text\/html/);
+  assert.ok(res.text.includes("<svg") === false || res.text.includes("chartGeometry"), "page carries the chart bootstrap");
+  assert.ok(res.text.includes("location.hash"), "reads the token from the fragment");
+  // Cacheable but not too long.
+  assert.match(res.headers["cache-control"] || "", /max-age=/);
+});

--- a/server/test/unit/usageChart.test.js
+++ b/server/test/unit/usageChart.test.js
@@ -1,0 +1,44 @@
+"use strict";
+// Unit tests for the embeddable usage chart (#5): the pure geometry helper, and that
+// the served page is well-formed and embeds that exact helper.
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { chartGeometry, PAGE } = require("../../src/embed/usageChart");
+
+test("chartGeometry maps rows to a polyline within the viewBox", () => {
+  const rows = [{ date: "2026-01-01", cost: 0 }, { date: "2026-01-02", cost: 5 }, { date: "2026-01-03", cost: 10 }];
+  const g = chartGeometry(rows, { metric: "cost", width: 100, height: 100, pad: 10 });
+  const pts = g.points.split(" ").map((p) => p.split(",").map(Number));
+  assert.equal(pts.length, 3);
+  assert.equal(g.max, 10);
+  // First x at left pad, last x at right pad.
+  assert.equal(pts[0][0], 10);
+  assert.equal(pts[2][0], 90);
+  // Max value (row 3) sits at the top pad; zero (row 1) at the bottom.
+  assert.equal(pts[2][1], 10, "the max value is at the top (y = pad)");
+  assert.equal(pts[0][1], 90, "zero is at the bottom (y = height - pad)");
+});
+
+test("chartGeometry centers a single point and never divides by zero", () => {
+  const g = chartGeometry([{ cost: 3 }], { metric: "cost", width: 100, height: 100, pad: 10 });
+  const [x] = g.points.split(",").map(Number);
+  assert.equal(x, 50, "a lone point is centered");
+});
+
+test("chartGeometry handles all-zero series without NaN (max floored)", () => {
+  const g = chartGeometry([{ cost: 0 }, { cost: 0 }], { metric: "cost", width: 100, height: 100, pad: 10 });
+  assert.ok(!/NaN/.test(g.points), "no NaN coordinates");
+});
+
+test("chartGeometry selects the requested metric", () => {
+  const rows = [{ cost: 1, requests: 100 }, { cost: 2, requests: 50 }];
+  assert.equal(chartGeometry(rows, { metric: "requests" }).max, 100);
+  assert.equal(chartGeometry(rows, { metric: "cost" }).max, 2);
+});
+
+test("the served page embeds the exact chartGeometry source and reads the token from the fragment", () => {
+  assert.ok(PAGE.includes("function chartGeometry"), "geometry is inlined, so page and tests share one source");
+  assert.ok(PAGE.includes("location.hash"), "token comes from the URL fragment, not a query/param");
+  assert.ok(PAGE.includes("/v1/usage/timeseries"), "fetches the scoped timeseries endpoint");
+  assert.ok(!PAGE.includes("</scr" + "ipt><scr" + "ipt"), "single inline script");
+});


### PR DESCRIPTION
**Feature #5 of the self-service initiative** (its own PR, consuming the merged `/v1/usage` endpoints from #243).

## The gap
`TrendChart` lives only inside Arbr's admin web bundle, so a partner app couldn't show an end user a usage chart without rebuilding one.

## The fix: a drop-in iframe widget
`GET /embed/usage` serves a **self-contained HTML page** (inline SVG, no external scripts, no dependencies) a partner embeds:

```html
<iframe src="https://models.example.com/embed/usage#token=ab_read_…&metric=cost&bucket=day"
        style="width:100%;height:220px;border:0"></iframe>
```

Two deliberate design choices make it safe and simple:
- **Token in the URL fragment** (`#token=…`) — the browser never sends a fragment to the server or leaks it via `Referer`, so the token stays out of access logs.
- **Served same-origin** by Arbr, so its `/v1/usage` fetches need **no CORS setup** (a cross-origin web component would have hit Arbr's dashboard-locked CORS).

It renders the same scoped data the console shows, gated entirely by the read token — which only ever exposes its own scope.

## One source for the math
`chartGeometry` (`server/src/embed/usageChart.js`) is a **pure function embedded into the page via `toString()`**, so the rendered chart and the unit-tested geometry are the same code — they can't drift.

## Verification
- 6 tests: geometry (row→polyline mapping, single-point centering, all-zero safety, metric selection) and the served page (well-formed HTML, reads the fragment token, hits the scoped endpoint)
- Full server suite 357/358 (the one failure is the env-dependent `assertProductionReady`, reproduces on clean main); lint 0 errors
- Server-only; no web-bundle change. (Couldn't screenshot in this env — Playwright browser unavailable — but the geometry + page structure are unit-covered.)

## Remaining in the initiative
#4 (per-user alerts) and #1 (live-FX currency) follow, each as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)