### PR TITLE
Fix false-positive "routing done" in onboarding checklist

### DIFF
--- a/web/src/components/GettingStarted.jsx
+++ b/web/src/components/GettingStarted.jsx
@@ -56,7 +56,10 @@ export default function GettingStarted() {
         !!(s && (s.demoMode === false || (Array.isArray(s.liveProviders) && s.liveProviders.length > 0))),
         Array.isArray(keys) && keys.length > 0,
         !!(ov && Number(ov.totalRequests) > 0),
-        !!(s && ((s.routingMode && s.routingMode !== "off") || s.defaultModel)) || (Array.isArray(rules) && rules.length > 0),
+        // Routing = the user actually turned on auto-routing OR created a rule (generic or app-specific).
+        // A default model doesn't count — it's auto-set when a provider is connected, so it isn't a
+        // signal that the user configured routing.
+        !!(s && s.routingMode && s.routingMode !== "off") || (Array.isArray(rules) && rules.length > 0),
       ];
       setDone(d);
       if (d.every(Boolean)) { write(DISMISS_KEY, true); setDismissed(true); } // all set — retire it


### PR DESCRIPTION
Follow-up to #274. Connecting a provider auto-sets `Settings.defaultModel`, and the checklist's routing step counted a set `defaultModel` as "routing configured" — so **Set up routing** wrongly checked off after the user only connected a provider (they did nothing in AI routing or rules).

**Fix:** the routing step is done only when the user actually configured routing — `routingMode !== "off"` (auto-routing turned on) **or** a rule exists (generic or application-specific). A default model no longer counts.

(The fix was pushed to #274's branch just after it merged, so it never made it into `main` — hence this separate PR.)

## Test
- `npm --prefix web run build` passes.
- After connecting only a provider: step 1 checks off, "Set up routing" stays open until auto-routing is enabled or a rule is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)