### PR TITLE
Account: Upgrade button links to /plans

### DIFF
--- a/web/src/pages/Account.jsx
+++ b/web/src/pages/Account.jsx
@@ -137,14 +137,9 @@ export default function Account() {
 
       <div className="flex flex-wrap items-center gap-3">
         {data.plan === "free" ? (
-          <button
-            className="btn-primary disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={busy || !data.billingEnabled}
-            title={data.billingEnabled ? "" : "Billing not configured yet"}
-            onClick={upgrade}
-          >
-            Upgrade to Paid
-          </button>
+          // Send the user to the in-app /plans page (plan comparison + upgrade). That page links back
+          // to /account?upgrade=1, where the effect above opens Checkout — one checkout path, reused.
+          <a className="btn-primary" href="/plans">Upgrade to Paid</a>
         ) : (
           <button className="btn-outline disabled:opacity-50" disabled={busy} onClick={cancel}>
             Cancel subscription


### PR DESCRIPTION
The Account page's **Upgrade to Paid** button now navigates to the in-app **/plans** page (plan comparison + upgrade/skip) instead of opening Checkout inline.

`/plans` (served by arbr-cloud) links its "Upgrade to Paid" CTA to `/account?upgrade=1`, where the effect added in #270 opens Razorpay Checkout. So there's still exactly one checkout implementation — it's just reached through the plans page now. `upgrade()` / the auto-open effect stay; only the button changes to a link.

Part of the new hosted flow: landing → login → first-time users land on `/plans`; the Account page's Upgrade also routes through `/plans`.

## Test
- `npm --prefix web run build` passes.
- Account (Free) shows "Upgrade to Paid" → `/plans`; `/account?upgrade=1` still auto-opens Checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)