### PR TITLE
fix(deps): patch high-severity ip-address and brace-expansion vulns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3127,7 +3127,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3301,10 +3300,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-      "dev": true,
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -5011,9 +5009,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -6259,9 +6257,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Why

Two **Required** security checks — *npm audit (prod deps, high+)* and *Trivy image scan* — are failing on `main`, which blocks every open PR (#245, #246, #247) from merging even though their own code checks are green. Both trace to the same dependabot advisory (#7): a high-severity vuln in transitive dependencies.

## Fix

Lockfile-only transitive bumps (no `package.json` change):
- **`ip-address` 10.2.0 → 10.4.0** (via `express-rate-limit`) — high-severity GHSA
- **`brace-expansion` 5.0.8 → 5.0.9** (via `@google-cloud/secret-manager` → `google-gax` → `rimraf` → `glob` → `minimatch`) — DoS (GHSA-rgw5-rvv9-x895)
- incidental `postcss` patch pulled along

Both `npm audit --omit=dev` (prod, what the CI gate checks) and full `npm audit` now report **0 vulnerabilities**.

## Verification

- `npm audit --omit=dev` → 0 vulnerabilities
- `npm run lint` → 0 errors (21 pre-existing warnings)
- `npm run test:server:unit` → 352/353 (the 1 failure is the known env-dependent `assertProductionReady`)

Once this merges, the open feature PRs need `main` merged in so their Trivy/npm-audit gates re-run against the patched lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)