### PR TITLE
fix(routing): make the AI policy authoritative; difficulty adjust is opt-in

### DIFF
--- a/docs/routing-spec.md
+++ b/docs/routing-spec.md
@@ -34,7 +34,7 @@ In order. Steps 1–6 pick the model (`explain.basis`); 7–9 can override or re
 | 1 | **Explicit pin** | `resolveExplicit` | A client model resolvable to a live provider is served as-is, skipping every policy. An unresolvable pin is rejected `400` (see §5). |
 | 2 | **Default** | `resolveDefault` | Base pick for auto mode: the API key's `defaultModel` if set and live, else the global default (`connections.effective`). Basis `passthrough`. |
 | 3 | **Rule** | `ruleEngine.findRoute` | First enabled `Rule` whose conditions match `taskType`/`application`/`workflow`. Basis `rule`. **Rules always beat AI and guardrail.** |
-| 4 | **AI policy** (mode `ai`) | `aiPolicy.lookup` + `resolveModel` | The policy's per-task assignment, then a difficulty adjustment (§4). Basis `ai`. |
+| 4 | **AI policy** (mode `ai`) | `aiPolicy.lookup` + `resolveModel` | The policy's per-task assignment. A difficulty adjustment (§4) may re-pick **only when `Settings.aiDifficultyAdjust` is on** (default off); otherwise the assignment is authoritative. Basis `ai`. |
 | 5 | **Cost guardrail** (mode `guardrail`) | `autoRouter.selectAutoRoute` | Downgrades cheap task types to a lighter model. Basis `auto`. |
 | 6 | **Canary** (auto only) | `canaryEngine.selectCanary` | Diverts a deterministic % of matching traffic to a candidate. Override `canary`. |
 | 7 | **Allowed-models** | handler.js | If the key restricts models and routing landed outside the set → swap to the key default, else `403`. Override `allowed`. |
@@ -77,8 +77,8 @@ Mode `ai`, policy maps `coding` → `claude-sonnet-4-6`, instance difficulty mat
 → classified `coding` (mid), served `claude-sonnet-4-6`. Basis `ai`.
 > "Auto-routing: Arbr classified this as coding, mid 6/10, confidence 0.90, and the global AI policy mapped it to claude-sonnet-4-6."
 
-### 2.4 AI policy, difficulty-adjusted (downgrade)
-Same policy, but the instance is rated *easier* than the task's tier and a cheaper capable model exists.
+### 2.4 AI policy, difficulty-adjusted (downgrade) — only when `aiDifficultyAdjust` is enabled
+Same policy, but the instance is rated *easier* than the task's tier and a cheaper capable model exists. This path runs **only** when the opt-in `aiDifficultyAdjust` setting is on; with it off (default) the policy pick from §2.3 is served unchanged.
 > "The policy's base pick was claude-sonnet-4-6; difficulty (light) adjusted it to claude-haiku-4-5."
 
 Note: after #232, difficulty may only substitute a **cheaper, priced** model, and never overrides an explicit assignment with an unrelated/unpriced one.

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -104,17 +104,19 @@ Known cheap task types: `classification`, `extraction`, `summarisation`, `transl
 
 The classifier also outputs a **difficulty score (1–10)** and a **confidence (0–1)**. Both are stored on the `RequestRecord` for observability. Low-confidence results (`< 0.5`) do not drive difficulty-based routing changes.
 
-## Difficulty-aware routing
+## Difficulty-aware routing (opt-in)
 
-Within a task type, not all requests are equally hard. Once AI routing mode is on, Arbr adjusts the model pick based on difficulty:
+By default the AI policy is **authoritative**: every request routes to exactly the model the policy assigns for its task type, and if that model is unavailable it falls through to the default model. What you see in the policy table is what runs.
+
+There is an optional per-request **difficulty adjustment** — off by default — that trades that predictability for cost. Enable it under **Routing → "Auto-adjust model by request difficulty"** (or set `aiDifficultyAdjust` via `PATCH /api/governance`). When on, and once AI routing mode is on:
 
 | Difficulty | Routing adjustment |
 |---|---|
-| Easy (score ≤ 3) | Re-picks within the task type's tier toward a **cheaper** model |
+| Easy (score ≤ 3) | Re-picks toward a **cheaper** model — which may be one **not in your policy** |
 | Normal (4–7) | Uses the policy's default pick as-is |
 | Hard (score ≥ 8) | Re-picks toward a **stronger** model within the available set |
 
-This only applies when the AI policy has a pick for the task type; unmapped tasks are pass-through as before.
+It only adjusts a task the policy already has a pick for (unmapped tasks stay pass-through), and it only substitutes downward for cost. Because the re-pick scores the whole live-model catalog, it can land on a model you didn't assign — that is why it is opt-in. Leave it off to keep routing equal to the policy table.
 
 ## Routing explainability
 

--- a/server/src/api/routes/governance.js
+++ b/server/src/api/routes/governance.js
@@ -20,6 +20,7 @@ function governanceView(s) {
     piiMaskingEnabled:       s.piiMaskingEnabled ?? defaults.piiMaskingEnabled,
     customPiiPatterns:       s.customPiiPatterns || [],
     requireApiKey:           s.requireApiKey ?? false,
+    aiDifficultyAdjust:      s.aiDifficultyAdjust ?? false,
     webhookUrl:              s.webhookUrl || null,
     retentionDays:           s.retentionDays ?? defaults.retentionDays,
     alertErrorRateEnabled:   s.alertErrorRateEnabled ?? false,
@@ -71,6 +72,8 @@ router.patch("/governance", requireRole("administrator"), async (req, res, next)
       update.customPiiPatterns = body.customPiiPatterns.filter(p => p.name && p.pattern);
     if ("requireApiKey" in body)
       update.requireApiKey = !!body.requireApiKey;
+    if ("aiDifficultyAdjust" in body)
+      update.aiDifficultyAdjust = !!body.aiDifficultyAdjust;
     if ("webhookUrl" in body)
       update.webhookUrl = body.webhookUrl ? String(body.webhookUrl).trim() : null;
     if ("retentionDays" in body)

--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -267,7 +267,10 @@ async function resolveRoute(body, { router, eff, application, workflow, userId =
       // fall back to the task's default policy pick when we're unsure.
       const effDifficulty = (confidence == null || confidence >= 0.5) ? difficulty : null;
       const base = aiPolicy.lookup(aiMap, taskType);
-      const hit = aiPolicy.resolveModel({ map: aiMap, taskType, difficulty: effDifficulty, eff });
+      // Off by default — the policy is authoritative. Only the opt-in setting lets a request
+      // downgrade to a cheaper, possibly-unlisted model. Settings.get() is cached (5s).
+      const aiAdjust = (await Settings.get()).aiDifficultyAdjust === true;
+      const hit = aiPolicy.resolveModel({ map: aiMap, taskType, difficulty: effDifficulty, eff, adjust: aiAdjust });
       if (hit && eff.liveIds.includes(hit.provider)) {
         served = { provider: hit.provider, model: hit.model };
         routingDecision = "ai";

--- a/server/src/models/Settings.js
+++ b/server/src/models/Settings.js
@@ -30,6 +30,13 @@ const settingsSchema = new mongoose.Schema(
       generatorModel:    { type: String, default: null },
       capabilityVersion: { type: Number, default: null },
     },
+    // AI mode only. When OFF (default) the policy is authoritative: every request routes to the
+    // model the policy assigns for its task type (falling back to the default model if that model
+    // is unavailable). When ON, a per-request "difficulty adjustment" may substitute a cheaper
+    // model — one NOT necessarily in the policy — for instances the classifier rates easier than
+    // the task's usual tier. Off by default because a silent swap to an unlisted model is
+    // surprising; leave it off to keep routing == the policy table.
+    aiDifficultyAdjust: { type: Boolean, default: false },
     // Editable knobs for the automated-routing cost guardrail. null fields fall back
     // to the hardcoded defaults in pricing/table.js (so behaviour is unchanged until edited).
     //   cheapTaskTypes: string[] — task types eligible for downgrade

--- a/server/src/routing/aiPolicy.js
+++ b/server/src/routing/aiPolicy.js
@@ -155,12 +155,16 @@ function lookup(map, taskType) {
   return { provider: m.provider, model };
 }
 
-// Difficulty-aware resolution. Start from the policy's pick for the task type; if the
-// classifier rated THIS instance easier or harder than the task's default tier, re-pick
-// within that tier using the same scoring engine. Falls back to the base pick on anything
-// unexpected (no difficulty, unknown task, scoring error, or a non-live result).
-function resolveModel({ map, taskType, difficulty, eff }) {
+// Resolve the model for a task. By default the policy is authoritative: return exactly the
+// model the policy assigns (the caller falls through to the default model if that pick is
+// unavailable). Only when `adjust` is enabled (Settings.aiDifficultyAdjust) do we apply the
+// per-request difficulty downgrade: if the classifier rated THIS instance easier or harder than
+// the task's default tier, re-pick within that tier using the scoring engine. That path can
+// substitute a cheaper model NOT in the operator's policy, which is why it is opt-in.
+function resolveModel({ map, taskType, difficulty, eff, adjust = false }) {
   const base = lookup(map, taskType);
+  // Policy is authoritative unless the operator opted into difficulty adjustment.
+  if (!adjust) return base;
   // Only ADJUST an existing policy pick; never invent one for an unmapped task (that stays
   // passthrough, as before). And no difficulty/eff → unchanged behavior.
   if (!base || !difficulty || !eff || !eff.liveIds) return base;

--- a/server/test/unit/aiPolicyAuthoritative.test.js
+++ b/server/test/unit/aiPolicyAuthoritative.test.js
@@ -1,0 +1,38 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const pricing = require("../../src/pricing/registry");
+const aiPolicy = require("../../src/routing/aiPolicy");
+
+// By default the AI policy is authoritative: a request routes to exactly the model the policy
+// assigns for its task type — never a per-request "difficulty" re-pick to a model the operator
+// didn't choose. That silent re-pick is the reported black box; it must be opt-in.
+
+test("authoritative by default: returns the assigned model, ignoring difficulty", () => {
+  const orig = pricing.getModel;
+  pricing.getModel = (id) => ({ provider: "anthropic", id, chatCapable: true, inputPer1M: 3 });
+  try {
+    const map = { "document-analysis": "claude-sonnet-4-6" };
+    const eff = { liveIds: ["anthropic", "gemini"] };
+    // Difficulty differs from the task's usual tier, but with adjust off nothing is swapped.
+    const hit = aiPolicy.resolveModel({ map, taskType: "document-analysis", difficulty: "mid", eff });
+    assert.deepEqual(hit, { provider: "anthropic", model: "claude-sonnet-4-6" });
+  } finally { pricing.getModel = orig; }
+});
+
+test("authoritative + unmapped task → null (caller falls through to the default model)", () => {
+  const hit = aiPolicy.resolveModel({
+    map: {}, taskType: "some-unmapped-task", difficulty: "mid", eff: { liveIds: ["anthropic"] },
+  });
+  assert.equal(hit, null);
+});
+
+test("adjust: true still guards — no eff/liveIds means it keeps the base pick", () => {
+  const orig = pricing.getModel;
+  pricing.getModel = (id) => ({ provider: "anthropic", id, chatCapable: true, inputPer1M: 3 });
+  try {
+    const map = { "document-analysis": "claude-sonnet-4-6" };
+    const hit = aiPolicy.resolveModel({ map, taskType: "document-analysis", difficulty: "mid", eff: null, adjust: true });
+    assert.deepEqual(hit, { provider: "anthropic", model: "claude-sonnet-4-6" });
+  } finally { pricing.getModel = orig; }
+});

--- a/web/src/pages/Routing.jsx
+++ b/web/src/pages/Routing.jsx
@@ -334,8 +334,17 @@ function AiPolicyEditor({ models }) {
   const [expanded, setExpanded] = useState({ light: false, mid: false, premium: false, custom: true });
   const [goal, setGoal] = useState("balanced"); // cost | balanced | quality
   const [sim, setSim] = useState(null);
+  const [difficultyAdjust, setDifficultyAdjust] = useState(false);
   const load = () => api.aiPolicy().then((p) => { setPol(p); setAssignments({ ...p.assignments }); }).catch((e) => setMsg(e.message));
-  useEffect(() => { load(); }, []);
+  useEffect(() => {
+    load();
+    api.governance().then((g) => setDifficultyAdjust(!!g.aiDifficultyAdjust)).catch(() => {});
+  }, []);
+  const toggleDifficultyAdjust = async (next) => {
+    setDifficultyAdjust(next);
+    try { await api.updateGovernance({ aiDifficultyAdjust: next }); setMsg(next ? "Difficulty adjustment on" : "Policy is now authoritative"); setTimeout(() => setMsg(null), 2000); }
+    catch (e) { setMsg(e.message); setDifficultyAdjust(!next); }
+  };
   if (!pol) return <Spinner />;
 
   const regen = async () => {
@@ -408,6 +417,22 @@ function AiPolicyEditor({ models }) {
           </button>
         ))}
       </div>
+      {/* Whether requests may deviate from the policy table at serve time. Off = the policy
+          you see is exactly what runs; on = a per-request cost downgrade may pick a cheaper
+          model that isn't in the policy. */}
+      <label className="flex items-start gap-2 rounded-lg border border-gray-200 p-3 text-xs">
+        <input type="checkbox" className="mt-0.5" checked={difficultyAdjust}
+          onChange={(e) => toggleDifficultyAdjust(e.target.checked)} />
+        <span>
+          <span className="font-medium">Auto-adjust model by request difficulty</span>
+          <span className="ml-1 text-gray-500">
+            (cost). When off (default), every request routes to the model this policy assigns for
+            its task — the table below is exactly what runs. When on, a request the classifier
+            rates easier than usual may be downgraded to a cheaper model that isn&apos;t
+            necessarily in the policy.
+          </span>
+        </span>
+      </label>
       <div className="flex flex-wrap items-center gap-3">
         <button className="btn-secondary" disabled={busy} onClick={() => setConfirmRegen(true)}>{busy ? "Generating…" : "Generate with AI"}</button>
         <button className="btn-outline" disabled={busy} onClick={save}>Save edits</button>


### PR DESCRIPTION
## The problem (reported)

A request classified as *document analysis* was auto-routed to **`gemini-2.0-flash`** — a model that is **nowhere in the routing policy** and is **deprecated** (Google 404: "no longer available"). The routing detail explained it as: base pick `claude-sonnet-4-6`, then *"difficulty (mid) adjusted it to gemini-2.0-flash."*

The operator's fair question: **who asked Arbr to pick a model outside my policy?** The policy should be authoritative — use the assigned model, or fall back to the default — not silently swap in something I never chose. As-is, the policy table wasn't what actually ran. That's a black box.

## Root cause

In AI mode, [`aiPolicy.resolveModel()`](server/src/routing/aiPolicy.js#L162) ran a per-request **difficulty adjustment**: when the classifier rated an instance easier/harder than the task's usual tier, it re-scored the **entire live-model catalog** and, if it found a cheaper capable model, substituted it as a cost downgrade — even a model not in the policy. It happened to pick `gemini-2.0-flash` (cheap, decent analysis score, still in the catalog though dead).

## Fix

**The policy is now authoritative by default.** A request routes to exactly the model the policy assigns for its task type; if that model is unavailable, it falls through to the default model (existing behavior). The difficulty downgrade is **not removed** — it's preserved but gated behind a new **off-by-default** setting and surfaced as a visible control, so it's an explicit opt-in rather than hidden behavior.

- `Settings.aiDifficultyAdjust` (default `false`)
- `resolveModel({..., adjust})` returns the assigned model unless `adjust` is on
- the handler reads the (5s-cached) setting and passes it through
- exposed via `GET`/`PATCH /api/governance`
- **Routing page** gets an "Auto-adjust model by request difficulty" toggle with an explanation that ON may pick a cheaper model not in your policy

Cost optimization is still available two transparent ways: pick **Optimize for: Cost** when generating the policy (bakes cheaper models into the visible table), or opt into the difficulty toggle knowingly.

## Not in this PR (follow-ups)

- **Deprecated-model resilience** — a model that 404s "no longer available" should fall back to the default and ideally self-disable. With this change the reported case no longer occurs (routes to `claude-sonnet-4-6`), but a policy that *explicitly* assigns a since-deprecated model would still need that safety net. Tracked separately.

## Testing

- New `server/test/unit/aiPolicyAuthoritative.test.js` — authoritative-by-default returns the assigned model regardless of difficulty; unmapped task → null (falls through to default); `adjust:true` still guards.
- `npm run test:server:unit` → 371/372 (the 1 failure is the known env-dependent `assertProductionReady`)
- `npm run lint` → 0 errors; `npm run web:build` → clean
- Docs updated: `routing.md`, `routing-spec.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)