### PR TITLE
Add request-count caps (metric: spend | requests)

### DIFF
--- a/server/src/logging/logger.js
+++ b/server/src/logging/logger.js
@@ -86,20 +86,26 @@ async function writeOrThrow(record) {
 
   const doc = await RequestRecord.create(fields);
 
-  // Hard budget counters: only count successful, priced spend (not blocked/failed).
-  if (rec.status === "success" && totalCost > 0 && rec.knownPricing !== false) {
-    setImmediate(() =>
-      capEngine.recordSpend(totalCost, {
-        application: rec.application,
-        provider: rec.provider,
-        userId: rec.userId || null,
-        department: rec.department || null,
-        workflow: rec.workflow || null,
-        model: rec.model || null,
-        // Arbr's own overhead counts against a global cap but not a scoped one.
-        internalKind: rec.internalKind || null,
-      }).catch(() => {})
-    );
+  // Hard usage counters, off the request path. Spend-metric caps count priced spend;
+  // request-metric caps count every successful request (even $0 / cached ones).
+  if (rec.status === "success") {
+    const capCtx = {
+      application: rec.application,
+      provider: rec.provider,
+      userId: rec.userId || null,
+      department: rec.department || null,
+      workflow: rec.workflow || null,
+      model: rec.model || null,
+      // Arbr's own overhead counts against a global spend cap but not a scoped one, and
+      // never against a request quota (recordRequest skips it).
+      internalKind: rec.internalKind || null,
+    };
+    setImmediate(() => {
+      if (totalCost > 0 && rec.knownPricing !== false) {
+        capEngine.recordSpend(totalCost, capCtx).catch(() => {});
+      }
+      capEngine.recordRequest(capCtx).catch(() => {});
+    });
   }
 
   return doc;

--- a/server/src/models/Cap.js
+++ b/server/src/models/Cap.js
@@ -1,7 +1,8 @@
-// A cost cap (budget). Dimension-agnostic: a cap targets a scope — an application,
+// A usage cap. Dimension-agnostic: a cap targets a scope — an application,
 // a provider, a department, a model, an end user, or the whole org (dimension = null)
-// — over a period. `action`: alert (notify only), downgrade, or block. All actions use
-// the hard CapSpend counters (see routing/capEngine.js) and fire warning/breach
+// — over a period. `metric` chooses what is counted: "spend" (USD budget, the default) or
+// "requests" (a raw request-count quota). `action`: alert (notify only), downgrade, or block.
+// All actions use the hard CapSpend counters (see routing/capEngine.js) and fire warning/breach
 // webhooks; dashboards use analytics.spend.
 const mongoose = require("mongoose");
 const { defineModel } = require("../db/context");
@@ -13,7 +14,11 @@ const capSchema = new mongoose.Schema(
     dimension: { type: String, default: null }, // "application" | "provider" | "department" | "model" | "user" | null
     value: { type: String, default: null },      // the scope value (e.g. "support-chat"); null for global
     period: { type: String, enum: ["day", "month"], default: "month" }, // rolling 24h / 30d
-    limit: { type: Number, required: true },      // USD
+    // What the counter measures. "spend" preserves the original USD-budget behaviour (default,
+    // so existing caps and OSS are unchanged); "requests" counts customer-facing requests, so
+    // `limit` becomes a request quota (e.g. a free-tier "N requests / month").
+    metric: { type: String, enum: ["spend", "requests"], default: "spend" },
+    limit: { type: Number, required: true },      // USD when metric="spend"; request count when metric="requests"
     // alert = notify (webhook) only, no routing change; downgrade = force the provider's
     // light model while breached; block = reject requests in scope (429) until the
     // window rolls past. Every action fires cap_warning / cap_breach webhooks.

--- a/server/src/routing/capEngine.js
+++ b/server/src/routing/capEngine.js
@@ -84,13 +84,8 @@ async function getSpend(cap, now = new Date()) {
   return doc ? Number(doc.spent) || 0 : 0;
 }
 
-// Atomic $inc after a priced request. No-ops for zero/negative cost. ctx carries the
-// request's scope fields (application/provider/user/department/workflow/model) so a
-// cap on any of those dimensions accumulates.
-async function recordSpend(totalCost, ctx = {}) {
-  const cost = Number(totalCost) || 0;
-  if (cost <= 0) return;
-  const caps = await _activeCaps();
+// Shared: atomically $inc the current window counter for every matching cap in `caps`.
+async function _bump(caps, ctx, amount) {
   const now = new Date();
   const ops = [];
   for (const cap of caps) {
@@ -99,14 +94,36 @@ async function recordSpend(totalCost, ctx = {}) {
     ops.push(
       CapSpend.findOneAndUpdate(
         { capId: cap._id, windowKey: key },
-        { $inc: { spent: cost }, $set: { updatedAt: now } },
+        { $inc: { spent: amount }, $set: { updatedAt: now } },
         { upsert: true, returnDocument: "after" }
       ).catch((err) => {
-        console.error("[capEngine] recordSpend failed:", err.message);
+        console.error("[capEngine] counter $inc failed:", err.message);
       })
     );
   }
   if (ops.length) await Promise.all(ops);
+}
+
+// Atomic $inc after a priced request. No-ops for zero/negative cost. Applies only to
+// spend-metric caps (request-metric caps are counted by recordRequest, not by cost). ctx
+// carries the request's scope fields (application/provider/user/department/workflow/model)
+// so a cap on any of those dimensions accumulates.
+async function recordSpend(totalCost, ctx = {}) {
+  const cost = Number(totalCost) || 0;
+  if (cost <= 0) return;
+  const caps = (await _activeCaps()).filter((c) => (c.metric || "spend") === "spend");
+  await _bump(caps, ctx, cost);
+}
+
+// Atomic +1 per customer-facing request, for request-metric caps only. Called once per
+// successful request regardless of cost (so $0 / cached requests still count). Arbr's own
+// internal overhead calls (classification, policy generation, ...) are not the customer's
+// requests, so they never burn a request quota — the caller passes internalKind and we skip.
+async function recordRequest(ctx = {}) {
+  if (ctx.internalKind) return;
+  const caps = (await _activeCaps()).filter((c) => c.metric === "requests");
+  if (!caps.length) return;
+  await _bump(caps, ctx, 1);
 }
 
 // The strictest enforcement for this request's scope: block > downgrade > null.
@@ -170,6 +187,9 @@ async function reconcileFromAnalytics() {
   const now = new Date();
   let updated = 0;
   for (const cap of caps) {
+    // Request-metric counters measure a raw count, not spend — analytics.spend can't realign
+    // them. Their $inc counters are authoritative under normal operation; skip here.
+    if ((cap.metric || "spend") !== "spend") continue;
     const spent = await analytics.spend({
       // The friendly "user" dimension maps to the analytics/record field "userId".
       dimension: cap.dimension === "user" ? "userId" : cap.dimension,
@@ -194,6 +214,7 @@ async function reconcileFromAnalytics() {
 module.exports = {
   enforcement,
   recordSpend,
+  recordRequest,
   getSpend,
   invalidate,
   describeScope,

--- a/server/test/integration/capRequestMetric.test.js
+++ b/server/test/integration/capRequestMetric.test.js
@@ -1,0 +1,106 @@
+"use strict";
+// Request-count caps: a cap with metric:"requests" enforces a raw request quota (e.g. a
+// free-tier "N requests / month") instead of a USD budget. recordRequest() counts every
+// successful customer-facing request — including $0 / cached ones — while recordSpend()
+// keeps counting only priced spend. The two metrics never cross-contaminate each other's
+// counters, and Arbr's own internal overhead never burns a request quota.
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+const mongoose = require("mongoose");
+
+const Cap = require("../../src/models/Cap");
+const CapSpend = require("../../src/models/CapSpend");
+const capEngine = require("../../src/routing/capEngine");
+
+let mongod;
+
+before(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+after(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+beforeEach(async () => {
+  await Cap.deleteMany({});
+  await CapSpend.deleteMany({});
+  capEngine.invalidate(); // drop the 5s cap-list cache so freshly-created caps are seen
+});
+
+const ctx = (over = {}) => ({ application: "chat", provider: "openai", ...over });
+
+test("request cap blocks after exactly `limit` successful requests", async () => {
+  await Cap.create({ dimension: null, metric: "requests", period: "month", limit: 3, action: "block" });
+  capEngine.invalidate();
+
+  assert.equal((await capEngine.enforcement(ctx())), null, "under quota: no enforcement");
+  await capEngine.recordRequest(ctx());
+  await capEngine.recordRequest(ctx());
+  assert.equal((await capEngine.enforcement(ctx())), null, "2/3 used: still allowed");
+
+  await capEngine.recordRequest(ctx()); // 3rd — reaches the limit
+  const enf = await capEngine.enforcement(ctx());
+  assert.equal(enf?.action, "block", "at quota: request is blocked");
+  assert.equal(enf.spent, 3);
+});
+
+test("request cap counts $0 / cached requests (independent of cost)", async () => {
+  await Cap.create({ dimension: null, metric: "requests", period: "month", limit: 2, action: "block" });
+  capEngine.invalidate();
+
+  // recordSpend for a $0 request is a no-op; recordRequest must still count it.
+  await capEngine.recordSpend(0, ctx());
+  await capEngine.recordRequest(ctx());
+  await capEngine.recordRequest(ctx());
+
+  const enf = await capEngine.enforcement(ctx());
+  assert.equal(enf?.action, "block", "two $0 requests still exhaust a 2-request quota");
+});
+
+test("request cap never counts Arbr's own internal overhead", async () => {
+  await Cap.create({ dimension: null, metric: "requests", period: "month", limit: 2, action: "block" });
+  capEngine.invalidate();
+
+  await capEngine.recordRequest(ctx({ internalKind: "classifier", application: null }));
+  await capEngine.recordRequest(ctx({ internalKind: "eval", application: null }));
+  assert.equal((await capEngine.enforcement(ctx())), null, "internal calls did not burn the quota");
+
+  await capEngine.recordRequest(ctx());
+  await capEngine.recordRequest(ctx());
+  assert.equal((await capEngine.enforcement(ctx()))?.action, "block", "only customer requests count");
+});
+
+test("spend and request metrics keep separate counters", async () => {
+  const spendCap = await Cap.create({ dimension: null, metric: "spend", period: "month", limit: 10, action: "block" });
+  const reqCap = await Cap.create({ dimension: null, metric: "requests", period: "month", limit: 5, action: "block" });
+  capEngine.invalidate();
+
+  // A priced request: recordSpend bumps the spend cap; recordRequest bumps the request cap.
+  await capEngine.recordSpend(4, ctx());   // spend: 4/10
+  await capEngine.recordRequest(ctx());    // requests: 1/5
+
+  assert.equal(await capEngine.getSpend(spendCap), 4, "spend counter got the dollars, not +1");
+  assert.equal(await capEngine.getSpend(reqCap), 1, "request counter got +1, not the dollars");
+
+  // Neither is at its limit yet.
+  assert.equal(await capEngine.enforcement(ctx()), null);
+});
+
+test("legacy caps with no metric behave as spend caps (backward compatible)", async () => {
+  // Simulate a pre-existing cap written before `metric` existed.
+  await Cap.collection.insertOne({
+    dimension: null, period: "month", limit: 5, action: "block",
+    warningThreshold: 0.8, enabled: true, createdAt: new Date(),
+  });
+  capEngine.invalidate();
+
+  await capEngine.recordRequest(ctx()); // must NOT touch a spend cap
+  assert.equal(await capEngine.enforcement(ctx()), null, "recordRequest left the spend cap untouched");
+
+  await capEngine.recordSpend(5, ctx()); // dollars do count
+  assert.equal((await capEngine.enforcement(ctx()))?.action, "block");
+});


### PR DESCRIPTION
## Why
Caps could only enforce a **USD budget**. For a hosted free tier under **BYOK**, a dollar cap is the wrong lever — the customer pays the provider directly, so it just limits *their own* money. The natural free-tier limit is a **request quota** ("N requests / month"). This adds that with a small, backward-compatible extension to the existing cap engine.

## What
- **`Cap.metric`**: `"spend"` (default → existing caps + OSS unchanged) or `"requests"`. `limit` is USD for spend, a request count for requests.
- **`capEngine`**: `recordSpend()` now applies only to spend-metric caps; new **`recordRequest(ctx)`** `+1`s request-metric caps. `enforcement()` already compares `counter >= limit`, so it enforces both unchanged (a breached `block` request cap → 429, same as spend). `reconcileFromAnalytics()` skips request caps (analytics.spend can't realign a raw count).
- **`logger`**: counts every **successful, customer-facing** request — independent of cost, so `$0`/cached requests still count. Arbr's own internal overhead (classification/eval/policy) never burns a request quota.

## Backward compatibility
Caps written before this change have no `metric` and are treated as `"spend"` everywhere — zero behaviour change for OSS/self-hosted. Verified by a test that inserts a legacy cap document directly.

## Tests
New `server/test/integration/capRequestMetric.test.js` (5 cases, all green): blocks after exactly N requests; `$0`/cached requests still count; internal overhead is skipped; spend vs request counters never cross-contaminate; legacy no-metric caps behave as spend caps. Existing `capEngine` unit + `internalSpend` integration tests still pass. (The 1 failing `gatewayHotPath` case is pre-existing on `main`, unrelated.)

## Follow-up (private arbr-cloud)
The hosted layer will set the free plan to `monthlyRequests: N` and have provisioning seed a `dimension:null, metric:"requests", action:"block"` cap in each tenant DB. This core change is the enabler; it ships no policy of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)