### PR TITLE
chore: add py.typed to support downstream type checkers

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -42,3 +42,7 @@ where = ["src"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
+
+[tool.setuptools.package-data]
+"arbr_client" = ["py.typed"]
+


### PR DESCRIPTION
Closes #278 

## Pull request checklist

- [ ] Changes are scoped to one concern
- [ ] `npm run dev` works end-to-end with your change
- [ ] No API keys, `.env` values, or secrets committed
- [ ] Commit messages follow Conventional Commits format
- [ ] PR description explains *why*, not just *what*

## Description
This pull request adds PEP 561 compliance to the Python SDK package.

### Why
Without a `py.typed` marker file included in the distributed package bundle, modern downstream type-checkers (like `mypy`, `pyright`) ignore inline type annotations present in this library.

###What
- Created an empty `py.typed` marker file inside `src/arbr_client/`.
- Configured `[tool.setuptools.package-data]` in `pyproject.toml` to explicitly ensure the marker file is bundled during distribution generation.
- Verified compilation locally via `python -m build` to guarantee file presence inside the generated `.whl` and `.tar.gz` build targets. 