### PR TITLE
Fix error-boundary reset scope + design tokens (follow-up to #302)

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -73,7 +73,10 @@ export default function App() {
 
   return (
     <Layout status={status} user={user} onSignOut={signOut}>
-      <ErrorBoundary key={location.pathname + location.search}>
+      {/* Key on pathname only: reset the boundary when navigating to a different page, but NOT on
+          query-string changes (?tab=…, filters), which would otherwise remount the whole routed
+          subtree on every tab switch and drop in-page state (form edits, evidence panels, etc). */}
+      <ErrorBoundary key={location.pathname}>
         <Routes>
           <Route path="/" element={<Overview />} />
           <Route path="/applications" element={<Applications />} />

--- a/web/src/components/ErrorBoundary.jsx
+++ b/web/src/components/ErrorBoundary.jsx
@@ -20,7 +20,7 @@ export default class ErrorBoundary extends React.Component {
       return (
         <div className="flex h-full flex-col items-center justify-center p-8 text-center">
           <div className="mb-4 text-4xl">⚠️</div>
-          <h2 className="mb-2 text-xl font-semibold text-gray-900">
+          <h2 className="mb-2 text-xl font-semibold text-arbr-charcoal">
             Something went wrong on this page
           </h2>
           <p className="mb-6 text-sm text-gray-500">
@@ -29,7 +29,7 @@ export default class ErrorBoundary extends React.Component {
           <Link
             to="/"
             onClick={() => this.setState({ hasError: false })}
-            className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-800"
+            className="btn-secondary"
           >
             Return to Overview
           </Link>


### PR DESCRIPTION
Follow-up to #302 (page-level error boundary by @rayulumukku), addressing the review. Branched from #302, so **once #302 merges this PR's diff collapses to just these two changes** (or merge this and close #302 — #302's author is credited via `Co-authored-by`).

## 1. Reset the boundary on `pathname` only (correctness)

#302 keyed the boundary on `location.pathname + location.search`. Changing a component's `key` remounts its **entire subtree**, so any query-string change remounts all of `<Routes>`. The app drives tabs via `?tab=` (`useTabParam`) across **Routing, ApplicationDetail, Settings, Overview, Governance, Account** — so every tab switch would remount the page: dropping in-page component state (form edits, the "View reasoning" evidence panel, expanded sections) and refetching with a flicker.

Keying on `pathname` only still resets the boundary on real page navigation and browser back/forward across pages, without nuking in-page tab/filter state.

## 2. Use the app's design tokens (consistency)

The fallback used raw `gray-900`/`gray-800`. Swapped to `text-arbr-charcoal` and the shared `.btn-secondary` class so the error screen matches the rest of the console.

## Notes
- `web` builds clean (verified locally).
- The boundary itself (from #302) is a solid, useful addition — the console had none, so a render crash previously blanked the whole dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)