### PR TITLE
Gate advanced features behind plan (requireFeature)

### DIFF
--- a/server/src/api/routes/aiPolicy.js
+++ b/server/src/api/routes/aiPolicy.js
@@ -2,6 +2,7 @@
 const express = require("express");
 const aiPolicy = require("../../routing/aiPolicy");
 const { requireRole } = require("../rbac");
+const { requireFeature } = require("../../cloud/entitlements");
 const { toRouterConfig, getRouter } = require("../../providers/router");
 const Settings = require("../../models/Settings");
 
@@ -21,14 +22,14 @@ router.get("/ai-policy", async (_req, res, next) => {
   } catch (e) { next(e); }
 });
 
-router.put("/ai-policy", requireRole("administrator"), async (req, res, next) => {
+router.put("/ai-policy", requireRole("administrator"), requireFeature("ai_routing"), async (req, res, next) => {
   try {
     await aiPolicy.setAssignments(req.body?.assignments || {});
     res.json(await aiPolicy.describe());
   } catch (e) { res.status(400).json({ error: "bad_request", message: String(e.message || e) }); }
 });
 
-router.post("/ai-policy/regenerate", requireRole("administrator"), async (req, res, next) => {
+router.post("/ai-policy/regenerate", requireRole("administrator"), requireFeature("ai_routing"), async (req, res, next) => {
   try {
     const { router: r, eff } = await getRouter();
     if (!r) return res.status(503).json({ error: "demo_mode", message: "Add a provider key to generate an AI policy." });

--- a/server/src/api/routes/appConfigs.js
+++ b/server/src/api/routes/appConfigs.js
@@ -6,6 +6,7 @@ const aiPolicy = require("../../routing/aiPolicy");
 const { toRouterConfig, getRouter } = require("../../providers/router");
 const Settings = require("../../models/Settings");
 const { config, KNOWN_PROVIDERS } = require("../../config");
+const { requireFeature } = require("../../cloud/entitlements");
 
 const router = express.Router();
 
@@ -46,7 +47,7 @@ router.put("/app-configs/:app", requireRole("operator"), async (req, res, next) 
   } catch (e) { next(e); }
 });
 
-router.post("/app-configs/:app/generate-policy", requireRole("operator"), async (req, res, next) => {
+router.post("/app-configs/:app/generate-policy", requireRole("operator"), requireFeature("ai_routing"), async (req, res, next) => {
   try {
     const { router: r, eff } = await getRouter();
     if (!r) return res.status(503).json({ error: "no live providers — cannot generate policy" });
@@ -77,7 +78,7 @@ router.post("/app-configs/:app/simulate", async (req, res, next) => {
   } catch (e) { next(e); }
 });
 
-router.post("/app-configs/:app/set-default-policy", requireRole("administrator"), async (req, res, next) => {
+router.post("/app-configs/:app/set-default-policy", requireRole("administrator"), requireFeature("ai_routing"), async (req, res, next) => {
   try {
     const cfg = await ApplicationConfig.findOne({ applicationName: req.params.app }).lean();
     if (!cfg?.aiPolicyAssignments) return res.status(400).json({ error: "No custom policy set for this application." });

--- a/server/src/api/routes/embed.js
+++ b/server/src/api/routes/embed.js
@@ -3,10 +3,11 @@
 // (the app sets none globally), so a partner can drop it into an <iframe>.
 const express = require("express");
 const { PAGE } = require("../../embed/usageChart");
+const { requireFeature } = require("../../cloud/entitlements");
 
 const router = express.Router();
 
-router.get("/usage", (_req, res) => {
+router.get("/usage", requireFeature("embed_widgets"), (_req, res) => {
   res.set("Cache-Control", "public, max-age=300");
   res.type("html").send(PAGE);
 });

--- a/server/src/api/routes/experiments.js
+++ b/server/src/api/routes/experiments.js
@@ -10,6 +10,7 @@ const EvalRun = require("../../models/EvalRun");
 const evalThresholds = require("../../eval/thresholds");
 const RoutingExperiment = require("../../models/RoutingExperiment");
 const canaryEngine = require("../../routing/canaryEngine");
+const { requireFeature } = require("../../cloud/entitlements");
 
 const router = express.Router();
 
@@ -51,7 +52,7 @@ router.get("/routing-experiments/:id", async (req, res, next) => {
 // Create a canary directly (not from a recommendation) — e.g. from a passed offline eval.
 // Same gate as shadow/recommendation: a passed offline run (requiredEvalRunId) or an override.
 // Only auto-routed traffic is affected.
-router.post("/routing-experiments", requireRole("operator"), async (req, res, next) => {
+router.post("/routing-experiments", requireRole("operator"), requireFeature("evals_canary"), async (req, res, next) => {
   try {
     const b = req.body || {};
     if (!b.application) return res.status(400).json({ error: "application is required" });
@@ -80,7 +81,7 @@ router.post("/routing-experiments", requireRole("operator"), async (req, res, ne
 });
 
 // Create a canary from a passed recommendation (only auto-routed traffic is affected).
-router.post("/recommendations/:id/create-canary", requireRole("operator"), async (req, res, next) => {
+router.post("/recommendations/:id/create-canary", requireRole("operator"), requireFeature("evals_canary"), async (req, res, next) => {
   try {
     const rec = await Recommendation.findById(req.params.id);
     if (!rec) return res.status(404).json({ error: "not found" });

--- a/server/src/api/routes/governance.js
+++ b/server/src/api/routes/governance.js
@@ -4,6 +4,7 @@ const { logAction } = require("../auditLogger");
 const { requireRole } = require("../rbac");
 const Settings = require("../../models/Settings");
 const { config } = require("../../config");
+const { feature } = require("../../cloud/entitlements");
 const telemetry = require("../../telemetry");
 const telemetryConfig = require("../../telemetry/config");
 
@@ -50,9 +51,24 @@ router.get("/governance", async (_req, res, next) => {
   } catch (e) { next(e); }
 });
 
+// Fields on this shared handler that belong to a gated feature. Setting any of them requires the
+// corresponding entitlement (inert in OSS, where feature() always allows). Other fields on this
+// endpoint (maintenance, retention, max-tokens, semantic cache, ...) are ungated on every plan.
+const GUARDRAIL_FIELDS = [
+  "piiMaskingEnabled", "customPiiPatterns", "outputGuardrailsEnabled", "outputGuardrailRules",
+  "maskPiiInResponses", "promptInjectionDetectionEnabled", "promptInjectionRules",
+];
+const WEBHOOK_FIELDS = ["webhookUrl", "alertErrorRateEnabled", "alertErrorRateThreshold"];
+
 router.patch("/governance", requireRole("administrator"), async (req, res, next) => {
   try {
     const body = req.body || {};
+    if (GUARDRAIL_FIELDS.some((f) => f in body) && !feature(req, "guardrails_pii")) {
+      return res.status(402).json({ error: "upgrade_required", feature: "guardrails_pii", message: "Guardrails & PII protection require a paid plan." });
+    }
+    if (WEBHOOK_FIELDS.some((f) => f in body) && !feature(req, "webhooks")) {
+      return res.status(402).json({ error: "upgrade_required", feature: "webhooks", message: "Webhooks require a paid plan." });
+    }
     const update = {};
     if (body.maintenanceMode !== undefined) {
       update["maintenanceMode.enabled"] = !!body.maintenanceMode.enabled;

--- a/server/src/api/routes/rules.js
+++ b/server/src/api/routes/rules.js
@@ -4,6 +4,7 @@ const Rule = require("../../models/Rule");
 const { logAction } = require("../auditLogger");
 const { requireRole } = require("../rbac");
 const ruleEngine = require("../../routing/ruleEngine");
+const { feature } = require("../../cloud/entitlements");
 const responseCache = require("../../routing/responseCache");
 const semanticCache = require("../../routing/semanticCache");
 const connections = require("../../providers/connections");
@@ -140,6 +141,10 @@ router.get("/routing-mode", async (_req, res, next) => {
 
 router.put("/routing-mode", requireRole("administrator"), async (req, res, next) => {
   try {
+    // "ai" mode is the paid feature; "off"/"guardrail" stay available on every plan.
+    if (String(req.body?.mode) === "ai" && !feature(req, "ai_routing")) {
+      return res.status(402).json({ error: "upgrade_required", feature: "ai_routing", message: "AI routing requires a paid plan." });
+    }
     const mode = await ruleEngine.setRoutingMode(req.body?.mode);
     res.json({ routingMode: mode });
   } catch (e) { next(e); }

--- a/server/src/api/routes/shadow.js
+++ b/server/src/api/routes/shadow.js
@@ -9,6 +9,7 @@ const EvalRun = require("../../models/EvalRun");
 const { invalidateCampaignCache } = require("../../eval/shadow");
 const { summarizeEvalPairs } = require("../../eval/logic");
 const evalThresholds = require("../../eval/thresholds");
+const { requireFeature } = require("../../cloud/entitlements");
 
 const router = express.Router();
 
@@ -30,7 +31,7 @@ router.get("/eval/campaigns", async (req, res, next) => {
   } catch (e) { next(e); }
 });
 
-router.post("/eval/campaigns", requireRole("operator"), async (req, res, next) => {
+router.post("/eval/campaigns", requireRole("operator"), requireFeature("evals_canary"), async (req, res, next) => {
   try {
     const b = req.body || {};
     const { application, candidateModel, judgeModel, sampleRate, thresholds, name, baselineModel, scope,
@@ -82,7 +83,7 @@ router.get("/eval/campaigns/:id", async (req, res, next) => {
 });
 
 // Start a shadow campaign directly from a recommendation (requires its offline eval passed).
-router.post("/recommendations/:id/start-shadow", requireRole("operator"), async (req, res, next) => {
+router.post("/recommendations/:id/start-shadow", requireRole("operator"), requireFeature("evals_canary"), async (req, res, next) => {
   try {
     const rec = await Recommendation.findById(req.params.id);
     if (!rec) return res.status(404).json({ error: "not found" });

--- a/server/src/cloud/entitlements.js
+++ b/server/src/cloud/entitlements.js
@@ -30,4 +30,19 @@ function limit(req, key, fallback = null) {
   return e.limits && e.limits[key] != null ? e.limits[key] : fallback;
 }
 
-module.exports = { entitlementsFor, feature, limit, ALL_ON };
+// Express middleware form of `feature()` for gating a whole route. Responds 402 (Payment
+// Required) when the signed-in plan doesn't include `key`. In OSS (ALL_ON) it always allows,
+// so self-hosted route behaviour is unchanged. For endpoints that mix gated and un-gated fields
+// (e.g. PATCH /governance), call `feature(req, key)` inline instead of using this.
+function requireFeature(key) {
+  return function requireFeatureMw(req, res, next) {
+    if (feature(req, key)) return next();
+    return res.status(402).json({
+      error: "upgrade_required",
+      feature: key,
+      message: `This feature (${key}) requires a paid plan.`,
+    });
+  };
+}
+
+module.exports = { entitlementsFor, feature, limit, requireFeature, ALL_ON };

--- a/server/test/unit/entitlements.test.js
+++ b/server/test/unit/entitlements.test.js
@@ -1,7 +1,22 @@
 "use strict";
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { entitlementsFor, feature, limit, ALL_ON } = require("../../src/cloud/entitlements");
+const { entitlementsFor, feature, limit, requireFeature, ALL_ON } = require("../../src/cloud/entitlements");
+
+// Minimal res double capturing status()/json().
+function resDouble() {
+  return {
+    _status: null, _json: null,
+    status(c) { this._status = c; return this; },
+    json(o) { this._json = o; return this; },
+  };
+}
+function run(mw, req) {
+  const res = resDouble();
+  let nexted = false;
+  mw(req, res, () => { nexted = true; });
+  return { res, nexted };
+}
 
 test("OSS default: no request entitlements => everything allowed", () => {
   assert.equal(entitlementsFor(null), ALL_ON);
@@ -28,4 +43,35 @@ test("limit() reads per-account limits with a fallback", () => {
   assert.equal(limit(req, "monthlySpendUsd"), 5);
   assert.equal(limit(req, "retentionDays", 30), 30); // unset => fallback
   assert.equal(limit(null, "rpm", 999), 999);         // no entitlements => fallback
+});
+
+test("requireFeature: OSS default (no entitlements) always calls next()", () => {
+  const { res, nexted } = run(requireFeature("ai_routing"), {});
+  assert.equal(nexted, true);
+  assert.equal(res._status, null);
+});
+
+test("requireFeature: allows when the plan includes the feature", () => {
+  const req = { entitlements: { features: new Set(["ai_routing"]) } };
+  const { nexted, res } = run(requireFeature("ai_routing"), req);
+  assert.equal(nexted, true);
+  assert.equal(res._status, null);
+});
+
+test("requireFeature: 402 upgrade_required when the plan excludes the feature", () => {
+  const req = { entitlements: { features: new Set(["ai_routing"]) } };
+  const { nexted, res } = run(requireFeature("webhooks"), req);
+  assert.equal(nexted, false);
+  assert.equal(res._status, 402);
+  assert.equal(res._json.error, "upgrade_required");
+  assert.equal(res._json.feature, "webhooks");
+});
+
+test("requireFeature: free plan (empty feature set) blocks every advanced feature", () => {
+  const req = { entitlements: { features: new Set() } };
+  for (const key of ["ai_routing", "evals_canary", "guardrails_pii", "webhooks", "embed_widgets", "sso"]) {
+    const { nexted, res } = run(requireFeature(key), req);
+    assert.equal(nexted, false, `${key} should be blocked`);
+    assert.equal(res._status, 402);
+  }
 });


### PR DESCRIPTION
Wires the entitlement seam (which was defined but unused) to real gate points, so a hosted plan that doesn't include a feature is refused with **402 `upgrade_required`**. **Inert for OSS** — with no `req.entitlements`, `ALL_ON` makes `feature()` allow everything, so self-hosted behaviour is unchanged.

## Gates
| Feature | Where | How |
|---|---|---|
| `ai_routing` | `PUT /ai-policy`, `POST /ai-policy/regenerate`, per-app `generate-policy`/`set-default-policy` | `requireFeature` middleware |
| `ai_routing` | `PUT /routing-mode` | field-level — only `mode:"ai"` is gated; `off`/`guardrail` stay on every plan |
| `evals_canary` | `POST /routing-experiments`, `create-canary`, `/eval/campaigns`, `start-shadow` | `requireFeature` on **creation** only (manage/rollback/delete left open so a downgraded account can clean up) |
| `guardrails_pii` | `PATCH /governance` (PII/guardrail/prompt-injection fields) | field-level inside the shared handler |
| `webhooks` | `PATCH /governance` (`webhookUrl`, error-alert fields) | field-level |
| `embed_widgets` | `GET /embed/usage` | `requireFeature` |
| `sso` | — | **No per-tenant config endpoint exists** (SSO is env-configured), so there's nothing to gate today. Flagged. |

Field-level (not route-level) was needed for `/governance` and `/keys`-adjacent handlers because they mix gated and un-gated fields — a blanket route guard would over-gate.

## Tests
8 unit tests on `requireFeature`/`feature` (OSS allows all; a features Set restricts; free blocks every advanced feature; 402 shape). Existing eval/canary/governance integration tests still green.

## Consumed by arbr-cloud
The Free plan's `features: []` now actually means something. After this merges + the submodule bumps, Free users get 402 on these; Paid (all 6) is unrestricted. **Note:** this gates the *config/enable* APIs; the console still shows the controls (hiding them for Free is a follow-up UI task).