### PR TITLE
feature: add page level error boundary

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
-import { Routes, Route, Navigate } from "react-router-dom";
+import { Routes, Route, Navigate, useLocation } from "react-router-dom";
 import Layout from "./components/Layout.jsx";
+import ErrorBoundary from "./components/ErrorBoundary.jsx";
 import { api, clearAdminToken, resetCsrfToken, loadCurrency } from "./api.js";
 import Login from "./pages/Login.jsx";
 import Overview from "./pages/Overview.jsx";
@@ -21,6 +22,7 @@ import Users from "./pages/Users.jsx";
 import Account from "./pages/Account.jsx";
 
 export default function App() {
+  const location = useLocation();
   const [status, setStatus] = useState(null);
   // null = probing, "open" = no auth needed / authed, "login" = needs to sign in
   const [authState, setAuthState] = useState(null);
@@ -71,30 +73,32 @@ export default function App() {
 
   return (
     <Layout status={status} user={user} onSignOut={signOut}>
-      <Routes>
-        <Route path="/" element={<Overview />} />
-        <Route path="/applications" element={<Applications />} />
-        <Route path="/applications/:name" element={<ApplicationDetail />} />
-        <Route path="/requests" element={<Requests />} />
-        <Route path="/internal-spend" element={<InternalSpend />} />
-        <Route path="/routing" element={<Routing onChange={refreshStatus} />} />
-        <Route path="/recommendations" element={<Recommendations />} />
-        <Route path="/budgets" element={<Budgets onChange={refreshStatus} />} />
-        <Route path="/models" element={<Models />} />
-        <Route path="/evals" element={<ModelEvals />} />
-        <Route path="/settings" element={<Settings onChange={refreshStatus} />} />
-        <Route path="/governance" element={<Governance />} />
-        <Route path="/audit" element={<Audit />} />
-        <Route path="/users" element={<Users />} />
-        {/* Hosted-only: the tenant plan/billing page. In OSS (no accountUrl) the route isn't even
-            registered, so /account never mounts the component or hits the (absent) data endpoint. */}
-        {status?.accountUrl && <Route path="/account" element={<Account />} />}
-        <Route path="/docs" element={<Docs />} />
+      <ErrorBoundary key={location.pathname + location.search}>
+        <Routes>
+          <Route path="/" element={<Overview />} />
+          <Route path="/applications" element={<Applications />} />
+          <Route path="/applications/:name" element={<ApplicationDetail />} />
+          <Route path="/requests" element={<Requests />} />
+          <Route path="/internal-spend" element={<InternalSpend />} />
+          <Route path="/routing" element={<Routing onChange={refreshStatus} />} />
+          <Route path="/recommendations" element={<Recommendations />} />
+          <Route path="/budgets" element={<Budgets onChange={refreshStatus} />} />
+          <Route path="/models" element={<Models />} />
+          <Route path="/evals" element={<ModelEvals />} />
+          <Route path="/settings" element={<Settings onChange={refreshStatus} />} />
+          <Route path="/governance" element={<Governance />} />
+          <Route path="/audit" element={<Audit />} />
+          <Route path="/users" element={<Users />} />
+          {/* Hosted-only: the tenant plan/billing page. In OSS (no accountUrl) the route isn't even
+              registered, so /account never mounts the component or hits the (absent) data endpoint. */}
+          {status?.accountUrl && <Route path="/account" element={<Account />} />}
+          <Route path="/docs" element={<Docs />} />
 
-        {/* Redirects for old / deep links. */}
-        <Route path="/rules" element={<Navigate to="/routing" replace />} />
-        <Route path="/views" element={<Navigate to="/?tab=dimensions" replace />} />
-      </Routes>
+          {/* Redirects for old / deep links. */}
+          <Route path="/rules" element={<Navigate to="/routing" replace />} />
+          <Route path="/views" element={<Navigate to="/?tab=dimensions" replace />} />
+        </Routes>
+      </ErrorBoundary>
     </Layout>
   );
 }

--- a/web/src/components/ErrorBoundary.jsx
+++ b/web/src/components/ErrorBoundary.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error("ErrorBoundary caught an error:", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex h-full flex-col items-center justify-center p-8 text-center">
+          <div className="mb-4 text-4xl">⚠️</div>
+          <h2 className="mb-2 text-xl font-semibold text-gray-900">
+            Something went wrong on this page
+          </h2>
+          <p className="mb-6 text-sm text-gray-500">
+            The application encountered an unexpected error while rendering.
+          </p>
+          <Link
+            to="/"
+            onClick={() => this.setState({ hasError: false })}
+            className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-800"
+          >
+            Return to Overview
+          </Link>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Added an ErrorBoundary around the dashboard routes so a page crash doesn't make the whole dashboard go blank.

It shows a simple error message with a way to go back to Overview.

Also resets the boundary when navigating between routes, including browser back/forward.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / build