### PR TITLE
Resolve prefixed Bedrock ids to curated capabilities + honest reason text

### DIFF
--- a/server/src/routing/aiPolicy.js
+++ b/server/src/routing/aiPolicy.js
@@ -12,7 +12,8 @@ const { perConnCache } = require("../db/context");
 // GET /api/ai-policy auto-regenerates if the stored version is behind.
 // HOW TO UPDATE: change the tables/engine below, then increment this number by 1.
 // v3: deterministic evidence-based engine (capability gates + traffic-informed expected cost).
-const CAPABILITY_VERSION = 3;
+// v4: prefix-aware curated-capability matching (Bedrock region/account ids resolve) + DeepSeek V3.x rows.
+const CAPABILITY_VERSION = 4;
 
 const _cache = perConnCache(); // per-connection: each tenant caches its own policy map
 const TTL_MS = 5000;
@@ -58,6 +59,8 @@ const MODEL_CAPABILITIES = {
   // DeepSeek
   "deepseek-chat":                 { coding:0.92, reasoning:0.82, writing:0.72, analysis:0.72, language:0.65, general:0.68, data:0.80 },
   "deepseek-reasoner":             { coding:0.78, reasoning:0.97, writing:0.60, analysis:0.75, language:0.60, general:0.62, data:0.70 },
+  "deepseek.v3.2":                 { coding:0.90, reasoning:0.88, writing:0.72, analysis:0.76, language:0.66, general:0.72, data:0.80 },
+  "deepseek.v3.1":                 { coding:0.90, reasoning:0.84, writing:0.72, analysis:0.74, language:0.66, general:0.70, data:0.80 },
   // xAI
   "grok-2":                        { coding:0.78, reasoning:0.82, writing:0.80, analysis:0.78, language:0.72, general:0.74, data:0.70 },
   "grok-3":                        { coding:0.85, reasoning:0.90, writing:0.85, analysis:0.85, language:0.78, general:0.80, data:0.78 },
@@ -241,11 +244,29 @@ function goalWeight(goal, tier) {
   return COST_SENSITIVITY[tier] || 0.25; // "balanced" / unset
 }
 
+// Normalize a model id for curated-capability matching. Gateway/Bedrock ids carry an inference-profile
+// prefix (e.g. "us-gov-east-1/amazon.nova-pro-v1:0") and account variants ("us.amazon." vs "amazon.")
+// that an exact-id lookup misses — so "amazon.nova-pro" would score as an unknown model despite being in
+// the curated table. This drops the "region/" path segment, unifies the Bedrock account prefix, and folds
+// dots→dashes, while KEEPING the model-family word (unlike the benchmark normalizer, which strips it).
+function capKey(id) {
+  let s = String(id || "").toLowerCase();
+  const slash = s.lastIndexOf("/");
+  if (slash >= 0) s = s.slice(slash + 1);          // us-gov-east-1/amazon.nova-pro-v1:0 → amazon.nova-pro-v1:0
+  s = s.replace(/^us\.amazon\./, "amazon.").replace(/^us\./, ""); // unify Bedrock account prefixes
+  return s.replace(/\./g, "-");                    // dots→dashes so "deepseek.v3.2" ≈ "deepseek-v3-2"
+}
+
+// Curated table indexed by normalized key, so prefixed/variant ids resolve to their known scores.
+const _capIndex = {};
+for (const [k, v] of Object.entries(MODEL_CAPABILITIES)) _capIndex[capKey(k)] = v;
+
 // Resolve a model's capability vector and whether it is MEASURED (from a LiveBench/LMSYS sync) or
 // ESTIMATED (curated table, or keyword-derived). Single source of truth for gates, scoring, evidence.
 function resolveCapabilities(model) {
   if (model.capabilities && model.capabilities.coding != null) return { caps: model.capabilities, measured: true };
-  if (MODEL_CAPABILITIES[model.id]) return { caps: MODEL_CAPABILITIES[model.id], measured: false };
+  const curated = MODEL_CAPABILITIES[model.id] || _capIndex[capKey(model.id)];
+  if (curated) return { caps: curated, measured: false };
   return { caps: deriveCapabilities(model), measured: false };
 }
 
@@ -326,11 +347,13 @@ function expectedCostPer1k(model, tokens) {
   return perReq * 1000;
 }
 
-// Templated, operator-facing rationale for the top pick (no LLM).
-function reasonFor(c, rank, goal, bar) {
+// Templated, operator-facing rationale for the top pick (no LLM). `barMet` is false when NO candidate
+// reached the quality bar and it was relaxed — so we must not claim the winner "cleared" it.
+function reasonFor(c, rank, goal, bar, barMet) {
   if (rank !== 0) return "";
   if (goal === "quality") return `highest capability (${Math.round(c.quality * 100)}) for this task`;
-  return `clears the ${bar.toFixed(2)} quality bar (${c.quality.toFixed(2)}) at the lowest expected cost`;
+  if (barMet) return `clears the ${bar.toFixed(2)} quality bar (${c.quality.toFixed(2)}) at the lowest expected cost`;
+  return `no model meets the ${bar.toFixed(2)} quality bar (best is ${c.quality.toFixed(2)}) — picked the lowest expected cost among the closest, add benchmark data to differentiate`;
 }
 
 // Rank all candidate models for one task with evidence attached. SYNCHRONOUS (cost reads the in-memory
@@ -360,9 +383,11 @@ function rankCandidates(task, liveModels, catalogMap, tokenProfiles, goal, tierO
     const meas = elig.filter((c) => c.measured);
     if (meas.length) elig = meas;
   }
-  // 3) quality bar — relax only if it empties the pool
+  // 3) quality bar — relax only if it empties the pool. barMet records whether the bar actually held,
+  // so the evidence/reason don't claim a "cleared bar" when everything fell short and cost alone decided.
   let clearing = elig.filter((c) => c.quality >= bar);
-  if (!clearing.length) clearing = elig;
+  const barMet = clearing.length > 0;
+  if (!barMet) clearing = elig;
 
   // 4) rank: quality goal → highest quality; else → cheapest expected cost. Deterministic tie-breaks.
   clearing.sort((a, b) => {
@@ -385,7 +410,7 @@ function rankCandidates(task, liveModels, catalogMap, tokenProfiles, goal, tierO
     measured: c.measured,
     confidence: c.measured ? (c.quality >= bar ? "high" : "medium") : "low",
     needsShadowEval: !c.measured,
-    reason: reasonFor(c, i, goal, bar),
+    reason: reasonFor(c, i, goal, bar, barMet),
   }));
 }
 
@@ -508,4 +533,4 @@ async function describe() {
   };
 }
 
-module.exports = { getEffective, lookup, resolveModel, setAssignments, regenerate, computeAssignments: _computeAssignments, simulate, describe, invalidate, CAPABILITY_VERSION, _goalWeight: goalWeight, _pricedPool: pricedPool, _rankCandidates: rankCandidates, _passesGates: passesGates, _qualityScore: qualityScore };
+module.exports = { getEffective, lookup, resolveModel, setAssignments, regenerate, computeAssignments: _computeAssignments, simulate, describe, invalidate, CAPABILITY_VERSION, _goalWeight: goalWeight, _pricedPool: pricedPool, _rankCandidates: rankCandidates, _passesGates: passesGates, _qualityScore: qualityScore, _resolveCapabilities: resolveCapabilities, _capKey: capKey };

--- a/server/test/unit/aiPolicyEngine.test.js
+++ b/server/test/unit/aiPolicyEngine.test.js
@@ -3,7 +3,7 @@
 // with hand-built model pools — no DB, no LLM — so the policy decisions are asserted in isolation.
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { _rankCandidates, _passesGates, _qualityScore } = require("../../src/routing/aiPolicy");
+const { _rankCandidates, _passesGates, _qualityScore, _resolveCapabilities, _capKey } = require("../../src/routing/aiPolicy");
 
 // Helper: a fully-specified (MEASURED) model with an explicit capability vector.
 function measured(id, tier, caps, inputPer1M, outputPer1M) {
@@ -98,6 +98,55 @@ test("same inputs produce the same ranking every time", () => {
   const a = _rankCandidates("coding", pool, { coding: { tier: "mid" } }, {}, "balanced");
   const b = _rankCandidates("coding", pool, { coding: { tier: "mid" } }, {}, "balanced");
   assert.deepEqual(a, b);
+});
+
+// ── Prefixed Bedrock ids resolve to curated capabilities (not the 0.40 unknown default) ─────
+test("region/account-prefixed Bedrock ids resolve to curated capabilities", () => {
+  // us-gov-east-1/amazon.nova-pro-v1:0 must match the curated us.amazon.nova-pro-v1:0 row.
+  const nova = _resolveCapabilities({ id: "us-gov-east-1/amazon.nova-pro-v1:0" });
+  assert.equal(nova.measured, false, "curated caps are estimated, not measured");
+  assert.equal(nova.caps.reasoning, 0.80, "resolves to nova-pro's known reasoning score, not the 0.40 default");
+  assert.equal(nova.caps.analysis, 0.82);
+});
+
+test("deepseek.v3.2 with a region prefix resolves to its curated caps", () => {
+  const ds = _resolveCapabilities({ id: "us-east-2/deepseek.v3.2" });
+  assert.equal(ds.measured, false);
+  assert.equal(ds.caps.coding, 0.90, "a strong coder, not the 0.40 unknown default");
+});
+
+test("capKey strips the region prefix and unifies the Bedrock account prefix", () => {
+  assert.equal(_capKey("us-gov-east-1/amazon.nova-pro-v1:0"), _capKey("us.amazon.nova-pro-v1:0"));
+  assert.equal(_capKey("us-east-2/deepseek.v3.2"), "deepseek-v3-2");
+});
+
+test("a genuinely unknown model still falls back to the estimated default", () => {
+  const unknown = _resolveCapabilities({ id: "acme/frontier-model-9000" });
+  assert.equal(unknown.measured, false);
+  assert.equal(unknown.caps.coding, 0.4, "keyword-derived default when nothing matches");
+});
+
+// ── The reason is honest when the quality bar was relaxed (#the misleading-text bug) ─────────
+test("reason does not claim the bar was cleared when no candidate met it", () => {
+  // Two low-capability estimated models; neither clears the 0.80 balanced bar for a coding task.
+  const pool = [
+    estimated("cheap-unknown", "mid", "assistant", 0.05, 0.1),
+    estimated("dear-unknown", "mid", "assistant", 0.5, 1.0),
+  ];
+  const [top] = _rankCandidates("coding", pool, { coding: { tier: "mid" } }, {}, "balanced");
+  assert.ok(top.quality < 0.8, "precondition: nobody clears the 0.80 bar");
+  assert.match(top.reason, /no model meets the 0\.80 quality bar/, "must not falsely claim the bar was cleared");
+  assert.doesNotMatch(top.reason, /clears the 0\.80 quality bar/);
+});
+
+test("reason DOES claim a cleared bar when a candidate genuinely meets it", () => {
+  const pool = [
+    measured("strong-coder", "mid",
+      { coding:0.92, reasoning:0.85, writing:0.7, analysis:0.75, language:0.6, general:0.7, data:0.8 }, 1.0, 3.0),
+  ];
+  const [top] = _rankCandidates("coding", pool, { coding: { tier: "mid" } }, {}, "balanced");
+  assert.ok(top.quality >= 0.8, "precondition: clears the bar");
+  assert.match(top.reason, /clears the 0\.80 quality bar/);
 });
 
 test("qualityScore is the task-weighted capability average", () => {


### PR DESCRIPTION
## Context

On a live OSS tenant (arbr.gyde.ai), a generated policy assigned **one model (`moonshotai.kimi-k2.5`) to all 35 tasks** despite 3 models being available. The new "View reasoning" panel made the cause visible: two of the three models scored a flat **0.40 (estimated)** on every task, so kimi — the only model with any capability signal, and also the cheapest — swept everything. This PR fixes the two real defects behind that.

## 1. Prefixed Bedrock ids didn't resolve to known capabilities

`resolveCapabilities` matched the curated `MODEL_CAPABILITIES` table by **exact id**. The tenant's ids carry an inference-profile prefix and account variant:

| tenant id | curated key | matched? |
|---|---|---|
| `us-gov-east-1/amazon.nova-pro-v1:0` | `us.amazon.nova-pro-v1:0` | ❌ → scored 0.40 |
| `us-east-2/deepseek.v3.2` | *(none)* | ❌ → scored 0.40 |

So a model Arbr **already has scores for** (nova-pro) was treated as unknown. Added `capKey()` — drops the `region/` path segment, unifies the Bedrock `us.amazon.`/`amazon.` prefix, folds dots→dashes, and **keeps the model-family word** (unlike the benchmark `normalize()`, which strips it). The curated table is indexed by it, so prefixed/variant ids now resolve. Result: models differentiate on real capability instead of collapsing to cheapest-wins.

## 2. Curated rows for DeepSeek V3.2 / V3.1

Brand-new; no LiveBench row yet, so they'd stay at the 0.40 default. Added conservative curated vectors (strong coder/reasoner).

## 3. The reason text lied when the bar was relaxed

Every winner said *"clears the 0.80 quality bar (0.43)"* — but 0.43 doesn't clear 0.80. What actually happened: nobody met the bar, so it was relaxed and cost alone decided. Threaded a `barMet` flag so the reason now reads *"no model meets the 0.80 quality bar (best is 0.43) — picked the lowest expected cost among the closest, add benchmark data to differentiate"*, and only claims a cleared bar when one genuinely is.

## Behavior change

After this, on that tenant, mid-tier tasks spread — e.g. DeepSeek V3.2 (coding 0.90) clears the bar on coding and wins it over kimi, nova-pro takes analysis-heavy tasks — while kimi keeps cheap high-volume tasks. `CAPABILITY_VERSION` 3→4 so existing policies auto-regenerate.

> Note: premium-tier tasks still prefer kimi while it's the only **measured** model (the existing "conservative unknowns" rule keeps estimated models off high-stakes tasks when a measured one qualifies). Getting the others benchmarked (LiveBench/LMSYS or evals) promotes them there too.

## Tests

+6 unit tests (prefix/variant resolution, unknown-model fallback, honest reason both ways). Full unit suite green (**433**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)