### PR TITLE
SDKs 0.6.0: usage analytics API + finishReason/warning (JS + Python)

### DIFF
--- a/clients/js/CHANGELOG.md
+++ b/clients/js/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.6.0 (2026-08-15)
+
+- **`client.usage`** — read-only usage analytics, authenticated by a **read token** (an API key of kind `read`, created in the console under Settings → API keys), not the gateway key. A read token is scoped to one application (+ optional user) and cannot run inference, so it's safe to embed in a partner app or a per-tenant dashboard.
+  - `usage.overview()` — headline stats for the token's scope (`GET /v1/usage/overview`): cost, requests, tokens, success rate, prompt-cache reuse + savings.
+  - `usage.timeseries(bucket)` — cost/request trend (`GET /v1/usage/timeseries`), `bucket` ∈ `"hour" | "day" | "month"`.
+  - `usage.byModel()` — spend + usage broken down by model (`GET /v1/usage/by-model`).
+  - `usage.scope()` — echo the token's own scope (`GET /v1/usage/scope`).
+  - Configure with `createClient({ readToken })` or `ARBR_READ_TOKEN`.
+- **`chat()` now surfaces `finishReason`** (`"stop" | "length" | "tool_calls" | "content_filter"`) and an optional **`warning`** — so you can tell a deliberately short answer from one truncated by `max_tokens` (e.g. a reasoning model that spent the whole budget on internal thinking and returned no text).
+- **TypeScript**: added `FinishReason`, `UsageOverview`, `UsageTimeseriesPoint`, `UsageModelRow`, `UsageScope`, `UsageApi`, `UsageBucket`; `ChatResponse` gains `finishReason`/`warning`; `ClientOptions` gains `readToken`; `Client` gains `usage`.
+
 ## 0.5.0 (2026-07-13)
 
 - **`embeddings()`** — generate vector embeddings via `POST /v1/embeddings`. OpenAI-compatible wire format (`{ model, input, dimensions? }`). Dispatches to Gemini (`gemini-embedding-001`) or any OpenAI-compat provider (`text-embedding-3-small`, etc.) with full observability parity to chat.

--- a/clients/js/README.md
+++ b/clients/js/README.md
@@ -69,6 +69,7 @@ the dashboard Requests drilldown.
 |---|---|---|
 | `baseUrl` | `process.env.ARBR_GATEWAY_URL` | Gateway origin. Required (here or via env). |
 | `apiKey` | `process.env.ARBR_API_KEY` | Gateway API key (`ab_…`, dashboard → Settings → API keys). Sent as `Authorization: Bearer`; binds attribution server-side. Required once the gateway has *Require API keys* on. |
+| `readToken` | `process.env.ARBR_READ_TOKEN` | Read token (API key of kind `read`) for `client.usage`. Scoped read-only; cannot run inference. Only needed for the usage analytics API. |
 | `application` | — | Default attribution merged into every call. Strongly recommended. |
 | `workflow`, `department`, `userId` | — | More default attribution. |
 | `timeoutMs` | `60000` | Per attempt, via `AbortController`. |
@@ -90,10 +91,16 @@ Request fields: `messages` (required), `model`, `provider`, `taskType`, `tempera
 ```
 
 Response: `{ requestId, model, modelRequested, provider, routingDecision, classifiedBy,
-cacheHit, text, usage: { inputTokens, outputTokens, totalTokens, cachedReadTokens, cacheWriteTokens } }`.
+cacheHit, finishReason, text, usage: { inputTokens, outputTokens, totalTokens, cachedReadTokens, cacheWriteTokens } }`
+(plus an optional `warning`).
 
 `usage.cachedReadTokens` and `usage.cacheWriteTokens` are non-zero when the provider's prompt
 cache was active (Anthropic, OpenAI). The gateway prices these at provider cache rates automatically.
+
+`finishReason` is `"stop" | "length" | "tool_calls" | "content_filter"` — check it to tell a
+deliberately short answer from one truncated by `maxTokens`. When a reasoning model spends its
+whole budget on internal thinking and returns no text, `finishReason` is `"length"` and a `warning`
+string is present; raise `maxTokens` and retry.
 
 ### Streaming
 
@@ -216,6 +223,35 @@ for (const p of providers) {
 // bedrock-nova → 11 models
 // anthropic    → 3 models
 ```
+
+### `client.usage` — usage analytics (read-only)
+
+Query cost, requests, and token usage programmatically — the same numbers the dashboard shows,
+scoped to a **read token**. A read token (an API key of kind `read`, created in the console under
+Settings → API keys) is locked to one application (and optionally one user) and **cannot run
+inference**, so it's safe to hand to a partner app or drop into a per-tenant dashboard. Set it via
+`createClient({ readToken })` or `ARBR_READ_TOKEN`.
+
+```js
+const arbr = createClient({ baseUrl: "http://localhost:4100", readToken: "ab_read_…" });
+
+const o = await arbr.usage.overview();
+console.log(`$${o.totalCost.toFixed(2)} over ${o.totalRequests} requests`);
+console.log(`cache hit rate ${(o.cacheHitRate * 100).toFixed(1)}% · saved $${o.cacheSavingUsd.toFixed(2)}`);
+
+const trend = await arbr.usage.timeseries("day");   // [{ date, requests, cost, failures }, …]
+const byModel = await arbr.usage.byModel();          // [{ key: modelId, requests, cost, … }, …]
+const scope = await arbr.usage.scope();              // { application, userId } this token may read
+```
+
+| Method | Endpoint | Returns |
+|---|---|---|
+| `usage.overview()` | `GET /v1/usage/overview` | Headline cost / requests / tokens / cache stats |
+| `usage.timeseries(bucket)` | `GET /v1/usage/timeseries` | Trend points; `bucket` ∈ `"hour" \| "day" \| "month"` |
+| `usage.byModel()` | `GET /v1/usage/by-model` | Spend + usage per model |
+| `usage.scope()` | `GET /v1/usage/scope` | The `{ application, userId }` this token is scoped to |
+
+Calling any of these without a read token throws a `GatewayError` explaining how to create one.
 
 ### `asLangChainModel(client, meta?) → { invoke, stream }`
 

--- a/clients/js/index.d.ts
+++ b/clients/js/index.d.ts
@@ -33,6 +33,9 @@ export type RoutingDecision =
 
 export type ClassifiedBy = "provided" | "keyword" | "ai";
 
+/** Why generation stopped. "length" means the answer was truncated by max_tokens. */
+export type FinishReason = "stop" | "length" | "tool_calls" | "content_filter";
+
 export interface Usage {
   inputTokens?: number;
   outputTokens?: number;
@@ -55,6 +58,10 @@ export interface ChatResponse {
   cacheHit: boolean;
   text: string;
   usage?: Usage;
+  /** Why generation stopped — tells a deliberately short answer from a truncated one. May be null. */
+  finishReason?: FinishReason | null;
+  /** Present only when a reasoning model spent the whole max_tokens budget on internal thinking and returned no text. */
+  warning?: string;
 }
 
 export interface StatusResponse {
@@ -121,6 +128,8 @@ export interface ClientOptions {
   baseUrl?: string;
   /** Gateway API key ("ab_…", from Settings → API keys). Falls back to ARBR_API_KEY. Binds attribution server-side. */
   apiKey?: string;
+  /** Read token (an API key of kind "read") for the usage analytics API. Falls back to ARBR_READ_TOKEN. Scoped read-only; cannot run inference. */
+  readToken?: string;
   /** Default attribution metadata merged into every call. */
   application?: string;
   workflow?: string;
@@ -197,6 +206,58 @@ export interface EmbeddingsResponse {
   usage: { prompt_tokens: number; total_tokens: number };
 }
 
+export type UsageBucket = "hour" | "day" | "month";
+
+/** Headline usage stats for a read token's scope (GET /v1/usage/overview). */
+export interface UsageOverview {
+  totalRequests: number;
+  totalCost: number;
+  customerCost: number;
+  internalCost: number;
+  avgCostPerRequest: number;
+  avgLatency: number;
+  totalTokens: number;
+  failures: number;
+  cacheHits: number;
+  cacheHitRate: number;
+  cachedReadTokens: number;
+  cacheSavingUsd: number;
+  [k: string]: unknown;
+}
+
+/** One point in the cost/request trend (GET /v1/usage/timeseries). */
+export interface UsageTimeseriesPoint {
+  /** "YYYY-MM-DD" (day/month) or "YYYY-MM-DDTHH" (hour), UTC. */
+  date: string;
+  requests: number;
+  cost: number;
+  failures: number;
+}
+
+/** Spend + usage for one model (GET /v1/usage/by-model). `key` is the model id. */
+export interface UsageModelRow {
+  key: string;
+  requests: number;
+  cost: number;
+  avgLatency: number;
+  failures: number;
+  [k: string]: unknown;
+}
+
+/** The scope a read token is allowed to see (GET /v1/usage/scope). */
+export interface UsageScope {
+  application: string | null;
+  userId: string | null;
+}
+
+/** Read-only usage analytics, authenticated by a read token (see ClientOptions.readToken). */
+export interface UsageApi {
+  overview(opts?: { signal?: AbortSignal }): Promise<UsageOverview>;
+  timeseries(bucket?: UsageBucket, opts?: { signal?: AbortSignal }): Promise<UsageTimeseriesPoint[]>;
+  byModel(opts?: { signal?: AbortSignal }): Promise<UsageModelRow[]>;
+  scope(opts?: { signal?: AbortSignal }): Promise<UsageScope>;
+}
+
 export interface Client {
   /** One routed completion via POST /v1/chat. */
   chat(opts: ChatRequest): Promise<ChatResponse>;
@@ -216,6 +277,8 @@ export interface Client {
   taskTypes(opts?: { signal?: AbortSignal }): Promise<TaskTypesResponse>;
   /** Generate embeddings — POST /v1/embeddings. OpenAI-compatible response format. */
   embeddings(opts: EmbeddingsRequest): Promise<EmbeddingsResponse>;
+  /** Read-only usage analytics (GET /v1/usage/*). Requires a read token (ClientOptions.readToken / ARBR_READ_TOKEN). */
+  usage: UsageApi;
   baseUrl: string;
 }
 

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arbr-client",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Official JS client for the Arbr AI control-plane gateway — one function to route, observe, and govern every LLM call.",
   "license": "MIT",
   "main": "./src/index.js",

--- a/clients/js/src/index.js
+++ b/clients/js/src/index.js
@@ -302,7 +302,37 @@ function createClient(options = {}) {
     );
   }
 
-  return { chat, stream, status, models, providers, taskTypes, embeddings, baseUrl };
+  // ── Usage analytics (read-only) ───────────────────────────────────────────
+  // Authenticated by a READ token (an API key of kind "read"), NOT the gateway key.
+  // A read token is scoped to one application (+ optional user) and cannot run
+  // inference — every query is forced to its own scope server-side. Create one in
+  // the console under Settings → API keys. Falls back to ARBR_READ_TOKEN.
+  const readToken = options.readToken || process.env.ARBR_READ_TOKEN || null;
+  // Returns a rejected promise (not a sync throw) so `await client.usage.x()` / `.catch()` behave
+  // like every other client method when no read token is configured.
+  function usageGet(path, { signal } = {}) {
+    if (!readToken) {
+      return Promise.reject(invalid("the usage API needs a read token — pass `readToken` (or set ARBR_READ_TOKEN). Create one in the console under Settings → API keys. A gateway key cannot read usage."));
+    }
+    return requestWithRetries(
+      fetchImpl,
+      `${baseUrl}/v1/usage/${path}`,
+      { method: "GET", headers: { Authorization: `Bearer ${readToken}` } },
+      { timeoutMs, retries, signal }
+    );
+  }
+  const usage = {
+    /** Headline stats for this token's scope: cost, requests, tokens, success rate, cache reuse. */
+    overview: (opts = {}) => usageGet("overview", opts),
+    /** Cost/request trend over time. bucket ∈ "hour" | "day" | "month" (default "day"). */
+    timeseries: (bucket = "day", opts = {}) => usageGet(`timeseries?bucket=${encodeURIComponent(bucket)}`, opts),
+    /** Spend + usage broken down by model, within this token's scope. */
+    byModel: (opts = {}) => usageGet("by-model", opts),
+    /** Echo the token's own scope ({ application, userId }) so you know what it may read. */
+    scope: (opts = {}) => usageGet("scope", opts),
+  };
+
+  return { chat, stream, status, models, providers, taskTypes, embeddings, usage, baseUrl };
 }
 
 // ── LangChain-style adapter (duck-typed; no LangChain dependency) ─────────────

--- a/clients/js/test/client.test.js
+++ b/clients/js/test/client.test.js
@@ -280,3 +280,57 @@ test("chat: usage without cache fields → cachedReadTokens and cacheWriteTokens
   assert.equal(res.usage.cachedReadTokens, undefined);
   assert.equal(res.usage.cacheWriteTokens, undefined);
 });
+
+// ── v0.6.0: finishReason / warning pass-through ──────────────────────────────
+
+test("chat: surfaces finishReason and warning from the gateway", async (t) => {
+  const { baseUrl } = await mockGateway(t, () => ({
+    body: { ...OK_RESPONSE, finishReason: "length", warning: "Output truncated by max_tokens." },
+  }));
+  const client = createClient({ baseUrl });
+  const res = await client.chat({ messages: "hi" });
+  assert.equal(res.finishReason, "length");
+  assert.equal(res.warning, "Output truncated by max_tokens.");
+});
+
+// ── v0.6.0: usage analytics (read token) ─────────────────────────────────────
+
+test("usage.overview: hits /v1/usage/overview with the read token", async (t) => {
+  const { baseUrl, seen } = await mockGateway(t, () => ({
+    body: { totalRequests: 42, totalCost: 1.23, cacheHitRate: 0.5, cacheSavingUsd: 0.4 },
+  }));
+  const client = createClient({ baseUrl, apiKey: "ab_gateway", readToken: "ab_read_xyz" });
+  const out = await client.usage.overview();
+  assert.equal(out.totalRequests, 42);
+  const call = seen[seen.length - 1];
+  assert.equal(call.method, "GET");
+  assert.equal(call.url, "/v1/usage/overview");
+  assert.equal(call.auth, "Bearer ab_read_xyz"); // read token, NOT the gateway key
+});
+
+test("usage.timeseries: forwards the bucket query param", async (t) => {
+  const { baseUrl, seen } = await mockGateway(t, () => ({ body: [] }));
+  const client = createClient({ baseUrl, readToken: "ab_read_xyz" });
+  await client.usage.timeseries("month");
+  assert.equal(seen[seen.length - 1].url, "/v1/usage/timeseries?bucket=month");
+});
+
+test("usage.byModel / scope: hit the right endpoints", async (t) => {
+  const { baseUrl, seen } = await mockGateway(t, () => ({ body: {} }));
+  const client = createClient({ baseUrl, readToken: "ab_read_xyz" });
+  await client.usage.byModel();
+  assert.equal(seen[seen.length - 1].url, "/v1/usage/by-model");
+  await client.usage.scope();
+  assert.equal(seen[seen.length - 1].url, "/v1/usage/scope");
+});
+
+test("usage without a read token throws a clear GatewayError", async (t) => {
+  const { baseUrl } = await mockGateway(t);
+  const client = createClient({ baseUrl, apiKey: "ab_gateway" }); // no readToken
+  await assert.rejects(() => client.usage.overview(), (e) => {
+    assert.ok(e instanceof GatewayError);
+    assert.equal(e.code, "invalid_input");
+    assert.match(e.message, /read token/i);
+    return true;
+  });
+});

--- a/clients/python/CHANGELOG.md
+++ b/clients/python/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.0 (2026-08-15)
+
+- **Usage analytics** — read-only, authenticated by a **read token** (an API key of kind `read`, created in the console under Settings → API keys), not the gateway key. A read token is scoped to one application (+ optional user) and cannot run inference, so it's safe to embed in a partner app or per-tenant dashboard. Configure with `create_client(read_token=...)` or `$ARBR_READ_TOKEN`.
+  - `usage_overview()` / `ausage_overview()` — headline stats: cost, requests, tokens, success rate, prompt-cache reuse + savings (`GET /v1/usage/overview`).
+  - `usage_timeseries(bucket)` / `ausage_timeseries(bucket)` — cost/request trend, `bucket` ∈ `"hour" | "day" | "month"` (`GET /v1/usage/timeseries`).
+  - `usage_by_model()` / `ausage_by_model()` — spend + usage by model (`GET /v1/usage/by-model`).
+  - `usage_scope()` / `ausage_scope()` — echo the token's own scope (`GET /v1/usage/scope`).
+- **`ChatResponse` now carries `finish_reason`** (`"stop" | "length" | "tool_calls" | "content_filter"`) and an optional **`warning`** — so you can tell a deliberately short answer from one truncated by `max_tokens` (e.g. a reasoning model that spent the whole budget on internal thinking and returned no text).
+
 ## 0.5.0 (2026-07-13)
 
 - **`embeddings()` / `aembeddings()`** — generate vector embeddings via `POST /v1/embeddings`. OpenAI-compatible wire format. Dispatches to Gemini (`gemini-embedding-001`) or any OpenAI-compat provider (`text-embedding-3-small`, etc.) with full observability parity to chat.

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -62,22 +62,28 @@ per-request and visible in the dashboard Requests drilldown.
 
 ## API
 
-### `create_client(base_url=None, *, application=None, workflow=None, department=None, user_id=None, api_key=None, timeout_s=60, retries=2) → Client`
+### `create_client(base_url=None, *, application=None, workflow=None, department=None, user_id=None, api_key=None, read_token=None, timeout_s=60, retries=2) → Client`
 
 `base_url` falls back to `$ARBR_GATEWAY_URL`; `api_key` to `$ARBR_API_KEY`. A gateway API key
 (`ab_…`, dashboard → Settings → API keys) is sent as `Authorization: Bearer` and binds attribution
 server-side — required once the gateway has *Require API keys* on. The metadata kwargs are defaults
-merged into every call (per-call kwargs override them).
+merged into every call (per-call kwargs override them). `read_token` (falls back to
+`$ARBR_READ_TOKEN`) is only needed for the read-only [usage analytics](#usage-analytics-read-only) methods.
 
 ### `Client.chat(messages, *, model=None, provider=None, task_type=None, temperature=None, max_tokens=None, ...) → ChatResponse`
 
 `messages` accepts a bare string, `{"role", "content"}` dicts, or LangChain message objects.
 `ChatResponse` is a frozen dataclass: `text`, `usage` (`input_tokens/output_tokens/total_tokens/cached_read_tokens/cache_write_tokens`),
 `model`, `model_requested`, `provider`, `routing_decision`, `classified_by`, `cache_hit`,
-`request_id`, plus `.raw` (the unmodified gateway payload).
+`request_id`, `finish_reason`, `warning`, plus `.raw` (the unmodified gateway payload).
 
 `usage.cached_read_tokens` and `usage.cache_write_tokens` are non-zero when the provider's prompt
 cache was active (Anthropic, OpenAI). The gateway prices these at provider cache rates automatically.
+
+`finish_reason` is `"stop" | "length" | "tool_calls" | "content_filter"` — check it to tell a
+deliberately short answer from one truncated by `max_tokens`. When a reasoning model spends its
+whole budget on internal thinking and returns no text, `finish_reason` is `"length"` and `warning`
+is set; raise `max_tokens` and retry.
 
 ### `Client.achat(...)` / `Client.astream(...)` / `Client.astatus()`
 
@@ -168,6 +174,35 @@ for p in result["data"]:
 ```
 
 Async counterpart: `await arbr.aproviders()`.
+
+### Usage analytics (read-only)
+
+Query cost, requests, and token usage programmatically — the same numbers the dashboard shows,
+scoped to a **read token**. A read token (an API key of kind `read`, created in the console under
+Settings → API keys) is locked to one application (and optionally one user) and **cannot run
+inference**, so it's safe to hand to a partner app or a per-tenant dashboard. Set it via
+`create_client(read_token=...)` or `$ARBR_READ_TOKEN`.
+
+```python
+arbr = create_client(base_url="http://localhost:4100", read_token="ab_read_…")
+
+o = arbr.usage_overview()
+print(f"${o['totalCost']:.2f} over {o['totalRequests']} requests")
+print(f"cache hit rate {o['cacheHitRate'] * 100:.1f}% · saved ${o['cacheSavingUsd']:.2f}")
+
+trend = arbr.usage_timeseries("day")   # [{"date", "requests", "cost", "failures"}, …]
+by_model = arbr.usage_by_model()        # [{"key": model_id, "requests", "cost", …}, …]
+scope = arbr.usage_scope()              # {"application": ..., "userId": ...}
+```
+
+| Method (async prefix `a`) | Endpoint | Returns |
+|---|---|---|
+| `usage_overview()` | `GET /v1/usage/overview` | Headline cost / requests / tokens / cache stats |
+| `usage_timeseries(bucket)` | `GET /v1/usage/timeseries` | Trend points; `bucket` ∈ `"hour" \| "day" \| "month"` |
+| `usage_by_model()` | `GET /v1/usage/by-model` | Spend + usage per model |
+| `usage_scope()` | `GET /v1/usage/scope` | The `{application, userId}` this token is scoped to |
+
+Calling any of these without a read token raises `GatewayError` explaining how to create one.
 
 ## Error handling
 

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "arbr-client"
-version = "0.5.0"
+version = "0.6.0"
 description = "Official Python client for the Arbr AI control-plane gateway — one function to route, observe, and govern every LLM call."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/clients/python/src/arbr_client/__init__.py
+++ b/clients/python/src/arbr_client/__init__.py
@@ -99,6 +99,12 @@ class ChatResponse:
     cache_hit: bool
     request_id: str
     usage: Optional[Usage] = None
+    # Why generation stopped ("stop" | "length" | "tool_calls" | "content_filter"); None if unknown.
+    # "length" means the answer was truncated by max_tokens — distinguish a short answer from a cut-off one.
+    finish_reason: Optional[str] = None
+    # Set only when a reasoning model spent the whole max_tokens budget on internal thinking and returned
+    # no text (see usage — reasoning tokens). None otherwise.
+    warning: Optional[str] = None
     raw: dict = field(repr=False, default_factory=dict)
 
     @staticmethod
@@ -125,6 +131,8 @@ class ChatResponse:
             cache_hit=bool(d.get("cacheHit")),
             request_id=d.get("requestId") or "",
             usage=usage,
+            finish_reason=d.get("finishReason"),
+            warning=d.get("warning"),
             raw=d,
         )
 
@@ -278,6 +286,7 @@ class Client:
         department: Optional[str] = None,
         user_id: Optional[str] = None,
         api_key: Optional[str] = None,
+        read_token: Optional[str] = None,
         timeout_s: float = 60.0,
         retries: int = 2,
     ) -> None:
@@ -294,6 +303,10 @@ class Client:
         # Gateway API key ("ka_…", Settings → API keys). Binds attribution server-side.
         key = api_key or os.environ.get("ARBR_API_KEY")
         self._headers = {"Authorization": f"Bearer {key}"} if key else {}
+        # Read token (an API key of kind "read") for the usage analytics API — scoped read-only,
+        # cannot run inference. Falls back to $ARBR_READ_TOKEN. None → the usage_* methods raise.
+        rt = read_token or os.environ.get("ARBR_READ_TOKEN")
+        self._read_headers = {"Authorization": f"Bearer {rt}"} if rt else None
         self._timeout_s = timeout_s
         self._retries = max(0, retries)
 
@@ -521,6 +534,75 @@ class Client:
         """Async :meth:`task_types`."""
         return await asyncio.to_thread(self.task_types)
 
+    # — usage analytics (read-only; requires a read token) —
+
+    def _usage_get(self, path: str) -> Any:
+        if self._read_headers is None:
+            raise _invalid(
+                "the usage API needs a read token — pass `read_token` (or set "
+                "ARBR_READ_TOKEN). Create one in the console under Settings → API keys. "
+                "A gateway key cannot read usage."
+            )
+        return _request_with_retries(
+            f"{self.base_url}/v1/usage/{path}",
+            method="GET",
+            body=None,
+            timeout_s=self._timeout_s,
+            retries=self._retries,
+            headers=self._read_headers,
+        )
+
+    def usage_overview(self) -> dict:
+        """Headline usage stats for this read token's scope — GET /v1/usage/overview.
+
+        Returns a dict with ``total_cost``-style keys (camelCase on the wire):
+        ``totalRequests``, ``totalCost``, ``customerCost``, ``avgCostPerRequest``,
+        ``avgLatency``, ``totalTokens``, ``failures``, ``cacheHits``,
+        ``cacheHitRate``, ``cachedReadTokens``, ``cacheSavingUsd``.
+        """
+        return self._usage_get("overview")
+
+    async def ausage_overview(self) -> dict:
+        """Async :meth:`usage_overview`."""
+        return await asyncio.to_thread(self.usage_overview)
+
+    def usage_timeseries(self, bucket: str = "day") -> list:
+        """Cost/request trend over time — GET /v1/usage/timeseries.
+
+        ``bucket`` is ``"hour"``, ``"day"``, or ``"month"``. Returns a list of
+        ``{"date", "requests", "cost", "failures"}`` points (UTC, ascending).
+        """
+        if bucket not in ("hour", "day", "month"):
+            raise _invalid('bucket must be "hour", "day", or "month"')
+        return self._usage_get(f"timeseries?bucket={bucket}")
+
+    async def ausage_timeseries(self, bucket: str = "day") -> list:
+        """Async :meth:`usage_timeseries`."""
+        return await asyncio.to_thread(self.usage_timeseries, bucket)
+
+    def usage_by_model(self) -> list:
+        """Spend + usage broken down by model — GET /v1/usage/by-model.
+
+        Returns a list of ``{"key": <model id>, "requests", "cost",
+        "avgLatency", "failures"}`` rows within this token's scope.
+        """
+        return self._usage_get("by-model")
+
+    async def ausage_by_model(self) -> list:
+        """Async :meth:`usage_by_model`."""
+        return await asyncio.to_thread(self.usage_by_model)
+
+    def usage_scope(self) -> dict:
+        """The scope this read token may see — GET /v1/usage/scope.
+
+        Returns ``{"application": ..., "userId": ...}``.
+        """
+        return self._usage_get("scope")
+
+    async def ausage_scope(self) -> dict:
+        """Async :meth:`usage_scope`."""
+        return await asyncio.to_thread(self.usage_scope)
+
 
 def create_client(
     base_url: Optional[str] = None,
@@ -530,11 +612,13 @@ def create_client(
     department: Optional[str] = None,
     user_id: Optional[str] = None,
     api_key: Optional[str] = None,
+    read_token: Optional[str] = None,
     timeout_s: float = 60.0,
     retries: int = 2,
 ) -> Client:
     """Create a gateway client. ``base_url`` falls back to $ARBR_GATEWAY_URL,
-    ``api_key`` to $ARBR_API_KEY."""
+    ``api_key`` to $ARBR_API_KEY, ``read_token`` to $ARBR_READ_TOKEN (for the
+    read-only usage analytics API)."""
     return Client(
         base_url=base_url,
         application=application,
@@ -542,6 +626,7 @@ def create_client(
         department=department,
         user_id=user_id,
         api_key=api_key,
+        read_token=read_token,
         timeout_s=timeout_s,
         retries=retries,
     )

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -326,3 +326,64 @@ def test_chat_usage_cache_fields_absent(gateway):
     res = karya.chat(messages=[{"role": "user", "content": "hi"}])
     assert res.usage.cached_read_tokens == 0
     assert res.usage.cache_write_tokens == 0
+
+
+# ── v0.6.0: finish_reason / warning pass-through ─────────────────────────────
+
+def test_chat_surfaces_finish_reason_and_warning(gateway):
+    gw = gateway(lambda m, p, b, n: (
+        200,
+        {**OK_RESPONSE, "finishReason": "length", "warning": "Output truncated by max_tokens."},
+        0,
+    ))
+    res = create_client(gw.base_url).chat("hi")
+    assert res.finish_reason == "length"
+    assert res.warning == "Output truncated by max_tokens."
+
+
+def test_chat_finish_reason_defaults_to_none(gateway):
+    gw = gateway()  # OK_RESPONSE has no finishReason
+    res = create_client(gw.base_url).chat("hi")
+    assert res.finish_reason is None
+    assert res.warning is None
+
+
+# ── v0.6.0: usage analytics (read token) ─────────────────────────────────────
+
+def test_usage_overview_uses_read_token(gateway):
+    gw = gateway(lambda m, p, b, n: (200, {"totalRequests": 42, "totalCost": 1.23}, 0))
+    client = create_client(gw.base_url, api_key="ab_gateway", read_token="ab_read_xyz")
+    out = client.usage_overview()
+    assert out["totalRequests"] == 42
+    sent = gw.seen[-1]
+    assert sent["method"] == "GET"
+    assert sent["path"] == "/v1/usage/overview"
+    assert sent["auth"] == "Bearer ab_read_xyz"  # read token, not the gateway key
+
+
+def test_usage_timeseries_forwards_bucket(gateway):
+    gw = gateway(lambda m, p, b, n: (200, [], 0))
+    client = create_client(gw.base_url, read_token="ab_read_xyz")
+    client.usage_timeseries("month")
+    assert gw.seen[-1]["path"] == "/v1/usage/timeseries?bucket=month"
+
+
+def test_usage_timeseries_rejects_bad_bucket(gateway):
+    client = create_client(gateway().base_url, read_token="ab_read_xyz")
+    with pytest.raises(GatewayError):
+        client.usage_timeseries("year")
+
+
+def test_usage_by_model_and_scope_endpoints(gateway):
+    gw = gateway(lambda m, p, b, n: (200, {}, 0))
+    client = create_client(gw.base_url, read_token="ab_read_xyz")
+    client.usage_by_model()
+    assert gw.seen[-1]["path"] == "/v1/usage/by-model"
+    client.usage_scope()
+    assert gw.seen[-1]["path"] == "/v1/usage/scope"
+
+
+def test_usage_without_read_token_raises(gateway):
+    client = create_client(gateway().base_url, api_key="ab_gateway")  # no read_token
+    with pytest.raises(GatewayError, match="read token"):
+        client.usage_overview()


### PR DESCRIPTION
Freshens both official clients for launch. **arbr-client** JS + Python bumped **0.5.0 → 0.6.0**.

## 1. Usage analytics API (new)

Query cost / requests / tokens programmatically — the same numbers the dashboard shows — authenticated by a **read token** (an API key of `kind: "read"`, created in the console), *not* the gateway key. A read token is scoped to one application (+ optional user) and **cannot run inference**, so it's safe to embed in a partner app or a per-tenant dashboard. Wraps the existing `/v1/usage/*` surface that had no client.

| JS | Python (async: `a`-prefix) | Endpoint |
|---|---|---|
| `client.usage.overview()` | `usage_overview()` | `GET /v1/usage/overview` |
| `client.usage.timeseries(bucket)` | `usage_timeseries(bucket)` | `GET /v1/usage/timeseries` |
| `client.usage.byModel()` | `usage_by_model()` | `GET /v1/usage/by-model` |
| `client.usage.scope()` | `usage_scope()` | `GET /v1/usage/scope` |

Configure via `createClient({ readToken })` / `create_client(read_token=…)` or `ARBR_READ_TOKEN`. Calling any usage method without a read token rejects/raises a `GatewayError` explaining how to mint one.

## 2. `finishReason` / `warning` on chat responses (new)

The gateway already returns `finishReason` (`"stop" | "length" | "tool_calls" | "content_filter"`) and an optional `warning`, but the SDKs dropped them (JS surfaced them at runtime but not in the TS types; Python's dataclass picked fields and omitted them). Now surfaced so callers can tell a deliberately short answer from one truncated by `max_tokens` — e.g. a reasoning model that spent its whole budget thinking and returned no text.

## Also

- **API consistency fix**: `usage.*` returns a rejected promise (not a sync throw) when no read token is set, matching every other client method.
- **TypeScript**: `FinishReason`, `UsageOverview/TimeseriesPoint/ModelRow/Scope/Api/Bucket`; `ChatResponse` gains `finishReason`/`warning`; `ClientOptions` gains `readToken`; `Client` gains `usage`.
- READMEs + CHANGELOGs updated; both dated 0.6.0 (2026-08-15).

## Tests
- JS **25/25** (added finishReason pass-through + 4 usage tests).
- Python **30/30** (added finish_reason parse + default-None + 5 usage tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)