### PR TITLE
docs: fix VitePress docs:build dead-link on .jsx source links

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -4,7 +4,13 @@ export default defineConfig({
   title: 'Arbr',
   description: 'Self-hosted model optimisation and governance — discover, evaluate, approve, and verify better LLM routes.',
 
-  ignoreDeadLinks: [/localhost/],
+  // `/localhost/` — example URLs in the docs.
+  // `/\.jsx$/` — inline links to source files (e.g. web/src/components/*.jsx in
+  // routing-spec.md). VitePress skips links to files with known code extensions
+  // (.js/.ts) but not .jsx, so it wrongly reports those as dead. These are
+  // pointers to code on GitHub, not built doc pages, so treat them like the .js
+  // siblings and skip the check.
+  ignoreDeadLinks: [/localhost/, /\.jsx$/],
 
   // Internal-only — not linked from the sidebar, and excluded here so it's
   // genuinely file-only: not built, not in the local search index, not


### PR DESCRIPTION
## What does this PR do?

`npm run docs:build` currently **fails** (exit 1):

```
(!) Found dead link ./../web/src/components/RequestsTable.jsx in file routing-spec.md
✗ Build failed in ...
[vitepress] 1 dead link(s) found.
```

The link target (`web/src/components/RequestsTable.jsx`) exists on disk. VitePress skips dead-link checks for links to files with known code extensions (`.js`/`.ts`) but **not** `.jsx`, so it treats that source-file pointer as a dead page link and fails the build. The four sibling `../server/*.js` links in the same file (`docs/routing-spec.md`) are skipped for exactly this reason, which is why only the one `.jsx` link trips.

This is a later regression: PR #172 recorded a clean `docs:build` at merge time; the `.jsx` link was introduced afterward.

Fix: add `/\.jsx$/` to `ignoreDeadLinks` in `docs/.vitepress/config.mjs` so `.jsx` source-file references are treated like their `.js` siblings.

Verified locally: `npm run docs:build` now completes with `build complete` (exit 0). (The unrelated cosmetic `The language 'env' is not loaded` warnings are non-fatal and left as-is.)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] CI / build

## Checklist

- [x] Verified `npm run docs:build` passes locally
- [x] No API keys, `.env` values, or secrets are committed
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Docs-only, config change

---
_Generated by [Claude Code](https://claude.ai/code/session_01CerHwK1GStg6a3Z6nA1cYb)_