### PR TITLE
fix(models): make toolCallSupported reflect endpoint reality

### DIFF
--- a/server/src/gateway/capabilities.js
+++ b/server/src/gateway/capabilities.js
@@ -21,18 +21,24 @@ const BEDROCK_TOOL_PATTERNS = [
   /writer\.palmyra-x5/i,      // Palmyra X5 (agentic capabilities)
 ];
 
-// Returns true when Arbr can route tool/function calls to this model.
-// Checks DB flag first (populated by LiteLLM sync), falls back to pattern matching.
+// Returns true when Arbr's /v1/chat/completions endpoint can actually route tool/function
+// calls for this model — i.e. what a client selecting a model by `toolCallSupported` will
+// get. This is a PROVIDER-first check on purpose: the endpoint only has a tool path for an
+// OpenAI-compatible provider (proxied) or a native-tool model (bedrock-nova via Converse).
+// Any other provider — notably gemini — returns 501 for tools even when the model itself is
+// function-calling capable, so the flag must be false there or it lies about the endpoint.
+// Keep this in lockstep with the endpoint gate in openaiCompat.js (openAICompatBaseURL +
+// isNativeToolModel); trusting the raw model capability flag was the bug it replaced.
 function supportsTools(provider, modelId) {
-  const entry = pricing.getModel(modelId);
-  if (entry?.supportsFunctionCalling != null) return entry.supportsFunctionCalling;
-
-  if (OPENAI_COMPAT_PROVIDERS.has(provider)) return true;
   if (provider === "bedrock-nova") {
-    const id = modelId || "";
-    return BEDROCK_TOOL_PATTERNS.some((re) => re.test(id));
+    return BEDROCK_TOOL_PATTERNS.some((re) => re.test(modelId || ""));
   }
-  return false;
+  // No endpoint tool path for any non-compat provider (gemini, native anthropic, etc.).
+  if (!OPENAI_COMPAT_PROVIDERS.has(provider)) return false;
+  // Provider can proxy tools; respect an explicit "not capable" from the LiteLLM sync when
+  // known, otherwise assume yes (the compat endpoint forwards tools to the upstream as-is).
+  const entry = pricing.getModel(modelId);
+  return entry?.supportsFunctionCalling !== false;
 }
 
 module.exports = { supportsTools };

--- a/server/test/unit/supportsTools.test.js
+++ b/server/test/unit/supportsTools.test.js
@@ -1,0 +1,48 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const pricing = require("../../src/pricing/registry");
+const { supportsTools } = require("../../src/gateway/capabilities");
+
+// toolCallSupported must reflect what /v1/chat/completions can actually route, not the raw
+// model capability. The endpoint only has a tool path for OpenAI-compatible providers and
+// bedrock-nova; anything else (gemini) returns 501, so the flag must be false there.
+
+test("tools true for OpenAI-compat providers", () => {
+  for (const p of ["openai", "deepseek", "moonshot", "xai", "groq", "litellm"]) {
+    assert.equal(supportsTools(p, "some-chat-model"), true, `${p} should support tools`);
+  }
+});
+
+test("tools FALSE for gemini even when the model is function-calling capable", () => {
+  // The reported bug: gemini-2.5-flash reports supportsFunctionCalling upstream, but the
+  // endpoint has no tool path for gemini, so the flag must not advertise it.
+  const orig = pricing.getModel;
+  pricing.getModel = () => ({ supportsFunctionCalling: true, provider: "gemini" });
+  try {
+    assert.equal(supportsTools("gemini", "gemini-2.5-flash"), false);
+  } finally {
+    pricing.getModel = orig;
+  }
+});
+
+test("tools false for other native providers (anthropic, plain bedrock)", () => {
+  assert.equal(supportsTools("anthropic", "claude-sonnet-4-5"), false);
+  assert.equal(supportsTools("bedrock", "anthropic.claude-3-5-sonnet"), false);
+});
+
+test("bedrock-nova gates tools by model pattern", () => {
+  assert.equal(supportsTools("bedrock-nova", "us.amazon.nova-pro-v1:0"), true);
+  assert.equal(supportsTools("bedrock-nova", "anthropic.claude-3-5-sonnet"), true);
+  assert.equal(supportsTools("bedrock-nova", "mistral.mistral-7b-instruct"), false);
+});
+
+test("an explicit not-capable flag on a compat provider is respected", () => {
+  const orig = pricing.getModel;
+  pricing.getModel = () => ({ supportsFunctionCalling: false });
+  try {
+    assert.equal(supportsTools("openai", "text-only-legacy-model"), false);
+  } finally {
+    pricing.getModel = orig;
+  }
+});


### PR DESCRIPTION
## Issue (developer integration report #1)

`GET /v1/models` reported `toolCallSupported: true` for ~180 models, but `POST /v1/chat/completions` rejects most of them:
> `Model "gemini-2.5-flash" does not support tools on /v1/chat/completions. Route to an OpenAI-compatible provider (openai, deepseek, moonshot, xai, groq)…`

Any client that selects a model by that flag — which is the field's purpose — could pick a broken one. Only ~41 of the 180 were on a provider the endpoint actually accepts for tools.

## Root cause

`capabilities.supportsTools()` returned the model's **capability flag** (`supportsFunctionCalling`, from the LiteLLM sync) *before* any provider check. But the endpoint (`openaiCompat.js`) gates tools on the **provider**: only OpenAI-compatible providers (proxied) or `bedrock-nova` (native Converse) have a tool path; everything else — notably gemini — returns 501. So a capable model on a non-compat provider advertised `true` while the endpoint refused it.

## Fix

`supportsTools()` is now provider-first, mirroring the endpoint gate:
- `bedrock-nova` → gated by the existing Nova model patterns
- non-OpenAI-compat provider (gemini, native anthropic, …) → **false** (no endpoint tool path)
- OpenAI-compat provider → true, but respects an explicit not-capable flag when the sync knows it

This is the "flag reflects endpoint reality" option — `toolCallSupported: true` now means "the endpoint will actually route tools for this model." (Custom OpenAI-compat providers are conservatively reported `false` since this helper doesn't see the live connection set; that under-reports rather than lies.)

## Testing

- New `server/test/unit/supportsTools.test.js` — 5 cases (compat providers true; gemini false despite capability; anthropic/plain-bedrock false; bedrock-nova pattern gating; explicit not-capable respected)
- `npm run lint` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)