### PR TITLE
fix(gateway): accept the documented bare-string messages at the raw API

### DIFF
--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -19,6 +19,7 @@ const canaryEngine = require("../routing/canaryEngine");
 const capEngine = require("../routing/capEngine");
 const responseCache = require("../routing/responseCache");
 const outputGuardrail = require("./outputGuardrail");
+const { normalizeMessages } = require("./normalizeMessages");
 const promptInjection = require("./promptInjection");
 const semanticCache = require("../routing/semanticCache");
 const { maybeShadowEval } = require("../eval/shadow");
@@ -381,6 +382,8 @@ async function handleChat(req, res) {
   const body = req.body || {};
 
   // 1 · INGRESS — validate, capture metadata, stamp id + time.
+  // Accept the documented bare-string shorthand (SDKs normalize it client-side).
+  body.messages = normalizeMessages(body.messages);
   if (!Array.isArray(body.messages) || body.messages.length === 0) {
     return res.status(400).json({ error: "messages array is required" });
   }

--- a/server/src/gateway/normalizeMessages.js
+++ b/server/src/gateway/normalizeMessages.js
@@ -1,0 +1,14 @@
+// Coerce a bare-string `messages` into the array both gateways expect. The arbr-client SDKs
+// document `messages` as accepting "a bare string" (→ one user message) and normalize it
+// client-side (clients/js/src/index.js, clients/python __init__.py). Applying the same
+// coercion server-side honors that documented contract for callers hitting the raw HTTP API
+// or porting from the SDK docs, instead of returning "messages array is required".
+//
+// Only a string is transformed; arrays (and any other shape) pass through unchanged so the
+// existing validation still rejects genuinely-invalid bodies.
+function normalizeMessages(messages) {
+  if (typeof messages === "string") return [{ role: "user", content: messages }];
+  return messages;
+}
+
+module.exports = { normalizeMessages };

--- a/server/src/gateway/openaiCompat.js
+++ b/server/src/gateway/openaiCompat.js
@@ -5,6 +5,7 @@
 const { v4: uuidv4 } = require("uuid");
 const { getRouter } = require("../providers/router");
 const { extractFinishReason } = require("../providers/llm-router");
+const { normalizeMessages } = require("./normalizeMessages");
 const {
   resolveRoute, invokeWithFallback, getAppConfig, setGatewayHeaders,
 } = require("./core");
@@ -295,6 +296,8 @@ async function handleOpenAICompat(req, res) {
   const _reqStart = Date.now();
   const body = req.body || {};
 
+  // Accept the documented bare-string shorthand (SDKs normalize it client-side).
+  body.messages = normalizeMessages(body.messages);
   if (!Array.isArray(body.messages) || body.messages.length === 0) {
     return res.status(400).json({
       error: { message: "messages array is required", type: "invalid_request_error" },

--- a/server/test/unit/normalizeMessages.test.js
+++ b/server/test/unit/normalizeMessages.test.js
@@ -1,0 +1,22 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { normalizeMessages } = require("../../src/gateway/normalizeMessages");
+
+test("a bare string becomes a single user message", () => {
+  assert.deepEqual(normalizeMessages("Summarise this ticket"), [
+    { role: "user", content: "Summarise this ticket" },
+  ]);
+});
+
+test("an existing array passes through unchanged", () => {
+  const msgs = [{ role: "system", content: "be terse" }, { role: "user", content: "hi" }];
+  assert.equal(normalizeMessages(msgs), msgs); // same reference, untouched
+});
+
+test("non-string / non-array shapes pass through so validation still rejects them", () => {
+  assert.equal(normalizeMessages(undefined), undefined);
+  assert.equal(normalizeMessages(null), null);
+  const obj = { role: "user" };
+  assert.equal(normalizeMessages(obj), obj);
+});


### PR DESCRIPTION
## Issue (developer integration report #5)

The arbr-client README documents `messages` as accepting **"a bare string"**, but the convenience is implemented **client-side only**. A raw `POST /v1/chat` (or `/v1/chat/completions`) with a string returns:
```json
{"error":"messages array is required"}
```
Fine for SDK users, confusing for anyone hitting the API directly or porting from the docs.

## Root cause

Both `handler.js` and `openaiCompat.js` guard with `Array.isArray(body.messages)`, so a string is rejected. The SDKs (`clients/js`, `clients/python`) expand the string into a message array before POSTing; the server never did.

## Fix

Adds a shared `normalizeMessages()` helper — `string → [{ role: "user", content }]` — applied right before the guard on both gateways. Arrays and any other shape pass through untouched, so genuinely-invalid bodies are still rejected. This makes the raw HTTP contract match what the SDK docs already promise (no README change needed — reality now matches).

## Testing

- New `server/test/unit/normalizeMessages.test.js` — bare string → user message; array passes through by reference; null/undefined/object pass through so validation still rejects them.
- `npm run lint` → 0 errors; syntax-checked both gateways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)