### PR TITLE
Python SDK: release 0.6.1 (py.typed / PEP 561)

### DIFF
--- a/clients/python/CHANGELOG.md
+++ b/clients/python/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.1 (2026-08-17)
+
+- **Typing**: ship a `py.typed` marker (PEP 561) so downstream type checkers (mypy, pyright) honor the SDK's inline type hints in consuming projects. Packaging-only — no API changes. Thanks to @govardhanreddyg2005-byte (#304).
+
 ## 0.6.0 (2026-08-15)
 
 - **Usage analytics** — read-only, authenticated by a **read token** (an API key of kind `read`, created in the console under Settings → API keys), not the gateway key. A read token is scoped to one application (+ optional user) and cannot run inference, so it's safe to embed in a partner app or per-tenant dashboard. Configure with `create_client(read_token=...)` or `$ARBR_READ_TOKEN`.

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "arbr-client"
-version = "0.6.0"
+version = "0.6.1"
 description = "Official Python client for the Arbr AI control-plane gateway — one function to route, observe, and govern every LLM call."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump + CHANGELOG for the `py.typed` marker merged in #304 (thanks @govardhanreddyg2005-byte).

- `pyproject.toml`: `0.6.0` → `0.6.1`
- `CHANGELOG.md`: 0.6.1 entry (packaging-only, no API change)

**Already published to PyPI:** https://pypi.org/project/arbr-client/0.6.1/ (built from this bump; verified `arbr_client/py.typed` ships in the wheel + sdist, `twine check` passed). This PR just records the version bump in the repo so it matches PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)