### PR TITLE
docs(architecture): correct internal-LLM-call list and handler line ref

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -62,7 +62,7 @@ verified against the code, not approximated:
 4. **Enforce budget** — `routing/capEngine.js` runs *after* routing, against the model
    routing just decided on. A breached enforcing cap outranks everything decided in step
    3, **including an explicit pin** — that's the point of enforcement (per the code's own
-   comment at `gateway/handler.js:382-384`): block returns 429; downgrade forces the
+   comment at `gateway/handler.js:491-493`): block returns 429; downgrade forces the
    provider's light-tier model regardless of how the served model was originally chosen.
 5. **Output-side clamp, then cache** — `pricing.clampMaxTokens` caps output to the *served*
    model's known ceiling, then the exact-match response cache
@@ -117,7 +117,7 @@ server/src/
                         integration — resolves a `gcp-sm://...` reference transparently;
                         one new file per additional cloud (AWS/Azure documented, not built)
   internal/complete.js   the one call site for every LLM call Arbr makes for itself
-                        (classification, policy generation, judging) — tagged and excluded
+                        (classification, judging, connection/model tests) — tagged and excluded
                         from customer-facing analytics
   health/readiness.js   pure GET /health/ready decision logic (shutting-down / Mongo state)
   telemetry/        OpenTelemetry: otel.js (OTLP export) · attributes.js (span shape,
@@ -192,8 +192,8 @@ traffic.
   `OTEL_ENABLED` (which would also flip `@langchain/core` into LangSmith-OTel mode).
 
 - **Arbr's own AI spend is counted but never attributed to a customer.** Arbr makes LLM
-  calls for itself (task classification on the routing path, AI policy generation, eval
-  judging, connection/model tests). Those are real money on the customer's provider key,
+  calls for itself (task classification on the routing path, eval judging,
+  connection/model tests). Those are real money on the customer's provider key,
   so they are stamped with `RequestRecord.internalKind` and **included in headline
   `totalCost`** — a cost dashboard that hid them would understate the actual provider bill.
   They are **excluded** from every per-application/workflow/user dimension view, from


### PR DESCRIPTION
## What does this PR do?

Fixes two factual drifts in `ARCHITECTURE.md` against current `server/src/`:

**1. "Policy generation" wrongly listed as an internal LLM call.**
Two places named policy generation among the calls routed through `internal/complete.js`:
- module map (`ARCHITECTURE.md:120`): `(classification, policy generation, judging)`
- internal-spend note (`ARCHITECTURE.md:195`): `AI policy generation`

The AI routing policy is a **deterministic scoring engine** now — `server/src/routing/aiPolicy.js` is `CAPABILITY_VERSION 4` ("deterministic evidence-based engine (capability gates + traffic-informed expected cost)") and makes **no LLM call**; it does not import `internal/complete`. The actual `internalComplete` callers are: `classify/classifier.js`, `api/routes/models.js`, `api/routes/connections.js`, and the eval judges (`judge.js`/`rubricJudge.js`/`replay.js`/`shadow.js`) — i.e. classification, eval judging, and connection/model tests. Removed "policy generation" from both lists (kept the accurate members).

**2. Stale line reference for the budget-enforcement comment.**
`ARCHITECTURE.md:65` cited `gateway/handler.js:382-384`. The "block → 429; downgrade → force the provider's light model" comment now lives at `handler.js:491-493` (shifted by later per-tenant refactors). Line 382-384 is now an unrelated function's return. Updated to `:491-493`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] CI / build

## Checklist

- [x] Verified each claim against current `server/src` (grep of `internal/complete` importers; `handler.js:491-493`)
- [x] No API keys, `.env` values, or secrets are committed
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Docs-only change

---
_Generated by [Claude Code](https://claude.ai/code/session_01CerHwK1GStg6a3Z6nA1cYb)_