### PR TITLE
feat(cloud): P0b migrate model access to request-scoped connection + isolation test

### DIFF
--- a/server/src/models/ApiKey.js
+++ b/server/src/models/ApiKey.js
@@ -2,6 +2,7 @@
 // ONCE at creation; only its sha256 hash is stored. A key binds requests to an
 // application — attribution becomes trusted instead of self-reported.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const apiKeySchema = new mongoose.Schema(
   {
@@ -36,4 +37,4 @@ const apiKeySchema = new mongoose.Schema(
   { collection: "api_keys" }
 );
 
-module.exports = mongoose.model("ApiKey", apiKeySchema);
+module.exports = defineModel("ApiKey", apiKeySchema);

--- a/server/src/models/ApplicationConfig.js
+++ b/server/src/models/ApplicationConfig.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const schema = new mongoose.Schema({
   applicationName: { type: String, required: true, unique: true, index: true },
@@ -8,4 +9,4 @@ const schema = new mongoose.Schema({
   aiPolicyAssignments: { type: mongoose.Schema.Types.Mixed, default: null }, // null = use global
 }, { collection: "applicationconfigs", timestamps: true });
 
-module.exports = mongoose.model("ApplicationConfig", schema);
+module.exports = defineModel("ApplicationConfig", schema);

--- a/server/src/models/AuditLog.js
+++ b/server/src/models/AuditLog.js
@@ -1,6 +1,7 @@
 // Immutable audit trail for admin operations. Written on every mutation to
 // rules, caps, keys, connections, and settings. Read-only from the dashboard.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const auditLogSchema = new mongoose.Schema(
   {
@@ -18,4 +19,4 @@ const auditLogSchema = new mongoose.Schema(
   { collection: "auditlogs" }
 );
 
-module.exports = mongoose.model("AuditLog", auditLogSchema);
+module.exports = defineModel("AuditLog", auditLogSchema);

--- a/server/src/models/Cap.js
+++ b/server/src/models/Cap.js
@@ -4,6 +4,7 @@
 // the hard CapSpend counters (see routing/capEngine.js) and fire warning/breach
 // webhooks; dashboards use analytics.spend.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const capSchema = new mongoose.Schema(
   {
@@ -25,4 +26,4 @@ const capSchema = new mongoose.Schema(
   { collection: "caps" }
 );
 
-module.exports = mongoose.model("Cap", capSchema);
+module.exports = defineModel("Cap", capSchema);

--- a/server/src/models/CapSpend.js
+++ b/server/src/models/CapSpend.js
@@ -3,6 +3,7 @@
 // 30s-stale aggregation cache. Analytics.spend remains the source of truth for
 // dashboards; reconcile() realigns counters periodically.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const capSpendSchema = new mongoose.Schema(
   {
@@ -17,4 +18,4 @@ const capSpendSchema = new mongoose.Schema(
 
 capSpendSchema.index({ capId: 1, windowKey: 1 }, { unique: true });
 
-module.exports = mongoose.model("CapSpend", capSpendSchema);
+module.exports = defineModel("CapSpend", capSpendSchema);

--- a/server/src/models/CustomProvider.js
+++ b/server/src/models/CustomProvider.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const customProviderSchema = new mongoose.Schema(
   {
@@ -14,4 +15,4 @@ const customProviderSchema = new mongoose.Schema(
   { collection: "custom_providers", timestamps: true }
 );
 
-module.exports = mongoose.model("CustomProvider", customProviderSchema);
+module.exports = defineModel("CustomProvider", customProviderSchema);

--- a/server/src/models/EvalCampaign.js
+++ b/server/src/models/EvalCampaign.js
@@ -2,6 +2,7 @@
 // traffic to a candidate model (without serving it), judge candidate-vs-prod, and gate a
 // model switch on a healthy verdict. See server/src/eval/shadow.js.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const evalCampaignSchema = new mongoose.Schema(
   {
@@ -38,4 +39,4 @@ const evalCampaignSchema = new mongoose.Schema(
   { timestamps: true, collection: "eval_campaigns" }
 );
 
-module.exports = mongoose.model("EvalCampaign", evalCampaignSchema);
+module.exports = defineModel("EvalCampaign", evalCampaignSchema);

--- a/server/src/models/EvalDataset.js
+++ b/server/src/models/EvalDataset.js
@@ -3,6 +3,7 @@
 // prompts/responses out of request_records, it is covered by the same retention purge and
 // masking rules (see maintenance/purge.js and piiMode below).
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const evalDatasetSchema = new mongoose.Schema(
   {
@@ -43,4 +44,4 @@ const evalDatasetSchema = new mongoose.Schema(
   { collection: "eval_datasets", timestamps: true }
 );
 
-module.exports = mongoose.model("EvalDataset", evalDatasetSchema);
+module.exports = defineModel("EvalDataset", evalDatasetSchema);

--- a/server/src/models/EvalItem.js
+++ b/server/src/models/EvalItem.js
@@ -2,6 +2,7 @@
 // parent dataset's piiMode (masked / omitted for metadata_only). Deleted with the dataset and
 // by the retention purge.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const evalItemSchema = new mongoose.Schema(
   {
@@ -38,4 +39,4 @@ const evalItemSchema = new mongoose.Schema(
   { collection: "eval_items", timestamps: true }
 );
 
-module.exports = mongoose.model("EvalItem", evalItemSchema);
+module.exports = defineModel("EvalItem", evalItemSchema);

--- a/server/src/models/EvalPair.js
+++ b/server/src/models/EvalPair.js
@@ -2,6 +2,7 @@
 // candidate response (mirrored, never served) for the same request, plus the judge verdict.
 // Prompt/responses are PII-masked at write time (same as RequestRecord) and size-capped.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const evalPairSchema = new mongoose.Schema(
   {
@@ -35,4 +36,4 @@ const evalPairSchema = new mongoose.Schema(
   { collection: "eval_pairs" }
 );
 
-module.exports = mongoose.model("EvalPair", evalPairSchema);
+module.exports = defineModel("EvalPair", evalPairSchema);

--- a/server/src/models/EvalResult.js
+++ b/server/src/models/EvalResult.js
@@ -1,6 +1,7 @@
 // The per-item outcome of an eval run: the candidate's response, its cost/latency, the judge
 // verdict + rubric scores, and validator results. Powers the "worst examples" evidence view.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const evalResultSchema = new mongoose.Schema(
   {
@@ -42,4 +43,4 @@ const evalResultSchema = new mongoose.Schema(
   { collection: "eval_results", timestamps: true }
 );
 
-module.exports = mongoose.model("EvalResult", evalResultSchema);
+module.exports = defineModel("EvalResult", evalResultSchema);

--- a/server/src/models/EvalRun.js
+++ b/server/src/models/EvalRun.js
@@ -2,6 +2,7 @@
 // the thresholds it was judged against, a cost ceiling, and the aggregated summary. Its
 // terminal status (passed/failed) is what gates a recommendation into an enabled rule.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const evalRunSchema = new mongoose.Schema(
   {
@@ -54,4 +55,4 @@ const evalRunSchema = new mongoose.Schema(
   { collection: "eval_runs", timestamps: true }
 );
 
-module.exports = mongoose.model("EvalRun", evalRunSchema);
+module.exports = defineModel("EvalRun", evalRunSchema);

--- a/server/src/models/ModelEntry.js
+++ b/server/src/models/ModelEntry.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const modelEntrySchema = new mongoose.Schema(
   {
@@ -52,4 +53,4 @@ const modelEntrySchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-module.exports = mongoose.model("ModelEntry", modelEntrySchema);
+module.exports = defineModel("ModelEntry", modelEntrySchema);

--- a/server/src/models/NotificationDedup.js
+++ b/server/src/models/NotificationDedup.js
@@ -3,6 +3,7 @@
 // replica (or an earlier request on this one) already claimed the key within
 // the window. Self-expires via the TTL index, so no manual pruning is needed.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const DEDUP_WINDOW_SECONDS = 5 * 60;
 
@@ -17,4 +18,4 @@ const notificationDedupSchema = new mongoose.Schema(
 notificationDedupSchema.index({ dedupKey: 1 }, { unique: true });
 notificationDedupSchema.index({ createdAt: 1 }, { expireAfterSeconds: DEDUP_WINDOW_SECONDS });
 
-module.exports = mongoose.model("NotificationDedup", notificationDedupSchema);
+module.exports = defineModel("NotificationDedup", notificationDedupSchema);

--- a/server/src/models/ProviderCredential.js
+++ b/server/src/models/ProviderCredential.js
@@ -3,6 +3,7 @@
 // ({ apiKey } for apiKey providers; { accessKeyId, secretAccessKey, region } for
 // AWS providers). Secrets never leave the server.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const providerCredentialSchema = new mongoose.Schema(
   {
@@ -16,4 +17,4 @@ const providerCredentialSchema = new mongoose.Schema(
   { collection: "provider_credentials", timestamps: true }
 );
 
-module.exports = mongoose.model("ProviderCredential", providerCredentialSchema);
+module.exports = defineModel("ProviderCredential", providerCredentialSchema);

--- a/server/src/models/RateBucket.js
+++ b/server/src/models/RateBucket.js
@@ -1,6 +1,7 @@
 // Fixed-window request counters for multi-replica RPM enforcement.
 // One document per (key, windowStartMs); atomic $inc keeps replicas consistent.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const rateBucketSchema = new mongoose.Schema(
   {
@@ -18,4 +19,4 @@ rateBucketSchema.index({ key: 1, windowStart: 1 }, { unique: true });
 // Auto-delete ~2 minutes after window start (window is 60s; keep a little headroom).
 rateBucketSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 
-module.exports = mongoose.model("RateBucket", rateBucketSchema);
+module.exports = defineModel("RateBucket", rateBucketSchema);

--- a/server/src/models/Recommendation.js
+++ b/server/src/models/Recommendation.js
@@ -1,6 +1,7 @@
 // An advisory, costed optimisation suggestion produced from the logged data.
 // A person accepts it (→ creates a disabled rule) or dismisses it.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const recommendationSchema = new mongoose.Schema(
   {
@@ -77,4 +78,4 @@ const recommendationSchema = new mongoose.Schema(
   { collection: "recommendations", timestamps: true }
 );
 
-module.exports = mongoose.model("Recommendation", recommendationSchema);
+module.exports = defineModel("Recommendation", recommendationSchema);

--- a/server/src/models/RequestRecord.js
+++ b/server/src/models/RequestRecord.js
@@ -2,6 +2,7 @@
 // Records BOTH the model requested and the model served (scope p.10) so realised
 // savings are measurable and later phases can learn which substitutions held up.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 // The kinds of LLM call Arbr makes on its own behalf. One entry per internal call
 // site; see server/src/internal/ for the wrapper that stamps these.
@@ -148,16 +149,16 @@ const requestRecordSchema = new mongoose.Schema(
   { collection: "request_records" }
 );
 
-const RequestRecord = mongoose.model("RequestRecord", requestRecordSchema);
-
+// Predicates attached as SCHEMA statics (not post-hoc on the model object) so they exist on
+// every per-tenant connection's model, not just the one that happened to compile first.
 // Predicates for the internal/customer split, so no caller hand-writes the shape.
-RequestRecord.CUSTOMER_ONLY = { internalKind: null };
-RequestRecord.INTERNAL_ONLY = { internalKind: { $ne: null } };
-RequestRecord.INTERNAL_KINDS = INTERNAL_KINDS;
+requestRecordSchema.statics.CUSTOMER_ONLY = { internalKind: null };
+requestRecordSchema.statics.INTERNAL_ONLY = { internalKind: { $ne: null } };
+requestRecordSchema.statics.INTERNAL_KINDS = INTERNAL_KINDS;
 
 // Predicates for the gateway/ingested split (F-01) — same shape, opposite default
 // visibility: unlike internalKind, callers do NOT exclude INGESTED_ONLY by default.
-RequestRecord.GATEWAY_ONLY = { source: null };
-RequestRecord.INGESTED_ONLY = { source: "ingested" };
+requestRecordSchema.statics.GATEWAY_ONLY = { source: null };
+requestRecordSchema.statics.INGESTED_ONLY = { source: "ingested" };
 
-module.exports = RequestRecord;
+module.exports = defineModel("RequestRecord", requestRecordSchema);

--- a/server/src/models/RoutingExperiment.js
+++ b/server/src/models/RoutingExperiment.js
@@ -3,6 +3,7 @@
 // are never touched) to the candidate; a monitor auto-rolls-back on guardrail breach, and an
 // admin can promote it to an enabled Rule. See routing/canaryEngine + routing/canaryMonitor.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const routingExperimentSchema = new mongoose.Schema(
   {
@@ -45,4 +46,4 @@ const routingExperimentSchema = new mongoose.Schema(
   { collection: "routing_experiments", timestamps: true }
 );
 
-module.exports = mongoose.model("RoutingExperiment", routingExperimentSchema);
+module.exports = defineModel("RoutingExperiment", routingExperimentSchema);

--- a/server/src/models/Rule.js
+++ b/server/src/models/Rule.js
@@ -1,6 +1,7 @@
 // A human-authored, reversible routing rule. Off by default. The gateway
 // executes an enabled rule exactly as written — no inference, no quality guess.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const ruleSchema = new mongoose.Schema(
   {
@@ -38,4 +39,4 @@ const ruleSchema = new mongoose.Schema(
   { collection: "rules", timestamps: true }
 );
 
-module.exports = mongoose.model("Rule", ruleSchema);
+module.exports = defineModel("Rule", ruleSchema);

--- a/server/src/models/Session.js
+++ b/server/src/models/Session.js
@@ -3,6 +3,7 @@
 // the client. Deleting a user's session rows (or disabling the User) revokes
 // access on their very next request — no waiting for a JWT to expire.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const sessionSchema = new mongoose.Schema(
   {
@@ -18,4 +19,4 @@ const sessionSchema = new mongoose.Schema(
 // Mongo TTL index — expired sessions are purged automatically.
 sessionSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 
-module.exports = mongoose.model("Session", sessionSchema);
+module.exports = defineModel("Session", sessionSchema);

--- a/server/src/models/Settings.js
+++ b/server/src/models/Settings.js
@@ -2,6 +2,7 @@
 // routing mode, automated-routing policies, default provider/model, API-key
 // requirement. Created on first read.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 const { config } = require("../config");
 
 function privacyDefaults(isProduction = config.isProduction) {
@@ -150,5 +151,7 @@ settingsSchema.statics.invalidateCache = function invalidateCache() {
   _cache.at = 0;
 };
 
-module.exports = mongoose.model("Settings", settingsSchema);
-module.exports.privacyDefaults = privacyDefaults;
+// Schema static (not post-hoc on the model) so it exists on every per-tenant connection.
+settingsSchema.statics.privacyDefaults = privacyDefaults;
+
+module.exports = defineModel("Settings", settingsSchema);

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -3,6 +3,7 @@
 // trusted-header login (default role: viewer); the first administrator is minted
 // by scripts/bootstrap-admin.js, not through the API.
 const mongoose = require("mongoose");
+const { defineModel } = require("../db/context");
 
 const ROLES = ["viewer", "operator", "administrator"];
 
@@ -20,5 +21,7 @@ const userSchema = new mongoose.Schema(
   { collection: "users" }
 );
 
-module.exports = mongoose.model("User", userSchema);
-module.exports.ROLES = ROLES;
+// Schema static (not post-hoc on the model) so it exists on every per-tenant connection.
+userSchema.statics.ROLES = ROLES;
+
+module.exports = defineModel("User", userSchema);

--- a/server/test/integration/tenantIsolation.test.js
+++ b/server/test/integration/tenantIsolation.test.js
@@ -1,0 +1,73 @@
+"use strict";
+// P0 acceptance gate: with the request-scoped DB seam, the SAME model modules
+// (require("../models/X")) resolve to a per-request connection, so two tenant databases never
+// observe each other's data — Settings, provider credentials, keys, request records, caps.
+const { test, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const mongoose = require("mongoose");
+const { runWithConnection } = require("../../src/db/context");
+const ProviderCredential = require("../../src/models/ProviderCredential");
+const ApiKey = require("../../src/models/ApiKey");
+const RequestRecord = require("../../src/models/RequestRecord");
+const Cap = require("../../src/models/Cap");
+
+let mongod, base, connA, connB, skip = false;
+
+before(async () => {
+  try {
+    const { MongoMemoryServer } = require("mongodb-memory-server");
+    mongod = await MongoMemoryServer.create();
+    base = await mongoose.createConnection(mongod.getUri()).asPromise();
+    // Database-per-tenant: two logical databases on one connection (as arbr-cloud does).
+    connA = base.useDb("tenant_a", { useCache: true });
+    connB = base.useDb("tenant_b", { useCache: true });
+  } catch { skip = true; }
+});
+after(async () => {
+  if (base) await base.close();
+  if (mongod) await mongod.stop();
+});
+function maybeSkip(t) { if (skip) { t.skip("MongoMemoryServer unavailable"); return true; } return false; }
+
+test("two tenant connections fully isolate model data (incl. provider credentials)", async (t) => {
+  if (maybeSkip(t)) return;
+
+  await runWithConnection(connA, async () => {
+    await ProviderCredential.create({ provider: "openai", ciphertext: "SECRET-A", iv: "a", tag: "a" });
+    await ApiKey.create({ name: "kA", application: "app-a", keyHash: "hashA", prefix: "ab_aaaa" });
+    await RequestRecord.create({ requestId: "reqA", application: "app-a" });
+    await Cap.create({ limit: 5 });
+  });
+  // Same provider id "openai" in tenant B — no unique-index collision because it is a different
+  // database; and its secret must never bleed into A.
+  await runWithConnection(connB, async () => {
+    await ProviderCredential.create({ provider: "openai", ciphertext: "SECRET-B", iv: "b", tag: "b" });
+    await ApiKey.create({ name: "kB", application: "app-b", keyHash: "hashB", prefix: "ab_bbbb" });
+    await RequestRecord.create({ requestId: "reqB", application: "app-b" });
+    await Cap.create({ limit: 99 });
+  });
+
+  await runWithConnection(connA, async () => {
+    const cred = await ProviderCredential.findOne({ provider: "openai" }).lean();
+    assert.equal(cred.ciphertext, "SECRET-A", "tenant A must never read tenant B's provider secret");
+    assert.deepEqual((await ApiKey.find().lean()).map((k) => k.prefix), ["ab_aaaa"]);
+    assert.deepEqual((await RequestRecord.find().lean()).map((r) => r.application), ["app-a"]);
+    assert.deepEqual((await Cap.find().lean()).map((c) => c.limit), [5]);
+  });
+  await runWithConnection(connB, async () => {
+    const cred = await ProviderCredential.findOne({ provider: "openai" }).lean();
+    assert.equal(cred.ciphertext, "SECRET-B", "tenant B must never read tenant A's provider secret");
+    assert.deepEqual((await ApiKey.find().lean()).map((k) => k.prefix), ["ab_bbbb"]);
+    assert.deepEqual((await RequestRecord.find().lean()).map((r) => r.application), ["app-b"]);
+    assert.deepEqual((await Cap.find().lean()).map((c) => c.limit), [99]);
+  });
+});
+
+test("the same required model resolves to a different database per connection", async (t) => {
+  if (maybeSkip(t)) return;
+  const a = await runWithConnection(connA, () => ApiKey.countDocuments());
+  const b = await runWithConnection(connB, () => ApiKey.countDocuments());
+  assert.equal(a, 1);
+  assert.equal(b, 1);
+  assert.notEqual(connA.name, connB.name); // genuinely different databases
+});


### PR DESCRIPTION
Stacked on #255 (base = `feat/p0-request-scoped-db-seam`), so this diff is only the migration.

## What

Makes the P0a seam actually take effect: every model module now uses `defineModel()` instead of `mongoose.model()`, so `require("../models/X")` resolves against the **request's** connection. In OSS there is no per-request connection, so the global connection is used exactly as before — **zero behavior change**.

- **23 model modules**: `mongoose.model(...)` → `defineModel(...)`.
- **Post-hoc statics moved to `schema.statics`** so they exist on every per-tenant connection's model (not just the one that compiled first): `Settings.privacyDefaults`, `User.ROLES`, and `RequestRecord`'s `CUSTOMER_ONLY` / `INTERNAL_ONLY` / `INTERNAL_KINDS` / `GATEWAY_ONLY` / `INGESTED_ONLY`. (Verified mongoose 8 copies non-function statics to every connection's model.)
- **`server/test/integration/tenantIsolation.test.js`**: two tenant databases never see each other's `ProviderCredential` (the credential-leak case), `ApiKey`, `RequestRecord`, or `Cap`. Passes locally against MongoMemoryServer.

## Regression check (done locally against a real Mongo)

The full server suite shows the **same pre-existing failures with and without this change** (compared on the P0a base — they're local/environmental flakiness in demo-fixture eval + a cap-test isolation quirk, unrelated to models), plus the **2 new isolation tests passing**. The migration introduces **no new failures**. Lint: 0 errors.

## Deliberate follow-up (P0b.2 — required before multi-tenant serving)

The model **data** layer now isolates, but process-global in-memory caches and boot-time globals would still leak across tenants and must be keyed per-tenant next: `Settings.get()` (5s), `connections.effective()` (3s — **credentials**), the pricing `registry`, response/semantic caches, and the `capEngine`/`aiPolicy`/`ruleEngine` caches. This PR intentionally scopes to the model-access layer; the cache work is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)