### PR TITLE
fix(gateway): surface finishReason + reasoning tokens on /v1/chat

### DIFF
--- a/docs/gateway/native.md
+++ b/docs/gateway/native.md
@@ -59,6 +59,7 @@ curl -X POST http://localhost:4100/v1/chat \
   "routingDecision": "explicit",
   "classifiedBy": "provided",
   "cacheHit": false,
+  "finishReason": "stop",
   "usage": {
     "inputTokens": 28,
     "outputTokens": 1,
@@ -81,9 +82,12 @@ curl -X POST http://localhost:4100/v1/chat \
 | `routingDecision` | `explicit` \| `passthrough` \| `rule` \| `auto` \| `ai` \| `cache` \| `semantic_cache` \| `fallback` \| `budget` \| `canary` \| `external` |
 | `classifiedBy` | How `taskType` was determined: `provided` \| `keyword` \| `ai` |
 | `cacheHit` | Whether the response was served from Arbr's response cache |
+| `finishReason` | Why generation stopped: `stop` (complete) \| `length` (hit `maxTokens`) \| `tool_calls` \| `content_filter`. `null` if the provider didn't report one. Use it to tell a deliberately-short answer from a truncated one. |
+| `warning` | Present only in the notable case where `finishReason` is `length` **and** `text` is empty — a reasoning/thinking model consumed the whole `maxTokens` budget on internal reasoning before producing any output. Raise `maxTokens`. |
 | `usage.inputTokens` | Total prompt tokens (includes any cached tokens) |
-| `usage.outputTokens` | Completion tokens |
-| `usage.totalTokens` | Total tokens |
+| `usage.outputTokens` | Completion (visible answer) tokens |
+| `usage.totalTokens` | Total tokens — may exceed `inputTokens + outputTokens` when a model spends reasoning tokens |
+| `usage.reasoningTokens` | Present only when the model reports it (Gemini thinking, OpenAI o-series): tokens spent on internal reasoning. These count toward `totalTokens` but not `outputTokens` — the reason for a gap between them |
 | `usage.cachedReadTokens` | Prompt tokens served from the provider's prompt cache (billed at cache-read rate) |
 | `usage.cacheWriteTokens` | Prompt tokens written to the provider's prompt cache (billed at cache-write rate) |
 

--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -696,8 +696,18 @@ async function handleChat(req, res) {
     routingDecision,
     classifiedBy,
     cacheHit: false,
+    // Why generation stopped ("stop" | "length" | "tool_calls" | "content_filter"), so a caller
+    // can tell a deliberately-short answer from a truncated one. openaiCompat already surfaces
+    // this; /v1/chat previously dropped it.
+    finishReason: result.finishReason || null,
     text: deliveryText,
     usage: result.usage,
+    // A thinking/reasoning model can spend the whole max_tokens budget on internal reasoning and
+    // return an empty answer with no error. Flag that case explicitly instead of leaving an empty
+    // string indistinguishable from a legitimate empty response.
+    ...(result.finishReason === "length" && !deliveryText
+      ? { warning: "Output truncated by max_tokens before any text was produced — a reasoning model likely consumed the budget on internal thinking (see usage.reasoningTokens). Raise max_tokens." }
+      : {}),
   });
 
   // 5 · AFTER THE RESPONSE — cache + log (cost computed in the logger).

--- a/server/src/providers/llm-router/index.js
+++ b/server/src/providers/llm-router/index.js
@@ -234,10 +234,19 @@ function extractUsage(response) {
   const outputTokens = um.output_tokens ?? um.outputTokens ?? rm.completion_tokens ?? rm.output_tokens;
   const totalTokens  = um.total_tokens  ?? um.totalTokens  ?? rm.total_tokens;
 
+  // Reasoning/"thinking" tokens (Gemini thoughtsTokenCount, OpenAI o-series reasoning). These
+  // count toward total but not toward the visible output_tokens, which is why total can exceed
+  // input+output. Surfaced so an empty answer with a consumed budget is explainable rather than
+  // mysterious. Only included when the provider reports it.
+  const reasoningTokens =
+    (um.output_token_details && um.output_token_details.reasoning)
+    ?? (rm.completion_tokens_details && rm.completion_tokens_details.reasoning_tokens);
+
   return {
     inputTokens,
     outputTokens,
     totalTokens,
+    ...(reasoningTokens != null ? { reasoningTokens: Number(reasoningTokens) || 0 } : {}),
     cachedReadTokens: Number(cachedReadTokens) || 0,
     cacheWriteTokens: Number(cacheWriteTokens) || 0,
   };

--- a/server/test/unit/extractUsage.test.js
+++ b/server/test/unit/extractUsage.test.js
@@ -1,0 +1,39 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { extractUsage, extractFinishReason } = require("../../src/providers/llm-router");
+
+// Reasoning/"thinking" tokens count toward total but not output_tokens — the reason a thinking
+// model can return total > input+output with an empty answer. Surfacing them makes that visible.
+test("reasoningTokens surfaced from LangChain output_token_details (Gemini thinking)", () => {
+  // Mirrors the reported case: 6 in, 0 visible out, 16 reasoning, 22 total.
+  const u = extractUsage({
+    usage_metadata: {
+      input_tokens: 6,
+      output_tokens: 0,
+      total_tokens: 22,
+      output_token_details: { reasoning: 16 },
+    },
+  });
+  assert.equal(u.inputTokens, 6);
+  assert.equal(u.outputTokens, 0);
+  assert.equal(u.totalTokens, 22);
+  assert.equal(u.reasoningTokens, 16);
+});
+
+test("reasoningTokens surfaced from raw OpenAI completion_tokens_details", () => {
+  const u = extractUsage({
+    response_metadata: { usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 40,
+      completion_tokens_details: { reasoning_tokens: 25 } } },
+  });
+  assert.equal(u.reasoningTokens, 25);
+});
+
+test("reasoningTokens omitted entirely when the provider does not report it", () => {
+  const u = extractUsage({ usage_metadata: { input_tokens: 6, output_tokens: 4, total_tokens: 10 } });
+  assert.ok(!("reasoningTokens" in u), "no reasoning field when absent");
+});
+
+test("Gemini MAX_TOKENS maps to finish_reason 'length'", () => {
+  assert.equal(extractFinishReason({ response_metadata: { finishReason: "MAX_TOKENS" } }), "length");
+});


### PR DESCRIPTION
## Issue (developer integration report #4)

A thinking model with a low `maxTokens` silently returned empty text:
```
POST /v1/chat {"model":"auto","maxTokens":20,…}
→ {"model":"gemini-2.5-flash","text":"","usage":{"inputTokens":6,"outputTokens":0,"totalTokens":22}}
```
`totalTokens` (22) exceeds `inputTokens + outputTokens` (6) — the budget went to reasoning — but the result is an empty string with no error or flag, indistinguishable from a legitimate empty answer.

## Root cause

The router **already** computes `finishReason` (mapping Gemini `MAX_TOKENS` → `"length"`) and `/v1/chat/completions` surfaces it — but `/v1/chat` dropped `result.finishReason` when shaping its response. And the reasoning-token count (Gemini `thoughtsTokenCount`, exposed by LangChain as `output_token_details.reasoning`) was never extracted, so the 22-vs-6 gap was unexplained.

## Fix

- `/v1/chat` now returns **`finishReason`** (`stop | length | tool_calls | content_filter | null`) — parity with the OpenAI-compat endpoint. A caller can now tell a deliberately-short answer from a truncated one.
- Adds a **`warning`** field *only* in the exact failure case — `finishReason === "length"` **and** empty `text` — pointing at the consumed reasoning budget.
- `extractUsage` now surfaces **`usage.reasoningTokens`** when the provider reports it (Gemini `output_token_details.reasoning` / OpenAI `completion_tokens_details.reasoning_tokens`), so `total > input + output` is explainable. Only added when present.

## Testing

- New `server/test/unit/extractUsage.test.js` — the reported 6/0/16/22 case, OpenAI reasoning-token path, omission when absent, and `MAX_TOKENS → length`.
- `npm run test:server:unit` → 372/373 (the 1 failure is the known env-dependent `assertProductionReady`)
- `npm run lint` → 0 errors
- Docs: `docs/gateway/native.md` documents `finishReason`, `warning`, and `usage.reasoningTokens`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)