### PR TITLE
Hosted logout: sign-out uses ARBR_LOGOUT_URL when set

### DIFF
--- a/server/src/api/routes/status.js
+++ b/server/src/api/routes/status.js
@@ -29,6 +29,7 @@ router.get("/status", async (_req, res, next) => {
       requireApiKey,
       breachedCaps,
       accountUrl: config.ui.accountUrl,
+      logoutUrl: config.ui.logoutUrl,
       showDemoBadge: config.ui.showDemoBadge,
     });
   } catch (e) { next(e); }

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -217,6 +217,7 @@ const config = {
   // console can link to an external account/billing page and suppress the "no keys" badge.
   ui: {
     accountUrl: process.env.ARBR_ACCOUNT_URL || null,       // when set, the header shows an account link
+    logoutUrl: process.env.ARBR_LOGOUT_URL || null,         // when set, sign-out navigates here (hosted logout) instead of the core Login page
     showDemoBadge: process.env.ARBR_SHOW_DEMO_BADGE !== "0", // set "0" to hide the demo (no-provider-keys) badge
   },
 

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -50,6 +50,14 @@ export default function App() {
   useEffect(() => { refreshStatus(); loadCurrency(); }, []);
 
   const signOut = async () => {
+    // Hosted deployments own logout: a full navigation to their logout URL destroys the hosted
+    // session and returns to the landing page. OSS keeps the in-app core logout + Login screen.
+    if (status?.logoutUrl) {
+      clearAdminToken();
+      resetCsrfToken();
+      window.location.href = status.logoutUrl;
+      return;
+    }
     try { await api.logout(); } catch { /* ignore — still clear local state */ }
     clearAdminToken();
     resetCsrfToken();


### PR DESCRIPTION
Config-gated `logoutUrl` (companion to `accountUrl`): when set, the console's **sign-out** does a full navigation there. The hosted layer's `GET /auth/logout` destroys the cloud session and returns to the landing page — instead of the in-app core logout + Login screen (which, in hosted, leaves the cloud session alive and shows the wrong page).

- `config.ui.logoutUrl` (`ARBR_LOGOUT_URL`), surfaced via `GET /status`.
- `App.signOut`: if `status.logoutUrl` is set → `window.location.href = logoutUrl` (after clearing local state); else the existing core logout + Login.

**Inert for OSS** — no `logoutUrl` → sign-out behaves exactly as before. Needed once the Account page is in-shell (arbr-cloud#10): the console's own sign-out becomes the hosted logout. arbr-cloud will set `ARBR_LOGOUT_URL=/auth/logout`.