### PR TITLE
feat(currency): live-FX display currency (INR and others)

### DIFF
--- a/server/src/api/routes/currency.js
+++ b/server/src/api/routes/currency.js
@@ -1,0 +1,31 @@
+// Admin API routes — display currency (live FX).
+const express = require("express");
+const fx = require("../../currency/fx");
+const { requireRole } = require("../rbac");
+const { logAction } = require("../auditLogger");
+
+const router = express.Router();
+
+// Current display currency + rate + freshness (stale/available). Read by the console.
+router.get("/currency", async (_req, res, next) => {
+  try { res.json(await fx.getState()); } catch (e) { next(e); }
+});
+
+// Set the display currency; fx.setCurrency resets the cached rate then fetches the new
+// one, so a failed fetch can't leave the previous currency's rate under the new label.
+router.put("/currency", requireRole("administrator"), async (req, res, next) => {
+  try {
+    const code = String(req.body?.currency || "USD").trim().toUpperCase().slice(0, 3);
+    if (!/^[A-Z]{3}$/.test(code)) return res.status(400).json({ error: "currency must be a 3-letter code (e.g. USD, INR)" });
+    const state = await fx.setCurrency(code);
+    setImmediate(() => logAction("currency.set", "settings", "global", { currency: code, rate: state.rate, available: state.available }, req.user));
+    res.json(state);
+  } catch (e) { next(e); }
+});
+
+// Force an FX rate refresh now (otherwise it runs on a schedule).
+router.post("/currency/refresh", requireRole("operator"), async (_req, res, next) => {
+  try { res.json(await fx.refreshRate()); } catch (e) { next(e); }
+});
+
+module.exports = router;

--- a/server/src/api/routes/index.js
+++ b/server/src/api/routes/index.js
@@ -10,6 +10,7 @@ router.use(require("./connections.js"));
 router.use(require("./customProviders.js"));
 router.use(require("./models.js"));
 router.use(require("./analytics.js"));
+router.use(require("./currency.js"));
 router.use(require("./requests.js"));
 router.use(require("./recommendations.js"));
 router.use(require("./evalBenchmarks.js"));

--- a/server/src/currency/fx.js
+++ b/server/src/currency/fx.js
@@ -1,0 +1,108 @@
+// Live FX for display currency. Costs are stored in USD everywhere (LiteLLM-native);
+// this fetches a USD→currency rate on a schedule and caches it in Settings, so the
+// dashboard can show ₹ (or any currency) without changing any stored value.
+//
+// Failure is handled so a cost figure is never WRONG:
+//   - Multiple keyless providers are tried in order.
+//   - If all fail but a good rate was fetched before, the last one is kept (stale-ok)
+//     and flagged `stale` so the UI can say so.
+//   - If a rate was NEVER fetched for the current currency (`available: false`), the
+//     UI falls back to showing USD rather than applying a bogus 1:1 rate under a
+//     foreign label ("₹1.20" for $1.20 would badly understate cost).
+//   - Switching currency resets the cached rate first, so a failed fetch can't
+//     misapply the PREVIOUS currency's rate under the new label.
+const Settings = require("../models/Settings");
+
+const REFRESH_MS = Number(process.env.ARBR_FX_REFRESH_MS) || 12 * 60 * 60 * 1000; // twice a day
+const STALE_MS   = Number(process.env.ARBR_FX_STALE_MS)   || 48 * 60 * 60 * 1000; // 2 days
+
+function num(v) { return typeof v === "number" && v > 0 ? v : null; }
+
+// Ordered, keyless FX providers. `url(currency)` and `parse(json, currency)` per source.
+const PROVIDERS = [
+  { name: "er-api",
+    url: () => process.env.ARBR_FX_URL || "https://open.er-api.com/v6/latest/USD",
+    parse: (j, c) => num(j && j.rates && j.rates[c]) },
+  { name: "frankfurter",
+    url: (c) => `https://api.frankfurter.app/latest?from=USD&to=${c}`,
+    parse: (j, c) => num(j && j.rates && j.rates[c]) },
+];
+
+// Pure: pull the USD→`currency` rate out of a provider's response. Exported for tests.
+function parseRate(json, currency) {
+  const rates = json && json.rates;
+  return num(rates && rates[String(currency || "").toUpperCase()]);
+}
+
+// Pure: USD amount → display amount. rate defaults to 1 (USD / unknown).
+function convert(usd, rate) {
+  return (Number(usd) || 0) * (Number(rate) > 0 ? Number(rate) : 1);
+}
+
+// Try each provider in order; first positive rate wins; null if all fail.
+async function fetchRate(currency) {
+  for (const p of PROVIDERS) {
+    try {
+      const resp = await fetch(p.url(currency), { signal: AbortSignal.timeout(8000) });
+      if (!resp || !resp.ok) continue;
+      const rate = p.parse(await resp.json(), currency);
+      if (rate) return rate;
+    } catch { /* try the next provider */ }
+  }
+  return null;
+}
+
+// { currency, rate, updatedAt, stale, available }. `available` means a real rate has
+// been fetched for this currency (USD is always available at 1). `stale` means it is
+// available but older than STALE_MS.
+function state(currency, rate, updatedAt) {
+  const cur = String(currency || "USD").toUpperCase();
+  const available = cur === "USD" || !!updatedAt;
+  const stale = cur !== "USD" && (!updatedAt || Date.now() - new Date(updatedAt).getTime() > STALE_MS);
+  return { currency: cur, rate: Number(rate) > 0 ? Number(rate) : 1, updatedAt: updatedAt || null, stale, available };
+}
+
+// Fetch the rate for the configured currency and cache it. USD short-circuits to 1.
+// Keeps the previous rate on total failure; never throws.
+async function refreshRate() {
+  const s = await Settings.get();
+  const currency = (s.currency || "USD").toUpperCase();
+  if (currency === "USD") {
+    if (s.fxRate !== 1 || s.fxUpdatedAt == null) { s.fxRate = 1; s.fxUpdatedAt = new Date(); await s.save(); Settings.invalidateCache(); }
+    return state("USD", 1, s.fxUpdatedAt || new Date());
+  }
+  const rate = await fetchRate(currency);
+  if (rate) {
+    s.fxRate = rate; s.fxUpdatedAt = new Date(); await s.save(); Settings.invalidateCache();
+    return state(currency, rate, s.fxUpdatedAt);
+  }
+  console.warn(`[fx] all providers failed for ${currency}; ` +
+    (s.fxUpdatedAt ? `keeping last rate ${s.fxRate} (stale)` : "no rate yet — display falls back to USD"));
+  return state(currency, s.fxRate || 1, s.fxUpdatedAt || null);
+}
+
+// Switch display currency. Reset the cached rate FIRST so a failed fetch cannot
+// misapply the previous currency's rate under the new label, then fetch the new one.
+async function setCurrency(code) {
+  const currency = String(code || "USD").toUpperCase();
+  const s = await Settings.get();
+  s.currency = currency; s.fxRate = 1; s.fxUpdatedAt = null;
+  await s.save(); Settings.invalidateCache();
+  return refreshRate();
+}
+
+async function getState() {
+  try { const s = await Settings.get(); return state((s.currency || "USD").toUpperCase(), s.fxRate || 1, s.fxUpdatedAt || null); }
+  catch { return state("USD", 1, new Date()); }
+}
+
+let _timer = null;
+function startAutoRefresh(ms = REFRESH_MS) {
+  if (_timer || !(ms > 0)) return;
+  refreshRate().catch(() => {});
+  _timer = setInterval(() => refreshRate().catch(() => {}), ms);
+  if (_timer.unref) _timer.unref();
+}
+function stopAutoRefresh() { if (_timer) { clearInterval(_timer); _timer = null; } }
+
+module.exports = { parseRate, convert, fetchRate, state, refreshRate, setCurrency, getState, startAutoRefresh, stopAutoRefresh };

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -61,6 +61,7 @@ async function start() {
   await registry.init(); // seed ModelEntry if empty + warm in-memory cache
   await backfillInternalKind(); // idempotent; no-op after the first run
   telemetry.init(); // OTLP trace export — a no-op unless ARBR_OTEL_ENABLED is set
+  require("./currency/fx").startAutoRefresh(); // live USD→display-currency rate (no-op for USD)
 
   // Production: force data-plane API keys on so anonymous /v1 calls are rejected.
   if (config.isProduction) {

--- a/server/src/models/Settings.js
+++ b/server/src/models/Settings.js
@@ -61,6 +61,12 @@ const settingsSchema = new mongoose.Schema(
     maxTokensGuardrail: { type: Number, default: null },
     // Webhook URL for real-time alerts (cap breach, provider errors, new unknown applications).
     webhookUrl: { type: String, default: null },
+    // Display currency. Costs are always STORED in USD (LiteLLM-native); this only
+    // converts them for display. fxRate is USD→currency, refreshed live from an FX
+    // source; fxUpdatedAt lets the UI show how fresh the rate is. USD keeps rate 1.
+    currency: { type: String, default: "USD" },
+    fxRate: { type: Number, default: 1 },
+    fxUpdatedAt: { type: Date, default: null },
     // Request record retention in days. Records older than this are auto-purged daily.
     retentionDays: { type: Number, default: PRIVACY_DEFAULTS.retentionDays },
     // PII masking: when enabled, PII patterns are redacted from prompts before logging.

--- a/server/test/unit/fx.test.js
+++ b/server/test/unit/fx.test.js
@@ -1,0 +1,86 @@
+"use strict";
+// Unit tests for the live-FX display currency (#1): the pure conversion + rate parse,
+// the multi-provider fetch fallback, and the availability/staleness state that keeps a
+// failed FX fetch from ever showing a wrong number.
+const { test, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const { convert, parseRate, fetchRate, state } = require("../../src/currency/fx");
+
+const realFetch = global.fetch;
+afterEach(() => { global.fetch = realFetch; });
+
+test("convert multiplies a USD amount by the rate", () => {
+  assert.equal(convert(2, 83.5), 167);
+  assert.equal(convert(0, 83.5), 0);
+});
+
+test("convert defaults to a 1:1 rate for USD / missing / invalid rate", () => {
+  assert.equal(convert(5), 5);
+  assert.equal(convert(5, 0), 5, "a zero rate falls back to 1, never zeroing every cost");
+  assert.equal(convert(5, -3), 5);
+  assert.equal(convert(5, null), 5);
+});
+
+test("convert coerces non-numeric input to 0", () => {
+  assert.equal(convert("abc", 83.5), 0);
+});
+
+test("parseRate pulls the requested currency (case-insensitive) or null", () => {
+  const json = { rates: { INR: 83.5, EUR: 0.92 } };
+  assert.equal(parseRate(json, "inr"), 83.5);
+  assert.equal(parseRate(json, "XYZ"), null);
+  assert.equal(parseRate({}, "INR"), null);
+  assert.equal(parseRate({ rates: { INR: 0 } }, "INR"), null, "non-positive rate rejected");
+});
+
+// The fallback the user asked to harden: if the first provider fails, try the next.
+test("fetchRate falls back to the second provider when the first fails", async () => {
+  let calls = 0;
+  global.fetch = async () => {
+    calls++;
+    if (calls === 1) throw new Error("network down"); // provider 1 dies
+    return { ok: true, json: async () => ({ rates: { INR: 84.2 } }) }; // provider 2 ok
+  };
+  assert.equal(await fetchRate("INR"), 84.2);
+  assert.equal(calls, 2, "second provider was tried");
+});
+
+test("fetchRate returns null when every provider fails (caller keeps last/USD)", async () => {
+  global.fetch = async () => { throw new Error("down"); };
+  assert.equal(await fetchRate("INR"), null);
+});
+
+test("fetchRate skips a provider that returns the currency-less/!ok response", async () => {
+  let calls = 0;
+  global.fetch = async () => {
+    calls++;
+    if (calls === 1) return { ok: false, json: async () => ({}) };            // http error
+    return { ok: true, json: async () => ({ rates: { INR: 83 } }) };
+  };
+  assert.equal(await fetchRate("INR"), 83);
+});
+
+// state() drives the UI's "show USD instead of wrong numbers" behavior.
+test("state: USD is always available and never stale", () => {
+  const s = state("USD", 1, null);
+  assert.equal(s.available, true);
+  assert.equal(s.stale, false);
+});
+
+test("state: a non-USD currency with no updatedAt is unavailable (UI shows USD)", () => {
+  const s = state("INR", 1, null);
+  assert.equal(s.available, false, "no rate ever fetched → not available");
+});
+
+test("state: a recently fetched non-USD rate is available and fresh", () => {
+  const s = state("INR", 83.5, new Date());
+  assert.equal(s.available, true);
+  assert.equal(s.stale, false);
+});
+
+test("state: an old fetched rate is available but stale", () => {
+  const old = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000); // 5 days ago
+  const s = state("INR", 83.5, old);
+  assert.equal(s.available, true);
+  assert.equal(s.stale, true);
+});

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 import Layout from "./components/Layout.jsx";
-import { api, clearAdminToken, resetCsrfToken } from "./api.js";
+import { api, clearAdminToken, resetCsrfToken, loadCurrency } from "./api.js";
 import Login from "./pages/Login.jsx";
 import Overview from "./pages/Overview.jsx";
 import Routing from "./pages/Routing.jsx";
@@ -46,7 +46,7 @@ export default function App() {
         if (e.status !== 401) return;
         return goToLogin();
       });
-  useEffect(() => { refreshStatus(); }, []);
+  useEffect(() => { refreshStatus(); loadCurrency(); }, []);
 
   const signOut = async () => {
     try { await api.logout(); } catch { /* ignore — still clear local state */ }

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -216,6 +216,9 @@ export const api = {
   removeProviderKey: (provider) => req(`/connections/${provider}`, { method: "DELETE" }),
   setDefaultProvider: (provider) => req("/default-provider", { method: "PUT", body: JSON.stringify({ provider }) }),
   setDefaultModel: (model) => req("/default-model", { method: "PUT", body: JSON.stringify({ model }) }),
+  getCurrency: () => req("/currency"),
+  setCurrencyCode: (currency) => req("/currency", { method: "PUT", body: JSON.stringify({ currency }) }),
+  refreshCurrency: () => req("/currency/refresh", { method: "POST" }),
   testProvider: (provider) => req(`/connections/${provider}/test`, { method: "POST" }),
 
   customProviders: () => req("/custom-providers"),
@@ -256,8 +259,48 @@ export const api = {
   evalCampaignPairs: (id) => req(`/eval/campaigns/${id}/pairs`),
 };
 
+// Display currency, loaded once at app start via loadCurrency(). Costs from the API
+// are always USD; fmt converts at display using the live rate. Defaults to USD so
+// nothing renders wrong before the rate loads or if the fetch fails.
+//   available:false — no rate has ever been fetched for this currency, so we display
+//     USD instead of applying a bogus 1:1 rate under a foreign label (which would
+//     badly understate cost). stale — a rate exists but is old (still used).
+let _fx = { currency: "USD", rate: 1, available: true, stale: false };
+export function setCurrency(fx) {
+  if (fx && fx.currency) {
+    _fx = {
+      currency: String(fx.currency).toUpperCase(),
+      rate: Number(fx.rate) > 0 ? Number(fx.rate) : 1,
+      available: fx.available !== false,
+      stale: !!fx.stale,
+    };
+  }
+}
+export async function loadCurrency() {
+  try { setCurrency(await req("/currency")); } catch { /* keep USD */ }
+  return _fx;
+}
+export function currency() { return { ..._fx }; }
+
+// Format a USD amount in the configured display currency. If no rate is available for
+// a non-USD currency, fall back to USD so the number is right (just labeled USD)
+// rather than a misleading foreign-labeled USD magnitude.
+function money(n) {
+  const useCurrency = _fx.available ? _fx.currency : "USD";
+  const rate = _fx.available ? _fx.rate : 1;
+  const v = (Number(n) || 0) * (rate > 0 ? rate : 1);
+  try {
+    return new Intl.NumberFormat(undefined, { style: "currency", currency: useCurrency, minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(v);
+  } catch {
+    return `${useCurrency} ${v.toFixed(2)}`;
+  }
+}
+
 export const fmt = {
-  usd: (n) => `$${(Number(n) || 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
+  // Kept as `usd` for call-site compatibility, but it now renders the configured
+  // display currency. `money` is the clearer alias for new code.
+  usd: money,
+  money,
   num: (n) => (Number(n) || 0).toLocaleString(),
   ms: (n) => `${Math.round(Number(n) || 0)} ms`,
   date: (d) => new Date(d).toLocaleString(),

--- a/web/src/pages/Settings.jsx
+++ b/web/src/pages/Settings.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { api } from "../api.js";
 import { Card, Badge, Spinner, Toggle, Tabs, useTabParam } from "../components/ui.jsx";
+import { loadCurrency } from "../api.js";
 
 // ── Key row — inline edit of name + application ───────────────────────────────
 
@@ -301,6 +302,59 @@ const SUBTABS = [
 
 // ── Settings page ─────────────────────────────────────────────────────────────
 
+// Display currency (live FX). Costs are stored in USD; this converts them for display.
+const CURRENCIES = ["USD", "INR", "EUR", "GBP", "AUD", "CAD", "SGD", "AED", "JPY", "BRL"];
+function CurrencyCard() {
+  const [cur, setCur] = useState(null);
+  const [busy, setBusy] = useState(false);
+  useEffect(() => { api.getCurrency().then(setCur).catch(() => setCur({ currency: "USD", rate: 1, updatedAt: null })); }, []);
+  if (!cur) return <Card title="Display currency"><Spinner /></Card>;
+  const options = CURRENCIES.includes(cur.currency) ? CURRENCIES : [cur.currency, ...CURRENCIES];
+
+  const change = async (code) => {
+    setBusy(true);
+    try {
+      const next = await api.setCurrencyCode(code);
+      setCur(next);
+      await loadCurrency();            // update the shared formatter
+      window.location.reload();        // re-render every cost figure in the new currency
+    } finally { setBusy(false); }
+  };
+
+  return (
+    <Card title="Display currency">
+      <p className="mb-3 text-sm text-gray-600">
+        Costs are stored in USD and shown here in your currency using a live exchange rate.
+        Only the display changes; nothing stored is converted.
+      </p>
+      <div className="flex flex-wrap items-end gap-4">
+        <div>
+          <div className="label mb-1">Currency</div>
+          <select className="input w-40" value={cur.currency} disabled={busy} onChange={(e) => change(e.target.value)}>
+            {options.map((c) => <option key={c} value={c}>{c}</option>)}
+          </select>
+        </div>
+        <div className="text-xs text-gray-500">
+          {cur.currency === "USD"
+            ? "Base currency (rate 1.00)."
+            : `1 USD = ${Number(cur.rate).toFixed(4)} ${cur.currency}${cur.updatedAt ? ` · updated ${new Date(cur.updatedAt).toLocaleString()}` : ""}`}
+        </div>
+        {cur.currency !== "USD" && !cur.available && (
+          <div className="w-full text-xs text-amber-700">
+            No exchange rate could be fetched yet, so costs are shown in USD for now. It will
+            switch to {cur.currency} once a rate is available (retried on a schedule).
+          </div>
+        )}
+        {cur.currency !== "USD" && cur.available && cur.stale && (
+          <div className="w-full text-xs text-amber-700">
+            Using the last known rate — a fresh one could not be fetched. Costs may be slightly off until it updates.
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}
+
 export default function Settings({ onChange }) {
   const [data, setData]           = useState(null);
   const [customProvs, setCustomProvs] = useState([]);
@@ -405,6 +459,8 @@ export default function Settings({ onChange }) {
               </div>
             )}
           </Card>
+
+          <CurrencyCard />
 
           <Card title="Security">
             <div className="flex items-center justify-between">


### PR DESCRIPTION
**Feature #1 of the self-service initiative** (its own PR, independent of the others).

## The gap
Every cost was USD-only — `fmt.usd` hardcoded `$`, no conversion anywhere. Gyde (and anyone outside the US) needs costs in their currency.

## The approach: display-only, live rate
Costs stay **stored in USD** (LiteLLM-native). The dashboard converts them at display using a live exchange rate.

- `Settings` gains `currency` / `fxRate` / `fxUpdatedAt`. `currency/fx.js` fetches the USD→currency rate on a schedule (twice a day) and caches it.
- `GET`/`PUT /api/currency` + `POST /api/currency/refresh`. The console gets a **"Display currency"** card; `fmt.usd`/`fmt.money` convert at display via the live rate, loaded once at app start.

## Failure handling (the part that matters)
A cost figure must **never render wrong**:

1. **Multiple keyless providers** tried in order (`open.er-api`, then `frankfurter`).
2. All fail but a rate was fetched before → keep the last one, flag **`stale`**, UI says so.
3. A rate was **never** fetched for the current currency (`available: false`) → the UI shows **USD** rather than applying a bogus `1:1` rate under a foreign label (which would badly *understate* cost — "₹1.20" for $1.20).
4. **Switching currency resets the cached rate first**, so a failed fetch can't leave the *previous* currency's rate under the new label (e.g. INR's 83 shown as "€83/USD").

## Verification
- 11 unit tests: pure `convert`/`parseRate`, the **provider fallback** (first dies → second used; all die → null), and the `available`/`stale` state that drives the safe display
- Full server suite 363/364 (the one failure is the env-dependent `assertProductionReady`, reproduces on clean main); lint 0 errors; web build compiles

## Note
The external `/v1/usage` API stays USD (documented); currency is a dashboard-display concern for now. That's the last of the five self-service gaps except **#4 (per-user alerts)**, which follows as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)