### PR TITLE
docs(vitepress): add orphaned usage-api page to the sidebar

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -73,6 +73,7 @@ export default defineConfig({
           { text: 'Accountable admin access', link: '/auth' },
           { text: 'OpenTelemetry tracing', link: '/opentelemetry' },
           { text: 'Cloud secret-manager integration', link: '/secret-manager' },
+          { text: 'Scoped usage API (read tokens)', link: '/usage-api' },
           { text: 'Design-partner demo fixture', link: '/demo-fixture' },
         ]
       },


### PR DESCRIPTION
## What does this PR do?

`docs/usage-api.md` documents shipped, user-facing functionality — the scoped read-token usage API (`GET /v1/usage/*`), the embeddable usage chart, and self-service key rotate/revoke — but it was missing from the VitePress sidebar in `docs/.vitepress/config.mjs` and is linked from no other page.

Because the page is **not** in `srcExclude` (unlike `competitive-analysis-portkey.md`), VitePress still builds it and indexes it for local search, so it was reachable only by a direct URL or a search hit, never by browsing the docs. This adds it under **Features** so it sits alongside the other feature docs. No content changes.

Verified the documented endpoints are real: `server/src/api/routes/usage.js` is mounted at `/v1/usage` in `server/src/index.js` behind `readTokenAuth`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] CI / build

## Checklist

- [ ] I've tested this locally with `npm run dev`
- [x] No API keys, `.env` values, or secrets are committed
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format (`feat:`, `fix:`, etc.)
- [x] I've updated docs if the change affects user-facing behaviour

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfZy45XVHxPVbUzTRDLu5f)_