### PR TITLE
Seed curated provider catalogue so connected models are discoverable + pinnable

### DIFF
--- a/server/src/litellm/sync.js
+++ b/server/src/litellm/sync.js
@@ -138,6 +138,15 @@ function buildIndex(data) {
 
     const provider = normalizeProvider(prefix);
 
+    // Skip the LiteLLM "amazon-nova" namespace: its ids (e.g. "nova-lite-v1") are NOT the Bedrock
+    // inference-profile ids the adapter calls — the real Nova models are seeded from the curated
+    // catalogue under provider "bedrock-nova". Importing these only yields misleading "did you mean"
+    // suggestions and an orphaned, never-connected "amazon-nova" provider tag.
+    if (prefix === "amazon-nova") continue;
+    // Skip obviously-noisy Bedrock catalogue variants (commitment plans, legacy invoke/, wildcard region)
+    // that clutter /v1/models. Region-specific ids are kept.
+    if (provider === "bedrock-nova" && (/(^|\/)\d+-month-commitment\//.test(id) || id.startsWith("invoke/") || id.startsWith("*/"))) continue;
+
     // Skip deprecated
     if (ltEntry.deprecated === true) continue;
     // Skip dated snapshots: -YYYY-MM-DD, -YYYYMMDD, -YYYY-MM

--- a/server/src/pricing/registry.js
+++ b/server/src/pricing/registry.js
@@ -7,6 +7,7 @@ const ModelEntry = require("../models/ModelEntry");
 const Settings = require("../models/Settings");
 const { clampMaxTokens } = require("./clamp");
 const { perConnCache } = require("../db/context");
+const providerCatalogue = require("./table"); // curated first-class provider models (real callable ids)
 
 // Task types that are "cheap work" — safe candidates for a lighter model.
 const CHEAP_TASK_TYPES = new Set([
@@ -71,10 +72,10 @@ async function init() {
     await require("../litellm/sync").run().catch((e) =>
       console.warn("[registry] initial sync failed (run Sync Models in the UI):", e.message)
     );
-  } else {
-    // Unmark legacy seed models so sync cleanup can manage them going forward.
-    await ModelEntry.updateMany({ builtIn: true }, { $set: { builtIn: false } });
   }
+  // Ensure the curated first-class provider models (real callable ids) are present + protected on every
+  // boot, so connected providers can be discovered/pinned regardless of LiteLLM's catalogue naming.
+  await seedProviderCatalogue();
   await _load();
   console.log(`[registry] ${Object.keys(_models()).length} models loaded`);
   startAutoRefresh();
@@ -101,6 +102,31 @@ function stopAutoRefresh() {
 // Call after any write to /api/models to keep cache current.
 async function reload() {
   await _load();
+}
+
+// Seed the curated first-class provider catalogue (pricing/table.js) into the registry as protected
+// builtIn rows. The registry is otherwise populated ONLY from the LiteLLM catalogue, whose ids/provider
+// tags don't match what the adapters actually call (e.g. Bedrock Nova serves `us.amazon.nova-lite-v1:0`,
+// but LiteLLM lists it under a bare/`amazon-nova` key) — so a connected provider's real models can't be
+// discovered or pinned. Seeding the callable ids under the connection provider fixes discovery + pinning
+// and gives the default a real registry entry. Idempotent: refreshes pricing/provider each run but leaves
+// operator-owned tier/enabled after first insert, and keeps builtIn:true so the LiteLLM cleanup (which
+// only deletes builtIn:false) can never remove them. Runs against currentConnection() (per tenant in
+// hosted, the one connection in OSS).
+async function seedProviderCatalogue() {
+  const ops = Object.entries(providerCatalogue.MODELS).map(([id, m]) => ({
+    updateOne: {
+      filter: { id },
+      update: {
+        $set: { provider: m.provider, inputPer1M: m.inputPer1M, outputPer1M: m.outputPer1M, chatCapable: true, builtIn: true },
+        $setOnInsert: { id, tier: m.tier, enabled: true, label: id },
+      },
+      upsert: true,
+    },
+  }));
+  if (ops.length) {
+    await ModelEntry.bulkWrite(ops, { ordered: false }).catch((e) => console.warn("[registry] seed provider catalogue failed:", e.message));
+  }
 }
 
 // ── Sync accessors (safe after init()) ──────────────────────────────────────
@@ -205,6 +231,7 @@ module.exports = {
   // Lifecycle
   init,
   ensureLoaded,
+  seedProviderCatalogue,
   reload,
   startAutoRefresh,
   stopAutoRefresh,


### PR DESCRIPTION
## Problem
The model registry is populated **only** from the LiteLLM catalogue, whose model ids and provider tags don't match what the provider adapters actually call. For a connected Amazon Bedrock (`bedrock-nova`, default `us.amazon.nova-lite-v1:0`):
- `model:"auto"` works (passthrough serves the config default **raw**, bypassing the registry).
- **Pinning fails**: `us.amazon.nova-lite-v1:0` is a bare LiteLLM key → skipped by the importer → `model_not_found`; `nova-lite-v1` comes from LiteLLM's `amazon-nova/…` namespace → tagged provider `amazon-nova` (never in `liveIds`) → `provider_not_connected`. `GET /v1/models` lists neither.

Root cause: **no provider-owned source of truth for a connected provider's real, callable models.** The historically-correct mapping in `pricing/table.js` (real ids → connection provider, priced) is dead code — nothing loads it.

## Fix
- **`registry.seedProviderCatalogue()`** upserts `pricing/table.js` (30 curated models across the 9 first-class providers, with the **real callable ids**, tier, pricing) into `ModelEntry` as **protected `builtIn` rows** under the connection provider id. Idempotent: refreshes pricing/provider each run, `$setOnInsert` leaves operator-owned `tier`/`enabled` after first insert, and `builtIn:true` keeps the LiteLLM cleanup (deletes only `builtIn:false`) from removing them.
- **`registry.init()`** seeds on every boot and drops the old `updateMany({builtIn:true},{builtIn:false})` that stripped protection.
- **`litellm/sync.js`** skips the `amazon-nova` namespace (un-callable duplicate ids that produced the misleading "did you mean nova-lite-v1") and noisy Bedrock variants (`*/N-month-commitment/…`, `invoke/…`, `*/…`) to declutter `/v1/models`. Region-specific ids kept.

No change to `gateway/handler.js` or the listing filters — once the real ids exist as connection-provider rows, the existing pin path (`resolveExplicit`→`getModel`→`liveIds`) and `/v1/models` both work, and `decideDefaultModel` stops reporting `not-in-registry` for the default.

## Test
- Core unit suite **417/418** (the one failure is the unrelated env-dependent `assertProductionReady`).
- Seed op shape validated (30 models; no `id` in both filter+`$set`, so no upsert conflict); `bedrock-nova` gets the four `us.amazon.nova-*` ids.

Hosted rollout (separate arbr-cloud PR): also seed at tenant provisioning + a one-off backfill for existing tenants, then verify pinning `us.amazon.nova-lite-v1:0` returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)