### PR TITLE
Make model registry + gateway key cache per-tenant (hosted tenant-safety)

### DIFF
--- a/server/src/gateway/auth.js
+++ b/server/src/gateway/auth.js
@@ -10,12 +10,16 @@
 const crypto = require("crypto");
 const ApiKey = require("../models/ApiKey");
 const Settings = require("../models/Settings");
+const { perConnCache, currentConnection, runWithConnection } = require("../db/context");
 
 const KEY_TTL_MS = 5000;
-let _cache = { byHash: new Map(), at: 0 };
+// Per-connection (per-tenant) key cache. A process-global map would let one tenant's request read
+// another tenant's cached keys within the 5s TTL window (accepting a foreign key or missing its own);
+// perConnCache keys each { byHash, at } slot by the connection's db name. OSS has one connection.
+const _cache = perConnCache();
 
 function invalidate() {
-  _cache.at = 0;
+  _cache.invalidate(); // drop the current tenant's slot so the next lookup reloads
 }
 
 function hashKey(rawKey) {
@@ -23,10 +27,12 @@ function hashKey(rawKey) {
 }
 
 async function _keysByHash() {
-  if (Date.now() - _cache.at < KEY_TTL_MS) return _cache.byHash;
+  const slot = _cache.get();
+  if (slot && Date.now() - slot.at < KEY_TTL_MS) return slot.byHash;
   const docs = await ApiKey.find({ enabled: true, revokedAt: null }).lean();
-  _cache = { byHash: new Map(docs.map((d) => [d.keyHash, d])), at: Date.now() };
-  return _cache.byHash;
+  const byHash = new Map(docs.map((d) => [d.keyHash, d]));
+  _cache.set({ byHash, at: Date.now() });
+  return byHash;
 }
 
 // Multi-replica RPM (Mongo fixed-window counters; see routing/rateLimit.js).
@@ -38,8 +44,14 @@ function stampLastUsed(keyDoc) {
   const prev = _lastStamped.get(keyDoc.keyHash) || 0;
   if (Date.now() - prev < 60_000) return;
   _lastStamped.set(keyDoc.keyHash, Date.now());
+  // The setImmediate callback runs OUTSIDE the request's AsyncLocalStorage store, so capture the tenant
+  // connection now and re-enter it — otherwise the write resolves ApiKey against the (unconnected in
+  // hosted) default connection and silently no-ops.
+  const conn = currentConnection();
   setImmediate(() =>
-    ApiKey.updateOne({ _id: keyDoc._id }, { $set: { lastUsedAt: new Date() } }).catch(() => {})
+    runWithConnection(conn, () =>
+      ApiKey.updateOne({ _id: keyDoc._id }, { $set: { lastUsedAt: new Date() } }).catch(() => {})
+    )
   );
 }
 

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -166,7 +166,14 @@ function buildApp({ resolveTenantDb = defaultResolveTenantDb, entitlements = def
     try { ent = entitlements(req); conn = resolveTenantDb(req); }
     catch (e) { return res.status(e.statusCode || 500).json({ error: e.code || "tenant_unavailable", message: String(e.message || e) }); }
     req.entitlements = ent;
-    runWithConnection(conn, next);
+    // Warm THIS tenant's model registry before dispatching (the registry cache is per-connection, and
+    // the hosted mount never runs registry.init(), so without this it would be empty after a restart).
+    // AsyncLocalStorage carries through the await, so next() and every downstream registry read run in
+    // the tenant connection with its models loaded. Null-safe: a load failure degrades to empty, not an error.
+    runWithConnection(conn, async () => {
+      try { await registry.ensureLoaded(); } catch (e) { console.warn("[registry] ensureLoaded failed:", e.message); }
+      next();
+    });
   });
 
   // The unified AI gateway — one endpoint for all AI requests.

--- a/server/src/pricing/registry.js
+++ b/server/src/pricing/registry.js
@@ -6,6 +6,7 @@
 const ModelEntry = require("../models/ModelEntry");
 const Settings = require("../models/Settings");
 const { clampMaxTokens } = require("./clamp");
+const { perConnCache } = require("../db/context");
 
 // Task types that are "cheap work" — safe candidates for a lighter model.
 const CHEAP_TASK_TYPES = new Set([
@@ -32,14 +33,30 @@ const LIGHT_TARGET_BY_PROVIDER = {
   mistral:        "mistral-small-latest",
 };
 
-// In-memory cache: { [id]: { id, provider, label, inputPer1M, outputPer1M, tier } }
-let _cache = {};
-let _ready = false;
+// In-memory cache of { [id]: modelDoc } — PER CONNECTION (per tenant DB), not a process-global.
+// Under database-per-tenant hosting a single global object would serve one tenant's models to all
+// tenants (and go empty after a restart until a write repopulated it); perConnCache keys each slot by
+// the connection's db name. In OSS there is one connection, so it behaves like a single cache.
+const _cache = perConnCache();
+const TTL_MS = Number(process.env.ARBR_REGISTRY_TTL_MS) || 5 * 60 * 1000;
+
+function _models() {
+  const slot = _cache.get();
+  return (slot && slot.models) || {};
+}
 
 async function _load() {
   const docs = await ModelEntry.find({ enabled: true }).lean();
-  _cache = Object.fromEntries(docs.map((d) => [d.id, d]));
-  _ready = true;
+  _cache.set({ models: Object.fromEntries(docs.map((d) => [d.id, d])), at: Date.now() });
+}
+
+// Populate the CURRENT connection's slot when empty or past the TTL. Called once per request by the
+// tenancy middleware (inside the tenant connection), so the synchronous accessors below have this
+// tenant's models. Cheap after the first load per tenant per TTL.
+async function ensureLoaded() {
+  const slot = _cache.get();
+  if (slot && Date.now() - slot.at < TTL_MS) return;
+  await _load();
 }
 
 // Called once at server boot after mongoose.connect().
@@ -59,7 +76,7 @@ async function init() {
     await ModelEntry.updateMany({ builtIn: true }, { $set: { builtIn: false } });
   }
   await _load();
-  console.log(`[registry] ${Object.keys(_cache).length} models loaded`);
+  console.log(`[registry] ${Object.keys(_models()).length} models loaded`);
   startAutoRefresh();
 }
 
@@ -89,11 +106,11 @@ async function reload() {
 // ── Sync accessors (safe after init()) ──────────────────────────────────────
 
 function getModel(id) {
-  return _cache[id] || null;
+  return _models()[id] || null;
 }
 
 function listModels() {
-  return Object.values(_cache);
+  return Object.values(_models());
 }
 
 // Vision-capable model IDs, optionally restricted to live providers. Used to tell
@@ -101,7 +118,7 @@ function listModels() {
 // cannot. Only affirmatively-flagged models qualify (null = unknown = excluded).
 function listVisionModels(liveIds = null) {
   const live = liveIds ? new Set(liveIds) : null;
-  return Object.values(_cache)
+  return Object.values(_models())
     .filter((m) => m.supportsVision === true && (!live || live.has(m.provider)))
     .map((m) => m.id)
     .sort();
@@ -111,7 +128,7 @@ function listVisionModels(liveIds = null) {
 // The common miss is a client sending a bare ID for a model the registry stores
 // region-scoped, e.g. "deepseek.v3.2" when the ID is "ap-southeast-3/deepseek.v3.2".
 function suggestModels(query, opts = {}) {
-  return rankSuggestions(query, Object.values(_cache), opts);
+  return rankSuggestions(query, Object.values(_models()), opts);
 }
 
 // Pure ranker over an explicit model list, so the scoring is testable without a DB.
@@ -140,7 +157,7 @@ function rankSuggestions(query, models, { limit = 5, liveIds = null } = {}) {
 }
 
 function isPremium(id) {
-  const m = _cache[id];
+  const m = _models()[id];
   return !!m && m.tier === "premium";
 }
 
@@ -152,7 +169,7 @@ function isCheapTask(taskType) {
 // cached-read and cache-write tokens so they bill at the provider's cache rates. Omitting cache
 // (or a model with no cache rates) prices everything at inputPer1M — identical to before.
 function costFor(modelId, promptTokens = 0, completionTokens = 0, cache = {}) {
-  const m = _cache[modelId];
+  const m = _models()[modelId];
   if (!m) return { inputCost: 0, outputCost: 0, totalCost: 0 };
   const cachedRead = Number(cache.cachedReadTokens) || 0;
   const cacheWrite = Number(cache.cacheWriteTokens) || 0;
@@ -169,12 +186,12 @@ function costFor(modelId, promptTokens = 0, completionTokens = 0, cache = {}) {
 // Max completion tokens the model accepts, or null when unknown. The gateway uses this
 // to clamp an over-large client max_tokens to the served model's ceiling.
 function maxOutputFor(modelId) {
-  const m = _cache[modelId];
+  const m = _models()[modelId];
   return m && m.maxOutputTokens ? m.maxOutputTokens : null;
 }
 
 function suggestLightTarget(modelId) {
-  const m = _cache[modelId];
+  const m = _models()[modelId];
   if (!m) return null;
   const target = LIGHT_TARGET_BY_PROVIDER[m.provider];
   if (!target || target === modelId) return null;
@@ -187,6 +204,7 @@ module.exports = {
   LIGHT_TARGET_BY_PROVIDER,
   // Lifecycle
   init,
+  ensureLoaded,
   reload,
   startAutoRefresh,
   stopAutoRefresh,


### PR DESCRIPTION
## Problem
The OSS core keeps two process-global in-memory caches that break under the hosted product's **database-per-tenant** mounting:

1. **Model registry** (`pricing/registry.js`): a global `_cache`, and the hosted mount (`mountCore`/`buildApp`) never calls `registry.init()` — only `start()` does, which hosted doesn't run. So after any restart the cache is **empty for all tenants** until a write repopulates the single shared object. → Models page + default-model dropdown go blank even though the tenant DB has the models; the gateway would get empty pricing/model resolution too.
2. **Gateway key cache** (`gateway/auth.js`): a global `{byHash}` map → within the 5s TTL, one tenant's request can read another tenant's keys (accept a foreign key / spurious 401); and `stampLastUsed`'s `setImmediate` runs outside the tenant connection, so `lastUsedAt` writes hit the unconnected default connection.

`Settings`, `connections`, and `capEngine` were already migrated to the per-connection primitive `perConnCache()` — these two were missed.

## Fix
- **`pricing/registry.js`** → `perConnCache()`; all sync accessors read the current connection's slot; new `ensureLoaded()` (per-tenant, 5-min TTL) populates the current slot; `_load`/`reload` write the current slot; `init()` kept for OSS boot.
- **`server/src/index.js`** tenancy middleware → `runWithConnection(conn, async () => { await registry.ensureLoaded(); next() })` so every request has its tenant's models loaded (ALS carries through the await; null-safe on failure).
- **`gateway/auth.js`** → key cache `perConnCache()`; `stampLastUsed` captures `currentConnection()` and re-enters it for the write.

## OSS impact
None — one global connection ⇒ one cache slot; `init()` still warms it at boot; per-request `ensureLoaded` is a cheap cache hit.

## Test
- Core unit suite: **417/418 pass** (the one failure is the env-dependent `assertProductionReady` test, unrelated). `perConnCache`, `defaultModelResolution`, `visionRouting`, `routingGuards`, `aiPolicyAuthoritative` all pass.
- `node --check` clean on all three files.

Part 1 of the "hosted tenant-safety" work; part 2 (resolve tenant from an `ab_` gateway key so external requests authenticate) is a separate arbr-cloud change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)