### PR TITLE
docs(contributing): align stated Node version with package.json engines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ for the full workflow. This document covers repo-specific setup.
 ## Local development
 
 ```bash
-# Prerequisites: Node 20+, MongoDB running locally (or Docker)
+# Prerequisites: Node 18.19+ (or 20.6+), MongoDB running locally (or Docker)
 git clone https://github.com/project-arbr/arbr-control-plane.git
 cd arbr-control-plane
 cp .env.example .env          # fill in at minimum ARBR_ADMIN_KEY and MONGO_URI


### PR DESCRIPTION
## What does this PR do?

`CONTRIBUTING.md` lists the prerequisite as **"Node 20+"**, but that contradicts the actual supported range:
- `package.json` `engines`: `"node": "^18.19.0 || >=20.6.0"`
- `README.md`: states Node **≥18**

The "Node 20+" claim would wrongly turn away contributors running Node 18.19+, which is supported and tested. Align the CONTRIBUTING prerequisite to the `engines` range: **Node 18.19+ (or 20.6+)**.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] CI / build

## Checklist

- [x] Cross-checked against `package.json` `engines` and `README.md`
- [x] No API keys, `.env` values, or secrets are committed
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Docs-only change

---
_Generated by [Claude Code](https://claude.ai/code/session_01CerHwK1GStg6a3Z6nA1cYb)_