### PR TITLE
Account page inside the console (hosted-gated)

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -78,7 +78,9 @@ export default function App() {
         <Route path="/governance" element={<Governance />} />
         <Route path="/audit" element={<Audit />} />
         <Route path="/users" element={<Users />} />
-        <Route path="/account" element={<Account />} />
+        {/* Hosted-only: the tenant plan/billing page. In OSS (no accountUrl) the route isn't even
+            registered, so /account never mounts the component or hits the (absent) data endpoint. */}
+        {status?.accountUrl && <Route path="/account" element={<Account />} />}
         <Route path="/docs" element={<Docs />} />
 
         {/* Redirects for old / deep links. */}

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -18,6 +18,7 @@ import Applications from "./pages/Applications.jsx";
 import InternalSpend from "./pages/InternalSpend.jsx";
 import ApplicationDetail from "./pages/ApplicationDetail.jsx";
 import Users from "./pages/Users.jsx";
+import Account from "./pages/Account.jsx";
 
 export default function App() {
   const [status, setStatus] = useState(null);
@@ -77,6 +78,7 @@ export default function App() {
         <Route path="/governance" element={<Governance />} />
         <Route path="/audit" element={<Audit />} />
         <Route path="/users" element={<Users />} />
+        <Route path="/account" element={<Account />} />
         <Route path="/docs" element={<Docs />} />
 
         {/* Redirects for old / deep links. */}

--- a/web/src/components/Layout.jsx
+++ b/web/src/components/Layout.jsx
@@ -94,20 +94,27 @@ const icons = {
       <path d="M12 3a13 13 0 0 1 0 18a13 13 0 0 1 0-18z"/>
     </Icon>
   ),
+  account: (
+    <Icon>
+      <rect x="3" y="5" width="18" height="14" rx="2"/>
+      <circle cx="8.5" cy="11" r="2"/>
+      <path d="M13.5 10h4M13.5 14h4M5.5 16c.4-1.2 1.4-1.8 3-1.8s2.6.6 3 1.8"/>
+    </Icon>
+  ),
 };
 
 // ── Navigation definition ─────────────────────────────────────────────────────
 // "Users" only appears for administrators — under adminkey mode (no per-user
 // identity, req.user is the implicit master-key administrator) it always
 // shows, matching what the API actually allows.
-function buildNavGroups(canManageUsers) {
+function buildNavGroups(canManageUsers, hosted) {
   const govern = [
     { to: "/budgets",    label: "Budgets",    icon: icons.budgets },
     { to: "/governance", label: "Governance", icon: icons.governance },
     { to: "/audit",      label: "Audit",      icon: icons.audit },
   ];
   if (canManageUsers) govern.push({ to: "/users", label: "Users", icon: icons.users });
-  return [
+  const groups = [
     { section: "Connect", hint: "Wire apps & providers to the gateway", items: [
       { to: "/models",   label: "Models",   icon: icons.models },
       { to: "/settings", label: "Settings", icon: icons.settings },
@@ -125,6 +132,13 @@ function buildNavGroups(canManageUsers) {
     ] },
     { section: "Govern", hint: "Limits, guardrails, and records", items: govern },
   ];
+  // Hosted-only: the tenant's plan & billing page. Inert in OSS (no accountUrl → no section).
+  if (hosted) {
+    groups.push({ section: "Account", hint: "Your plan & billing", items: [
+      { to: "/account", label: "Account", icon: icons.account },
+    ] });
+  }
+  return groups;
 }
 const FOOTER_LINK = { to: "/docs", label: "Docs", icon: icons.docs };
 const PROJECT_LINK = { href: "https://projectarbr.org/", label: "projectarbr.org", icon: icons.globe };
@@ -144,7 +158,8 @@ function Wordmark() {
 export default function Layout({ status, user, onSignOut, children }) {
   const [collapsed, setCollapsed] = useState(new Set());
   const canManageUsers = !user || user.role === "administrator";
-  const NAV_GROUPS = buildNavGroups(canManageUsers);
+  const hosted = !!(status && status.accountUrl); // hosted deployments expose an account/billing page
+  const NAV_GROUPS = buildNavGroups(canManageUsers, hosted);
 
   function toggleSection(section) {
     setCollapsed((prev) => {

--- a/web/src/pages/Account.jsx
+++ b/web/src/pages/Account.jsx
@@ -1,0 +1,145 @@
+import React, { useEffect, useState, useCallback } from "react";
+import { Card, Badge, Spinner } from "../components/ui.jsx";
+
+// The hosted Account page. Data + billing actions are served by the hosted layer (arbr-cloud) at
+// non-/api paths, so we use raw fetch here rather than the /api client. In OSS these endpoints don't
+// exist and this page is unreachable (no Account nav item — see Layout.jsx).
+
+const fmtNum = (n) => Number(n || 0).toLocaleString();
+
+// Load Razorpay Checkout on demand — only when a hosted user actually clicks Upgrade, so OSS never
+// pulls it in.
+function loadRazorpay() {
+  return new Promise((resolve) => {
+    if (window.Razorpay) return resolve(true);
+    const s = document.createElement("script");
+    s.src = "https://checkout.razorpay.com/v1/checkout.js";
+    s.onload = () => resolve(true);
+    s.onerror = () => resolve(false);
+    document.body.appendChild(s);
+  });
+}
+
+async function getAccount() {
+  const r = await fetch("/account/data", { credentials: "include" });
+  if (!r.ok) throw new Error(r.status === 401 ? "Please sign in." : `HTTP ${r.status}`);
+  return r.json();
+}
+
+export default function Account() {
+  const [data, setData] = useState(null);
+  const [err, setErr] = useState(null);
+  const [msg, setMsg] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    try { setData(await getAccount()); setErr(null); }
+    catch (e) { setErr(e.message); }
+  }, []);
+  useEffect(() => { load(); }, [load]);
+
+  // The plan flips via the Razorpay webhook, not the browser — poll until it lands, then reload.
+  const pollPlan = useCallback(async (target) => {
+    for (let i = 0; i < 20; i++) {
+      await new Promise((r) => setTimeout(r, 1500));
+      try { const j = await getAccount(); if (j.plan === target) { setData(j); setMsg(""); setBusy(false); return; } }
+      catch { /* keep polling */ }
+    }
+    setMsg("Still processing — refresh in a moment."); setBusy(false);
+  }, []);
+
+  const upgrade = async () => {
+    setBusy(true); setMsg("Opening checkout…");
+    if (!(await loadRazorpay())) { setMsg("Checkout failed to load — check your connection and retry."); setBusy(false); return; }
+    try {
+      const r = await fetch("/billing/subscribe", { method: "POST", credentials: "include" });
+      const s = await r.json();
+      if (!r.ok) throw new Error(s.error || `HTTP ${r.status}`);
+      const rzp = new window.Razorpay({
+        key: s.keyId, subscription_id: s.subscriptionId, name: s.appName || "Arbr",
+        description: "Arbr Paid plan", prefill: { email: s.email },
+        handler: () => { setMsg("Payment received — activating your plan…"); pollPlan("paid"); },
+        modal: { ondismiss: () => { setBusy(false); setMsg(""); } },
+      });
+      rzp.on("payment.failed", () => { setBusy(false); setMsg("Payment failed. Please try again."); });
+      rzp.open();
+    } catch (e) { setBusy(false); setMsg(`Could not start checkout (${e.message}).`); }
+  };
+
+  const cancel = async () => {
+    if (!window.confirm("Cancel your Paid subscription and move to the Free plan?")) return;
+    setBusy(true); setMsg("Cancelling…");
+    try {
+      const r = await fetch("/billing/cancel", { method: "POST", credentials: "include" });
+      const j = await r.json();
+      if (!r.ok) throw new Error(j.error || `HTTP ${r.status}`);
+      setMsg("Subscription cancelled — updating…"); pollPlan("free");
+    } catch (e) { setBusy(false); setMsg(`Could not cancel (${e.message}).`); }
+  };
+
+  if (err) return <div className="mx-auto max-w-2xl text-sm text-red-600">Could not load account — {err}</div>;
+  if (!data) return <div className="flex justify-center py-16"><Spinner /></div>;
+
+  const q = data.quota || {};
+  const unlimited = q.limit == null;
+  const used = q.used || 0;
+  const pct = unlimited ? 0 : Math.min(100, Math.round((used / q.limit) * 100));
+  const barColor = pct >= 100 ? "bg-red-500" : pct >= 80 ? "bg-amber-400" : "bg-arbr-charcoal";
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <div>
+        <h1 className="text-xl font-semibold text-arbr-charcoal">Account</h1>
+        <p className="mt-1 text-sm text-gray-500">Your Arbr plan and usage.</p>
+      </div>
+
+      <Card>
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-gray-500">Signed in as</span>
+          <span className="text-sm font-medium text-arbr-charcoal">{data.email}</span>
+        </div>
+        <div className="mt-3 flex items-center justify-between border-t border-gray-100 pt-3">
+          <span className="text-sm text-gray-500">Plan</span>
+          <Badge tone={data.plan === "paid" ? "green" : "charcoal"}>{data.planLabel || data.plan}</Badge>
+        </div>
+      </Card>
+
+      <Card title="Requests this month">
+        {unlimited ? (
+          <div className="text-lg font-semibold text-arbr-charcoal">Unlimited</div>
+        ) : (
+          <>
+            <div className="text-lg font-semibold text-arbr-charcoal">
+              {fmtNum(used)} <span className="text-sm font-normal text-gray-500">of {fmtNum(q.limit)} requests</span>
+            </div>
+            <div className="mt-3 h-2 w-full overflow-hidden rounded-full bg-gray-200">
+              <div className={`h-full rounded-full transition-all ${barColor}`} style={{ width: `${pct}%` }} />
+            </div>
+            <div className="mt-2 text-xs text-gray-500">
+              {fmtNum(q.remaining)} remaining · resets each {q.period || "month"}
+              {pct >= 100 ? " · quota reached — requests return 429 until reset" : ""}
+            </div>
+          </>
+        )}
+      </Card>
+
+      <div className="flex flex-wrap items-center gap-3">
+        {data.plan === "free" ? (
+          <button
+            className="btn-primary disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={busy || !data.billingEnabled}
+            title={data.billingEnabled ? "" : "Billing not configured yet"}
+            onClick={upgrade}
+          >
+            Upgrade to Paid
+          </button>
+        ) : (
+          <button className="btn-outline disabled:opacity-50" disabled={busy} onClick={cancel}>
+            Cancel subscription
+          </button>
+        )}
+        {msg && <span className="text-sm text-gray-500">{msg}</span>}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Makes the hosted plan/billing view a **first-class console page** instead of a standalone mini-site. It now renders inside the `Layout` shell (sidebar + header) and reuses the console's `Card`/`Badge`/`Spinner` and tokens, so it looks native.

## Changes
- **`web/src/pages/Account.jsx`** — identity, plan badge, request-quota bar (charcoal → amber ≥80% → red at 100%), and Upgrade/Cancel. Data + billing actions come from the hosted layer at non-`/api` paths, so it uses **raw `fetch`** (`/account/data`, `/billing/subscribe`|`cancel`). Razorpay `checkout.js` is loaded **on demand** (only when a hosted user clicks Upgrade) → OSS never loads it.
- **`App.jsx`** — `/account` route (inside the `Layout`-wrapped `<Routes>`).
- **`Layout.jsx`** — an **"Account"** nav section shown **only when `status.accountUrl`** is set (hosted).

## Inert for OSS
No `accountUrl` → no nav section, and `/account/data` doesn't exist in a self-hosted deploy → nothing hosted leaks. Same gating pattern as the #260 header hooks. Web build passes.

## Consumed by arbr-cloud
After this merges + the submodule bumps, arbr-cloud drops its standalone `/account` HTML so `/account` resolves to this SPA page (the header account icon + the new nav item both point at it).