### PR TITLE
feat(cloud): P0 request-scoped DB + entitlement seams + model migration

### DIFF
--- a/server/src/cloud/entitlements.js
+++ b/server/src/cloud/entitlements.js
@@ -1,0 +1,33 @@
+// Entitlement seam — the P0 hook that lets the hosted layer gate advanced features and size
+// per-account limits by plan. In the open-source product this is a no-op: everything is on and
+// nothing is limited, so `feature()` always allows.
+//
+// The hosted layer (arbr-cloud) attaches `req.entitlements = { plan, features, limits, seats }`
+// in its request middleware; the core only ever READS it through these helpers, so the two sides
+// stay decoupled and OSS carries no plan logic.
+"use strict";
+
+// OSS / single-tenant default: unrestricted. `features: null` means "no restriction".
+const ALL_ON = Object.freeze({ plan: "oss", features: null, limits: {}, seats: Infinity });
+
+function entitlementsFor(req) {
+  return (req && req.entitlements) || ALL_ON;
+}
+
+// The gate the core checks at advanced-feature entry points. Returns true (allow) unless an
+// entitlements object explicitly restricts the feature to a set that excludes `key`.
+//   features == null  -> unrestricted (OSS default) -> allow everything
+//   features is a Set -> allow only members
+function feature(req, key) {
+  const e = entitlementsFor(req);
+  if (!e.features) return true;
+  return e.features.has(key);
+}
+
+// A per-account limit (monthlySpendUsd / rpm / retentionDays / ...), or `fallback` when unset.
+function limit(req, key, fallback = null) {
+  const e = entitlementsFor(req);
+  return e.limits && e.limits[key] != null ? e.limits[key] : fallback;
+}
+
+module.exports = { entitlementsFor, feature, limit, ALL_ON };

--- a/server/src/db/context.js
+++ b/server/src/db/context.js
@@ -41,6 +41,12 @@ function modelForCurrent(name, schema) {
 //   - `Model(...)` as a function works (apply trap),
 //   - `doc instanceof Model` works (getPrototypeOf trap).
 function defineModel(name, schema) {
+  // Eagerly compile on the connection current at module-load time — the GLOBAL connection in OSS
+  // and in every existing test. This matches the old `mongoose.model(name, schema)` timing exactly,
+  // so index builds (e.g. NotificationDedup's unique dedup index) start at require-time and are not
+  // raced by code that relies on them right after first use. Per-tenant connections still compile
+  // lazily on their first access.
+  modelForCurrent(name, schema);
   const handler = {
     get(_t, prop) {
       const M = modelForCurrent(name, schema);

--- a/server/src/db/context.js
+++ b/server/src/db/context.js
@@ -1,0 +1,73 @@
+// Request-scoped database context — the P0 seam that lets the hosted layer (arbr-cloud) serve
+// many accounts from ONE process by giving each request its own Mongo connection
+// (database-per-tenant), while the open-source single-tenant product is completely unchanged.
+//
+// How it stays a no-op for OSS: model access resolves against `currentConnection()`, which is the
+// single global mongoose connection UNLESS a caller has explicitly entered `runWithConnection(conn)`.
+// OSS never enters one, so every model uses the global connection exactly as before. Only the cloud
+// request middleware wraps a request in a per-tenant connection.
+//
+// Nothing here is wired into the default boot path — a model must opt in via `defineModel()`
+// (done in the follow-up migration). This module only provides the primitives, and is safe to add.
+"use strict";
+const { AsyncLocalStorage } = require("node:async_hooks");
+const mongoose = require("mongoose");
+
+const _als = new AsyncLocalStorage();
+
+// The connection the current request's model access should use. Falls back to the global
+// mongoose connection when no per-request connection is active (OSS, background jobs, boot).
+function currentConnection() {
+  return _als.getStore() || mongoose.connection;
+}
+
+// Run `fn` (and everything it awaits) with `conn` as the request-scoped connection.
+function runWithConnection(conn, fn) {
+  return _als.run(conn, fn);
+}
+
+// The model for `name`, compiled on whatever connection is current, cached per connection
+// (mongoose caches compiled models on the connection, so this is a lookup after first use).
+function modelForCurrent(name, schema) {
+  const conn = currentConnection();
+  return conn.models[name] || conn.model(name, schema);
+}
+
+// Drop-in replacement for `mongoose.model(name, schema)` inside a model module. Returns a Proxy
+// that forwards every access to the CURRENT connection's model — so existing call sites
+// (`const X = require("../models/X"); X.findOne(...)`) become request-scoped with no change.
+//   - statics/query helpers keep `this === Model` (bound in the get trap),
+//   - `new Model()` works (construct trap),
+//   - `Model(...)` as a function works (apply trap),
+//   - `doc instanceof Model` works (getPrototypeOf trap).
+function defineModel(name, schema) {
+  const handler = {
+    get(_t, prop) {
+      const M = modelForCurrent(name, schema);
+      const v = M[prop];
+      return typeof v === "function" ? v.bind(M) : v;
+    },
+    set(_t, prop, value) {
+      modelForCurrent(name, schema)[prop] = value;
+      return true;
+    },
+    has(_t, prop) {
+      return prop in modelForCurrent(name, schema);
+    },
+    construct(_t, args) {
+      const M = modelForCurrent(name, schema);
+      return new M(...args);
+    },
+    apply(_t, _thisArg, args) {
+      const M = modelForCurrent(name, schema);
+      return M(...args);
+    },
+    getPrototypeOf() {
+      return Object.getPrototypeOf(modelForCurrent(name, schema));
+    },
+  };
+  // The Proxy target is a function so the construct/apply traps are permitted.
+  return new Proxy(function () {}, handler);
+}
+
+module.exports = { currentConnection, runWithConnection, modelForCurrent, defineModel, _als };

--- a/server/src/models/ApiKey.js
+++ b/server/src/models/ApiKey.js
@@ -2,6 +2,7 @@
 // ONCE at creation; only its sha256 hash is stored. A key binds requests to an
 // application — attribution becomes trusted instead of self-reported.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const apiKeySchema = new mongoose.Schema(
   {
@@ -36,4 +37,4 @@ const apiKeySchema = new mongoose.Schema(
   { collection: "api_keys" }
 );
 
-module.exports = mongoose.model("ApiKey", apiKeySchema);
+module.exports = defineModel("ApiKey", apiKeySchema);

--- a/server/src/models/ApplicationConfig.js
+++ b/server/src/models/ApplicationConfig.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const schema = new mongoose.Schema({
   applicationName: { type: String, required: true, unique: true, index: true },
@@ -8,4 +9,4 @@ const schema = new mongoose.Schema({
   aiPolicyAssignments: { type: mongoose.Schema.Types.Mixed, default: null }, // null = use global
 }, { collection: "applicationconfigs", timestamps: true });
 
-module.exports = mongoose.model("ApplicationConfig", schema);
+module.exports = defineModel("ApplicationConfig", schema);

--- a/server/src/models/AuditLog.js
+++ b/server/src/models/AuditLog.js
@@ -1,6 +1,7 @@
 // Immutable audit trail for admin operations. Written on every mutation to
 // rules, caps, keys, connections, and settings. Read-only from the dashboard.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const auditLogSchema = new mongoose.Schema(
   {
@@ -18,4 +19,4 @@ const auditLogSchema = new mongoose.Schema(
   { collection: "auditlogs" }
 );
 
-module.exports = mongoose.model("AuditLog", auditLogSchema);
+module.exports = defineModel("AuditLog", auditLogSchema);

--- a/server/src/models/Cap.js
+++ b/server/src/models/Cap.js
@@ -4,6 +4,7 @@
 // the hard CapSpend counters (see routing/capEngine.js) and fire warning/breach
 // webhooks; dashboards use analytics.spend.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const capSchema = new mongoose.Schema(
   {
@@ -25,4 +26,4 @@ const capSchema = new mongoose.Schema(
   { collection: "caps" }
 );
 
-module.exports = mongoose.model("Cap", capSchema);
+module.exports = defineModel("Cap", capSchema);

--- a/server/src/models/CapSpend.js
+++ b/server/src/models/CapSpend.js
@@ -3,6 +3,7 @@
 // 30s-stale aggregation cache. Analytics.spend remains the source of truth for
 // dashboards; reconcile() realigns counters periodically.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const capSpendSchema = new mongoose.Schema(
   {
@@ -17,4 +18,4 @@ const capSpendSchema = new mongoose.Schema(
 
 capSpendSchema.index({ capId: 1, windowKey: 1 }, { unique: true });
 
-module.exports = mongoose.model("CapSpend", capSpendSchema);
+module.exports = defineModel("CapSpend", capSpendSchema);

--- a/server/src/models/CustomProvider.js
+++ b/server/src/models/CustomProvider.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const customProviderSchema = new mongoose.Schema(
   {
@@ -14,4 +15,4 @@ const customProviderSchema = new mongoose.Schema(
   { collection: "custom_providers", timestamps: true }
 );
 
-module.exports = mongoose.model("CustomProvider", customProviderSchema);
+module.exports = defineModel("CustomProvider", customProviderSchema);

--- a/server/src/models/EvalCampaign.js
+++ b/server/src/models/EvalCampaign.js
@@ -2,6 +2,7 @@
 // traffic to a candidate model (without serving it), judge candidate-vs-prod, and gate a
 // model switch on a healthy verdict. See server/src/eval/shadow.js.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const evalCampaignSchema = new mongoose.Schema(
   {
@@ -38,4 +39,4 @@ const evalCampaignSchema = new mongoose.Schema(
   { timestamps: true, collection: "eval_campaigns" }
 );
 
-module.exports = mongoose.model("EvalCampaign", evalCampaignSchema);
+module.exports = defineModel("EvalCampaign", evalCampaignSchema);

--- a/server/src/models/EvalDataset.js
+++ b/server/src/models/EvalDataset.js
@@ -3,6 +3,7 @@
 // prompts/responses out of request_records, it is covered by the same retention purge and
 // masking rules (see maintenance/purge.js and piiMode below).
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const evalDatasetSchema = new mongoose.Schema(
   {
@@ -43,4 +44,4 @@ const evalDatasetSchema = new mongoose.Schema(
   { collection: "eval_datasets", timestamps: true }
 );
 
-module.exports = mongoose.model("EvalDataset", evalDatasetSchema);
+module.exports = defineModel("EvalDataset", evalDatasetSchema);

--- a/server/src/models/EvalItem.js
+++ b/server/src/models/EvalItem.js
@@ -2,6 +2,7 @@
 // parent dataset's piiMode (masked / omitted for metadata_only). Deleted with the dataset and
 // by the retention purge.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const evalItemSchema = new mongoose.Schema(
   {
@@ -38,4 +39,4 @@ const evalItemSchema = new mongoose.Schema(
   { collection: "eval_items", timestamps: true }
 );
 
-module.exports = mongoose.model("EvalItem", evalItemSchema);
+module.exports = defineModel("EvalItem", evalItemSchema);

--- a/server/src/models/EvalPair.js
+++ b/server/src/models/EvalPair.js
@@ -2,6 +2,7 @@
 // candidate response (mirrored, never served) for the same request, plus the judge verdict.
 // Prompt/responses are PII-masked at write time (same as RequestRecord) and size-capped.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const evalPairSchema = new mongoose.Schema(
   {
@@ -35,4 +36,4 @@ const evalPairSchema = new mongoose.Schema(
   { collection: "eval_pairs" }
 );
 
-module.exports = mongoose.model("EvalPair", evalPairSchema);
+module.exports = defineModel("EvalPair", evalPairSchema);

--- a/server/src/models/EvalResult.js
+++ b/server/src/models/EvalResult.js
@@ -1,6 +1,7 @@
 // The per-item outcome of an eval run: the candidate's response, its cost/latency, the judge
 // verdict + rubric scores, and validator results. Powers the "worst examples" evidence view.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const evalResultSchema = new mongoose.Schema(
   {
@@ -42,4 +43,4 @@ const evalResultSchema = new mongoose.Schema(
   { collection: "eval_results", timestamps: true }
 );
 
-module.exports = mongoose.model("EvalResult", evalResultSchema);
+module.exports = defineModel("EvalResult", evalResultSchema);

--- a/server/src/models/EvalRun.js
+++ b/server/src/models/EvalRun.js
@@ -2,6 +2,7 @@
 // the thresholds it was judged against, a cost ceiling, and the aggregated summary. Its
 // terminal status (passed/failed) is what gates a recommendation into an enabled rule.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const evalRunSchema = new mongoose.Schema(
   {
@@ -54,4 +55,4 @@ const evalRunSchema = new mongoose.Schema(
   { collection: "eval_runs", timestamps: true }
 );
 
-module.exports = mongoose.model("EvalRun", evalRunSchema);
+module.exports = defineModel("EvalRun", evalRunSchema);

--- a/server/src/models/ModelEntry.js
+++ b/server/src/models/ModelEntry.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const modelEntrySchema = new mongoose.Schema(
   {
@@ -52,4 +53,4 @@ const modelEntrySchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-module.exports = mongoose.model("ModelEntry", modelEntrySchema);
+module.exports = defineModel("ModelEntry", modelEntrySchema);

--- a/server/src/models/NotificationDedup.js
+++ b/server/src/models/NotificationDedup.js
@@ -3,6 +3,7 @@
 // replica (or an earlier request on this one) already claimed the key within
 // the window. Self-expires via the TTL index, so no manual pruning is needed.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const DEDUP_WINDOW_SECONDS = 5 * 60;
 
@@ -17,4 +18,4 @@ const notificationDedupSchema = new mongoose.Schema(
 notificationDedupSchema.index({ dedupKey: 1 }, { unique: true });
 notificationDedupSchema.index({ createdAt: 1 }, { expireAfterSeconds: DEDUP_WINDOW_SECONDS });
 
-module.exports = mongoose.model("NotificationDedup", notificationDedupSchema);
+module.exports = defineModel("NotificationDedup", notificationDedupSchema);

--- a/server/src/models/ProviderCredential.js
+++ b/server/src/models/ProviderCredential.js
@@ -3,6 +3,7 @@
 // ({ apiKey } for apiKey providers; { accessKeyId, secretAccessKey, region } for
 // AWS providers). Secrets never leave the server.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const providerCredentialSchema = new mongoose.Schema(
   {
@@ -16,4 +17,4 @@ const providerCredentialSchema = new mongoose.Schema(
   { collection: "provider_credentials", timestamps: true }
 );
 
-module.exports = mongoose.model("ProviderCredential", providerCredentialSchema);
+module.exports = defineModel("ProviderCredential", providerCredentialSchema);

--- a/server/src/models/RateBucket.js
+++ b/server/src/models/RateBucket.js
@@ -1,6 +1,7 @@
 // Fixed-window request counters for multi-replica RPM enforcement.
 // One document per (key, windowStartMs); atomic $inc keeps replicas consistent.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const rateBucketSchema = new mongoose.Schema(
   {
@@ -18,4 +19,4 @@ rateBucketSchema.index({ key: 1, windowStart: 1 }, { unique: true });
 // Auto-delete ~2 minutes after window start (window is 60s; keep a little headroom).
 rateBucketSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 
-module.exports = mongoose.model("RateBucket", rateBucketSchema);
+module.exports = defineModel("RateBucket", rateBucketSchema);

--- a/server/src/models/Recommendation.js
+++ b/server/src/models/Recommendation.js
@@ -1,6 +1,7 @@
 // An advisory, costed optimisation suggestion produced from the logged data.
 // A person accepts it (→ creates a disabled rule) or dismisses it.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const recommendationSchema = new mongoose.Schema(
   {
@@ -77,4 +78,4 @@ const recommendationSchema = new mongoose.Schema(
   { collection: "recommendations", timestamps: true }
 );
 
-module.exports = mongoose.model("Recommendation", recommendationSchema);
+module.exports = defineModel("Recommendation", recommendationSchema);

--- a/server/src/models/RequestRecord.js
+++ b/server/src/models/RequestRecord.js
@@ -2,6 +2,7 @@
 // Records BOTH the model requested and the model served (scope p.10) so realised
 // savings are measurable and later phases can learn which substitutions held up.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 // The kinds of LLM call Arbr makes on its own behalf. One entry per internal call
 // site; see server/src/internal/ for the wrapper that stamps these.
@@ -148,16 +149,16 @@ const requestRecordSchema = new mongoose.Schema(
   { collection: "request_records" }
 );
 
-const RequestRecord = mongoose.model("RequestRecord", requestRecordSchema);
-
+// Predicates attached as SCHEMA statics (not post-hoc on the model object) so they exist on
+// every per-tenant connection's model, not just the one that happened to compile first.
 // Predicates for the internal/customer split, so no caller hand-writes the shape.
-RequestRecord.CUSTOMER_ONLY = { internalKind: null };
-RequestRecord.INTERNAL_ONLY = { internalKind: { $ne: null } };
-RequestRecord.INTERNAL_KINDS = INTERNAL_KINDS;
+requestRecordSchema.statics.CUSTOMER_ONLY = { internalKind: null };
+requestRecordSchema.statics.INTERNAL_ONLY = { internalKind: { $ne: null } };
+requestRecordSchema.statics.INTERNAL_KINDS = INTERNAL_KINDS;
 
 // Predicates for the gateway/ingested split (F-01) — same shape, opposite default
 // visibility: unlike internalKind, callers do NOT exclude INGESTED_ONLY by default.
-RequestRecord.GATEWAY_ONLY = { source: null };
-RequestRecord.INGESTED_ONLY = { source: "ingested" };
+requestRecordSchema.statics.GATEWAY_ONLY = { source: null };
+requestRecordSchema.statics.INGESTED_ONLY = { source: "ingested" };
 
-module.exports = RequestRecord;
+module.exports = defineModel("RequestRecord", requestRecordSchema);

--- a/server/src/models/RoutingExperiment.js
+++ b/server/src/models/RoutingExperiment.js
@@ -3,6 +3,7 @@
 // are never touched) to the candidate; a monitor auto-rolls-back on guardrail breach, and an
 // admin can promote it to an enabled Rule. See routing/canaryEngine + routing/canaryMonitor.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const routingExperimentSchema = new mongoose.Schema(
   {
@@ -45,4 +46,4 @@ const routingExperimentSchema = new mongoose.Schema(
   { collection: "routing_experiments", timestamps: true }
 );
 
-module.exports = mongoose.model("RoutingExperiment", routingExperimentSchema);
+module.exports = defineModel("RoutingExperiment", routingExperimentSchema);

--- a/server/src/models/Rule.js
+++ b/server/src/models/Rule.js
@@ -1,6 +1,7 @@
 // A human-authored, reversible routing rule. Off by default. The gateway
 // executes an enabled rule exactly as written — no inference, no quality guess.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const ruleSchema = new mongoose.Schema(
   {
@@ -38,4 +39,4 @@ const ruleSchema = new mongoose.Schema(
   { collection: "rules", timestamps: true }
 );
 
-module.exports = mongoose.model("Rule", ruleSchema);
+module.exports = defineModel("Rule", ruleSchema);

--- a/server/src/models/Session.js
+++ b/server/src/models/Session.js
@@ -3,6 +3,7 @@
 // the client. Deleting a user's session rows (or disabling the User) revokes
 // access on their very next request — no waiting for a JWT to expire.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const sessionSchema = new mongoose.Schema(
   {
@@ -18,4 +19,4 @@ const sessionSchema = new mongoose.Schema(
 // Mongo TTL index — expired sessions are purged automatically.
 sessionSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 
-module.exports = mongoose.model("Session", sessionSchema);
+module.exports = defineModel("Session", sessionSchema);

--- a/server/src/models/Settings.js
+++ b/server/src/models/Settings.js
@@ -2,6 +2,7 @@
 // routing mode, automated-routing policies, default provider/model, API-key
 // requirement. Created on first read.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 const { config } = require("../config");
 
 function privacyDefaults(isProduction = config.isProduction) {
@@ -150,5 +151,7 @@ settingsSchema.statics.invalidateCache = function invalidateCache() {
   _cache.at = 0;
 };
 
-module.exports = mongoose.model("Settings", settingsSchema);
-module.exports.privacyDefaults = privacyDefaults;
+// Schema static (not post-hoc on the model) so it exists on every per-tenant connection.
+settingsSchema.statics.privacyDefaults = privacyDefaults;
+
+module.exports = defineModel("Settings", settingsSchema);

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -3,6 +3,7 @@
 // trusted-header login (default role: viewer); the first administrator is minted
 // by scripts/bootstrap-admin.js, not through the API.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const ROLES = ["viewer", "operator", "administrator"];
 
@@ -20,5 +21,7 @@ const userSchema = new mongoose.Schema(
   { collection: "users" }
 );
 
-module.exports = mongoose.model("User", userSchema);
-module.exports.ROLES = ROLES;
+// Schema static (not post-hoc on the model) so it exists on every per-tenant connection.
+userSchema.statics.ROLES = ROLES;
+
+module.exports = defineModel("User", userSchema);

--- a/server/test/integration/tenantIsolation.test.js
+++ b/server/test/integration/tenantIsolation.test.js
@@ -1,0 +1,73 @@
+"use strict";
+// P0 acceptance gate: with the request-scoped DB seam, the SAME model modules
+// (require("../models/X")) resolve to a per-request connection, so two tenant databases never
+// observe each other's data — Settings, provider credentials, keys, request records, caps.
+const { test, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const mongoose = require("mongoose");
+const { runWithConnection } = require("../../src/db/context");
+const ProviderCredential = require("../../src/models/ProviderCredential");
+const ApiKey = require("../../src/models/ApiKey");
+const RequestRecord = require("../../src/models/RequestRecord");
+const Cap = require("../../src/models/Cap");
+
+let mongod, base, connA, connB, skip = false;
+
+before(async () => {
+  try {
+    const { MongoMemoryServer } = require("mongodb-memory-server");
+    mongod = await MongoMemoryServer.create();
+    base = await mongoose.createConnection(mongod.getUri()).asPromise();
+    // Database-per-tenant: two logical databases on one connection (as arbr-cloud does).
+    connA = base.useDb("tenant_a", { useCache: true });
+    connB = base.useDb("tenant_b", { useCache: true });
+  } catch { skip = true; }
+});
+after(async () => {
+  if (base) await base.close();
+  if (mongod) await mongod.stop();
+});
+function maybeSkip(t) { if (skip) { t.skip("MongoMemoryServer unavailable"); return true; } return false; }
+
+test("two tenant connections fully isolate model data (incl. provider credentials)", async (t) => {
+  if (maybeSkip(t)) return;
+
+  await runWithConnection(connA, async () => {
+    await ProviderCredential.create({ provider: "openai", ciphertext: "SECRET-A", iv: "a", tag: "a" });
+    await ApiKey.create({ name: "kA", application: "app-a", keyHash: "hashA", prefix: "ab_aaaa" });
+    await RequestRecord.create({ requestId: "reqA", application: "app-a" });
+    await Cap.create({ limit: 5 });
+  });
+  // Same provider id "openai" in tenant B — no unique-index collision because it is a different
+  // database; and its secret must never bleed into A.
+  await runWithConnection(connB, async () => {
+    await ProviderCredential.create({ provider: "openai", ciphertext: "SECRET-B", iv: "b", tag: "b" });
+    await ApiKey.create({ name: "kB", application: "app-b", keyHash: "hashB", prefix: "ab_bbbb" });
+    await RequestRecord.create({ requestId: "reqB", application: "app-b" });
+    await Cap.create({ limit: 99 });
+  });
+
+  await runWithConnection(connA, async () => {
+    const cred = await ProviderCredential.findOne({ provider: "openai" }).lean();
+    assert.equal(cred.ciphertext, "SECRET-A", "tenant A must never read tenant B's provider secret");
+    assert.deepEqual((await ApiKey.find().lean()).map((k) => k.prefix), ["ab_aaaa"]);
+    assert.deepEqual((await RequestRecord.find().lean()).map((r) => r.application), ["app-a"]);
+    assert.deepEqual((await Cap.find().lean()).map((c) => c.limit), [5]);
+  });
+  await runWithConnection(connB, async () => {
+    const cred = await ProviderCredential.findOne({ provider: "openai" }).lean();
+    assert.equal(cred.ciphertext, "SECRET-B", "tenant B must never read tenant A's provider secret");
+    assert.deepEqual((await ApiKey.find().lean()).map((k) => k.prefix), ["ab_bbbb"]);
+    assert.deepEqual((await RequestRecord.find().lean()).map((r) => r.application), ["app-b"]);
+    assert.deepEqual((await Cap.find().lean()).map((c) => c.limit), [99]);
+  });
+});
+
+test("the same required model resolves to a different database per connection", async (t) => {
+  if (maybeSkip(t)) return;
+  const a = await runWithConnection(connA, () => ApiKey.countDocuments());
+  const b = await runWithConnection(connB, () => ApiKey.countDocuments());
+  assert.equal(a, 1);
+  assert.equal(b, 1);
+  assert.notEqual(connA.name, connB.name); // genuinely different databases
+});

--- a/server/test/unit/dbContext.test.js
+++ b/server/test/unit/dbContext.test.js
@@ -32,7 +32,7 @@ test("runWithConnection scopes currentConnection for the duration", () => {
 });
 
 test("defineModel resolves to the current connection's model, isolating per connection", () => {
-  const Thing = defineModel("Thing", { fake: true });
+  const Thing = defineModel("Thing", new mongoose.Schema({ x: Number }));
   runWithConnection(makeFakeConn("A"), () => {
     assert.equal(Thing.find(), "A:Thing:find");
     assert.equal(Thing.whoAmI(), "A");       // static's `this` is the real model, not the proxy
@@ -43,7 +43,7 @@ test("defineModel resolves to the current connection's model, isolating per conn
 });
 
 test("defineModel caches the model within a connection", () => {
-  const Thing = defineModel("Thing", { fake: true });
+  const Thing = defineModel("Thing", new mongoose.Schema({ x: Number }));
   const conn = makeFakeConn("C");
   runWithConnection(conn, () => {
     const first = Thing.find();
@@ -54,7 +54,7 @@ test("defineModel caches the model within a connection", () => {
 });
 
 test("defineModel supports `new Model(doc)` via the construct trap", () => {
-  const Thing = defineModel("Thing", { fake: true });
+  const Thing = defineModel("Thing", new mongoose.Schema({ x: Number }));
   runWithConnection(makeFakeConn("D"), () => {
     const doc = new Thing({ x: 1 });
     assert.deepEqual(doc.doc, { x: 1 });

--- a/server/test/unit/dbContext.test.js
+++ b/server/test/unit/dbContext.test.js
@@ -1,0 +1,71 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const mongoose = require("mongoose");
+const { currentConnection, runWithConnection, defineModel } = require("../../src/db/context");
+
+// A fake mongoose-like connection: model(name) returns a class with statics, cached per connection.
+function makeFakeConn(tag) {
+  const conn = { tag, models: {} };
+  conn.model = (name) => {
+    if (conn.models[name]) return conn.models[name];
+    const M = class {
+      constructor(doc) { this.doc = doc; this.conn = tag; }
+      static whoAmI() { return this === M ? tag : "WRONG_THIS"; } // proves `this === Model`
+      static find() { return `${tag}:${name}:find`; }
+    };
+    conn.models[name] = M;
+    return M;
+  };
+  return conn;
+}
+
+test("currentConnection defaults to the global mongoose connection (OSS behavior)", () => {
+  assert.equal(currentConnection(), mongoose.connection);
+});
+
+test("runWithConnection scopes currentConnection for the duration", () => {
+  const a = makeFakeConn("A");
+  runWithConnection(a, () => assert.equal(currentConnection(), a));
+  // ...and reverts outside.
+  assert.equal(currentConnection(), mongoose.connection);
+});
+
+test("defineModel resolves to the current connection's model, isolating per connection", () => {
+  const Thing = defineModel("Thing", { fake: true });
+  runWithConnection(makeFakeConn("A"), () => {
+    assert.equal(Thing.find(), "A:Thing:find");
+    assert.equal(Thing.whoAmI(), "A");       // static's `this` is the real model, not the proxy
+  });
+  runWithConnection(makeFakeConn("B"), () => {
+    assert.equal(Thing.find(), "B:Thing:find"); // same require(), different DB — the isolation core
+  });
+});
+
+test("defineModel caches the model within a connection", () => {
+  const Thing = defineModel("Thing", { fake: true });
+  const conn = makeFakeConn("C");
+  runWithConnection(conn, () => {
+    const first = Thing.find();
+    const second = Thing.find();
+    assert.equal(first, second);
+    assert.equal(Object.keys(conn.models).length, 1); // compiled once, reused
+  });
+});
+
+test("defineModel supports `new Model(doc)` via the construct trap", () => {
+  const Thing = defineModel("Thing", { fake: true });
+  runWithConnection(makeFakeConn("D"), () => {
+    const doc = new Thing({ x: 1 });
+    assert.deepEqual(doc.doc, { x: 1 });
+    assert.equal(doc.conn, "D");
+  });
+});
+
+test("async work inside runWithConnection keeps the scoped connection across awaits", async () => {
+  const a = makeFakeConn("A2");
+  await runWithConnection(a, async () => {
+    await Promise.resolve();
+    assert.equal(currentConnection(), a);
+  });
+});

--- a/server/test/unit/entitlements.test.js
+++ b/server/test/unit/entitlements.test.js
@@ -1,0 +1,31 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { entitlementsFor, feature, limit, ALL_ON } = require("../../src/cloud/entitlements");
+
+test("OSS default: no request entitlements => everything allowed", () => {
+  assert.equal(entitlementsFor(null), ALL_ON);
+  assert.equal(entitlementsFor(undefined), ALL_ON);
+  assert.equal(feature(null, "ai_routing"), true);
+  assert.equal(feature({}, "anything"), true);
+});
+
+test("features:null on an entitlements object still means unrestricted", () => {
+  assert.equal(feature({ entitlements: { features: null } }, "sso"), true);
+});
+
+test("a features Set restricts to its members", () => {
+  const req = { entitlements: { features: new Set(["ai_routing", "webhooks"]) } };
+  assert.equal(feature(req, "ai_routing"), true);
+  assert.equal(feature(req, "webhooks"), true);
+  assert.equal(feature(req, "evals_canary"), false);
+  assert.equal(feature(req, "sso"), false);
+});
+
+test("limit() reads per-account limits with a fallback", () => {
+  const req = { entitlements: { limits: { rpm: 60, monthlySpendUsd: 5 } } };
+  assert.equal(limit(req, "rpm", 999), 60);
+  assert.equal(limit(req, "monthlySpendUsd"), 5);
+  assert.equal(limit(req, "retentionDays", 30), 30); // unset => fallback
+  assert.equal(limit(null, "rpm", 999), 999);         // no entitlements => fallback
+});


### PR DESCRIPTION
## What

**P0** for the hosted product: the seam that lets the private `arbr-cloud` layer run this core in-process and serve many accounts **database-per-tenant**, while the open-source single-tenant product is **byte-for-byte unchanged**.

- **`server/src/db/context.js`** — request-scoped Mongo connection via `AsyncLocalStorage`. `currentConnection()` defaults to the **global** connection (OSS never enters a per-request scope); `runWithConnection(conn, fn)` scopes it; `defineModel(name, schema)` returns a Proxy resolving to the current connection's model (this-binding, `new Model()`, `instanceof` preserved). Models are **eager-compiled on the global connection at load** so index builds keep the old timing (no unique-index race).
- **`server/src/cloud/entitlements.js`** — `feature()`/`limit()` gates; OSS default allows everything.
- **All 23 model modules** migrated `mongoose.model(...)` → `defineModel(...)`. Post-hoc statics (`Settings.privacyDefaults`, `User.ROLES`, `RequestRecord.*`) moved to `schema.statics` so they exist on every per-tenant connection.
- **`server/test/integration/tenantIsolation.test.js`** — two tenant DBs never see each other's `ProviderCredential` (credential-leak case), `ApiKey`, `RequestRecord`, or `Cap`.

## Safety / validation (against a real Mongo, locally)

OSS behavior is unchanged: with no per-request connection, every model uses the global connection exactly as before. The full server suite shows the **same pre-existing (flaky/env) failures with and without this change**, plus the **new isolation tests passing** and the **NotificationDedup dedup tests passing** (the eager-compile fix). Lint: 0 errors.

## Deliberate follow-up (P0b.2 — required before multi-tenant serving)

Data isolation is done at the model layer, but process-global in-memory caches / boot globals would still leak and must be keyed per-tenant next: `Settings.get()` (5s), `connections.effective()` (3s — **credentials**), the pricing `registry`, response/semantic caches, and `capEngine`/`aiPolicy`/`ruleEngine`. Own change.

(Folds in the former #256.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)