### PR TITLE
fix(models): make embedding models discoverable, drop non-chat from chat list

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -64,11 +64,11 @@ Reports metadata for calls that already happened elsewhere (a partner's own gate
 
 ### `POST /v1/embeddings`
 
-OpenAI-compatible embeddings endpoint — routes to Gemini or an OpenAI-compat provider based on the model ID, with the same observability as the chat endpoints.
+OpenAI-compatible embeddings endpoint — routes to Gemini or an OpenAI-compat provider based on the model ID, with the same observability as the chat endpoints. Supported models are discoverable via `GET /v1/models` (the `type: "embedding"` entries); currently `text-embedding-3-small` / `-3-large` / `-ada-002` (openai) and `gemini-embedding-001` (gemini).
 
 ### `GET /v1/models`
 
-Lists models whose provider is currently connected (live), in the OpenAI model-list shape, with a `toolCallSupported` flag per model.
+Lists models whose provider is currently connected (live), in the OpenAI model-list shape. Each entry has a `type` (`"chat"` or `"embedding"`) and, for chat models, a `toolCallSupported` flag that reflects what `/v1/chat/completions` will actually accept (an OpenAI-compat provider or `bedrock-nova`) — not just the model's raw capability. Embedding entries also carry their default `dimensions`. Only chat-capable models appear under `type: "chat"`; embedding/media models are not listed as chat.
 
 ### `GET /v1/task-types`
 

--- a/server/src/gateway/embeddings.js
+++ b/server/src/gateway/embeddings.js
@@ -27,6 +27,24 @@ function inferProvider(modelId) {
   return null;
 }
 
+// The embedding models this endpoint actually accepts, with their default output
+// dimensions. Embedding models are not in the ModelEntry registry (chat-only sync), so
+// discovery (/v1/models) has no other way to surface them — without this list a caller
+// could only configure embeddings by out-of-band knowledge. Keep in sync with PROVIDER_RE:
+// every id here must resolve via inferProvider().
+const EMBEDDING_MODELS = [
+  { id: "text-embedding-3-small", provider: "openai", dimensions: 1536 },
+  { id: "text-embedding-3-large", provider: "openai", dimensions: 3072 },
+  { id: "text-embedding-ada-002", provider: "openai", dimensions: 1536 },
+  { id: "gemini-embedding-001",   provider: "gemini", dimensions: 3072 },
+];
+
+// Supported embedding models restricted to currently-connected providers, for discovery.
+function listEmbeddingModels(liveIds = null) {
+  const live = liveIds ? new Set(liveIds) : null;
+  return EMBEDDING_MODELS.filter((m) => !live || live.has(m.provider));
+}
+
 // ── Gemini embedding via REST ─────────────────────────────────────────────────
 
 async function embedWithGemini(model, inputs, dims, apiKey) {
@@ -212,4 +230,4 @@ async function handleEmbeddings(req, res) {
   }));
 }
 
-module.exports = { handleEmbeddings };
+module.exports = { handleEmbeddings, listEmbeddingModels, inferProvider, EMBEDDING_MODELS };

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -17,7 +17,7 @@ const usageRoutes = require("./api/routes/usage");
 const embedRoutes = require("./api/routes/embed");
 const selfKeyAuth = require("./gateway/selfKeyAuth");
 const selfKeyRoutes = require("./api/routes/selfKey");
-const { handleEmbeddings } = require("./gateway/embeddings");
+const { handleEmbeddings, listEmbeddingModels } = require("./gateway/embeddings");
 const { handleIngest } = require("./gateway/ingest");
 const { handleUpgrade, closeAll: closeRealtimeSessions } = require("./gateway/wsAuth");
 const { purgeOldRecords } = require("./maintenance/purge");
@@ -167,22 +167,38 @@ async function start() {
     try {
       const eff = await connections.effective();
       const liveSet = new Set(eff.liveIds);
-      const models = registry.listModels().filter((m) => liveSet.has(m.provider));
-      res.json({
-        object: "list",
-        data: models.map((m) => ({
-          id: m.id,
-          object: "model",
-          created: m.createdAt ? Math.floor(new Date(m.createdAt).getTime() / 1000) : 0,
-          owned_by: m.provider,
-          provider: m.provider,
-          label: m.label || m.id,
-          tier: m.tier,
-          inputPer1M: m.inputPer1M,
-          outputPer1M: m.outputPer1M,
-          toolCallSupported: supportsTools(m.provider, m.id),
-        })),
-      });
+      // Chat models only. Embedding / media rows (chatCapable === false) are not usable on
+      // /v1/chat/completions, and listing them here made clients pick models the endpoint
+      // rejects — e.g. nvidia/* embeddings that /v1/embeddings can't resolve either.
+      const chatModels = registry.listModels()
+        .filter((m) => liveSet.has(m.provider) && m.chatCapable !== false);
+      const chatData = chatModels.map((m) => ({
+        id: m.id,
+        object: "model",
+        type: "chat",
+        created: m.createdAt ? Math.floor(new Date(m.createdAt).getTime() / 1000) : 0,
+        owned_by: m.provider,
+        provider: m.provider,
+        label: m.label || m.id,
+        tier: m.tier,
+        inputPer1M: m.inputPer1M,
+        outputPer1M: m.outputPer1M,
+        toolCallSupported: supportsTools(m.provider, m.id),
+      }));
+      // Embedding models the /v1/embeddings resolver actually accepts, so embeddings are
+      // discoverable (they are not in the ModelEntry registry). Tagged type:"embedding".
+      const embeddingData = listEmbeddingModels(eff.liveIds).map((m) => ({
+        id: m.id,
+        object: "model",
+        type: "embedding",
+        created: 0,
+        owned_by: m.provider,
+        provider: m.provider,
+        label: m.id,
+        dimensions: m.dimensions,
+        toolCallSupported: false,
+      }));
+      res.json({ object: "list", data: [...chatData, ...embeddingData] });
     } catch (err) {
       res.status(500).json({ error: "internal_error", message: String(err.message || err) });
     }

--- a/server/test/unit/embeddingModels.test.js
+++ b/server/test/unit/embeddingModels.test.js
@@ -1,0 +1,36 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { listEmbeddingModels, inferProvider, EMBEDDING_MODELS } = require("../../src/gateway/embeddings");
+
+// Discovery must agree with the resolver: every model /v1/models advertises for embeddings
+// has to resolve to a provider the endpoint accepts, or we reintroduce the reported mismatch
+// (models listed that /v1/embeddings then rejects).
+test("every discoverable embedding model resolves via the endpoint's resolver", () => {
+  for (const m of EMBEDDING_MODELS) {
+    assert.equal(inferProvider(m.id), m.provider, `${m.id} must resolve to ${m.provider}`);
+    assert.ok(Number.isInteger(m.dimensions) && m.dimensions > 0, `${m.id} needs dimensions`);
+  }
+});
+
+test("listEmbeddingModels is restricted to connected providers", () => {
+  const openaiOnly = listEmbeddingModels(["openai"]);
+  assert.ok(openaiOnly.length > 0);
+  assert.ok(openaiOnly.every((m) => m.provider === "openai"));
+  assert.ok(openaiOnly.some((m) => m.id === "text-embedding-3-small"));
+
+  const geminiOnly = listEmbeddingModels(["gemini"]);
+  assert.ok(geminiOnly.some((m) => m.id === "gemini-embedding-001"));
+  assert.ok(geminiOnly.every((m) => m.provider === "gemini"));
+
+  // No live providers → nothing discoverable.
+  assert.equal(listEmbeddingModels([]).length, 0);
+  // No filter → the full catalogue.
+  assert.equal(listEmbeddingModels().length, EMBEDDING_MODELS.length);
+});
+
+test("the nvidia embedding models that broke discovery are NOT advertised", () => {
+  // /v1/embeddings can't resolve nvidia/* today, so they must not appear as usable.
+  assert.equal(inferProvider("nvidia/nv-embedqa-e5-v5"), null);
+  assert.ok(!EMBEDDING_MODELS.some((m) => m.id.startsWith("nvidia/")));
+});


### PR DESCRIPTION
## Issue (developer integration report #2)

`/v1/models` and `/v1/embeddings` disagreed completely:
- `/v1/models` listed 10 `nvidia/*` embedding models — all rejected by `/v1/embeddings`: `Cannot determine provider for model "nvidia/nv-embedqa-e5-v5". Supported prefixes: gemini-embedding-*, text-embedding-*, ada-*`.
- The models that **do** work (`text-embedding-3-small` → 1536, `gemini-embedding-001` → 3072) appear in `/v1/models` **not at all**.

Net effect: embeddings couldn't be configured by discovery, only by out-of-band knowledge.

## Root cause

The two sides use independent inventories. `/v1/models` lists the `ModelEntry` registry for live providers with **no chat-vs-embedding filter**, so LiteLLM-discovered `nvidia/*` embedding rows leak in. The embeddings resolver ignores the registry and maps model→provider from a hardcoded prefix allowlist. And the working embedding models aren't `ModelEntry` rows (chat-only sync), so they're never listed.

## Fix

- `/v1/models` now **excludes non-chat models** (`chatCapable === false`) from the chat listing — the `nvidia/*` embeddings (and other media/embedding rows) no longer masquerade as usable chat models. Each entry is tagged `type: "chat" | "embedding"`.
- Adds a small **curated embedding-model list** (with `dimensions`) in the resolver module, surfaced as `type: "embedding"` entries gated by live provider — so `/v1/embeddings` models are discoverable, matching what the resolver accepts.

This is the "embeddings by prefix rather than catalogue" approach — discovery is now honest in both directions.

Scope note: this makes the working models discoverable and stops advertising unusable ones. Actually **adding** `nvidia/*` embedding support (new resolver prefix + dispatch) is a separate feature, deliberately not included here.

## Testing

- New `server/test/unit/embeddingModels.test.js` — asserts every advertised embedding model resolves via the endpoint's own resolver (discovery can't drift), provider gating, and that `nvidia/*` is not advertised.
- `npm run test:server:unit` → 371/372 (the 1 failure is the known env-dependent `assertProductionReady`)
- `npm run lint` → 0 errors
- Docs: `docs/api-reference.md` updated for `type` + embedding discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)