### PR TITLE
Fix flaky notifierDedup test (issue #293): await unique index before asserting dedup

### DIFF
--- a/server/test/integration/notifierDedup.test.js
+++ b/server/test/integration/notifierDedup.test.js
@@ -22,6 +22,12 @@ let sendCount;
 before(async () => {
   mongod = await MongoMemoryServer.create();
   await mongoose.connect(mongod.getUri());
+  // The dedup guarantee IS the unique index on dedupKey. Mongoose builds indexes in the background
+  // after connect(), so without waiting the inserts below can race ahead of the index — uniqueness
+  // isn't enforced yet and every claim "succeeds", so dedup silently no-ops. That's the flake in
+  // issue #293 (tests 98 + 100 failed, 99 passed — the exact signature of an unenforced unique index).
+  // Production is unaffected: the index is built at boot, long before any notification fires.
+  await NotificationDedup.createIndexes();
 });
 
 after(async () => {


### PR DESCRIPTION
Fixes #293.

## Root cause — test-setup race, not a product bug

The dedup guarantee is the **unique index** on `NotificationDedup.dedupKey` (`notify()` inserts; a duplicate-key `11000` means "already claimed"). Mongoose builds indexes **in the background** after `connect()`, but the test starts inserting immediately in `before`/the first `test`. On unlucky CI timing, the inserts race *ahead* of the index build — uniqueness isn't enforced yet, so every `create()` succeeds and dedup silently no-ops.

The failure signature in the issue confirms it exactly:

```
not ok 98  - concurrent notify() calls ... send exactly once   (wants 1, got >1)
     ok 99  - different keys are not deduped                     (wants 2, got 2) ✅
not ok 100 - a later call within the window is still suppressed  (wants 1, got 2)
```

98 and 100 depend on the unique constraint; 99 doesn't. All three behaving that way ⇒ the unique index simply wasn't enforced yet.

**Production is unaffected:** the index is built at boot, long before any `cap_breach` ever fires. Only the test — which inserts milliseconds after connecting — is exposed.

## Fix

`await NotificationDedup.createIndexes()` in the `before()` hook, so the index exists before any test inserts. One line, no product change.

## Verification

- Ran the integration file **10× locally — 10/10 clean**.
- Full server unit suite unaffected.

## Why it mattered (per the issue)

`ops/deploy.sh`'s gate is "image exists in GHCR" and `publish-image` only runs after CI is green — so a flaky CI run silently blocks a deploy until someone re-runs it. This was exactly the b8b1eec situation. Hardening the test removes that failure mode at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)