### PR TITLE
Account page: add a Log out button

### DIFF
--- a/web/src/pages/Account.jsx
+++ b/web/src/pages/Account.jsx
@@ -138,6 +138,8 @@ export default function Account() {
             Cancel subscription
           </button>
         )}
+        {/* Hosted logout: the cloud layer's /auth/logout destroys the session and returns to the landing. */}
+        <a href="/auth/logout" className="btn-ghost">Log out</a>
         {msg && <span className="text-sm text-gray-500">{msg}</span>}
       </div>
     </div>


### PR DESCRIPTION
The in-console Account page had no Log out. Adds a **Log out** link to the Account actions row that navigates to the hosted layer's `GET /auth/logout` (destroys the session, returns to the landing page).

Hosted-only (the Account page only renders when `accountUrl` is set), so it's inert for OSS. Works with the already-shipped `/auth/logout` route. Web build passes.

After merge: bump the arbr-cloud submodule (which also picks up #267's `logoutUrl` wiring for the console's global sign-out) and redeploy.