### PR TITLE
docs(routing): correct AI-policy generation (deterministic engine, not an LLM)

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -124,16 +124,16 @@ Every `RequestRecord` includes a `routingExplain` object that captures the non-d
 
 ## AI routing policy
 
-When AI routing mode is on, Arbr uses an AI-generated `{taskType → model}` map. To regenerate it:
+When AI routing mode is on, Arbr routes each request through a `{taskType → model}` map. To regenerate it:
 
 1. Go to **Settings → Routing → AI routing policy**
-2. Click **Regenerate** — uses the default model to produce the map
-3. Review and edit the map
+2. Click **Regenerate** — a **deterministic evidence-based engine** builds the map: for each task type it gates candidate models on capability, then scores them on quality against expected cost (from your live traffic) relative to the active goal's quality bar. No LLM chooses the assignments, so regeneration is reproducible and explainable, with deterministic tie-breaks.
+3. Review the per-task evidence and edit any pick
 4. Enable AI routing mode to activate it
 
-::: warning Gemini thinking models
-`gemini-2.5-flash` with thinking mode can fail JSON generation. Use `gpt-4o-mini` or another model as your default when generating the AI routing policy.
-:::
+Only the policy *generation* is deterministic — per-request task **classification** still uses the AI classifier when AI routing mode is on (see [Task classification](#task-classification) above).
+
+For a full walk-through of the engine — the classifier, capability gating, how benchmarks become model capabilities, and where cost enters the decision — see [How Arbr generates and applies an AI routing policy](ai-routing.md).
 
 ## The developer's pin in practice
 


### PR DESCRIPTION
## What does this PR do?

Corrects the **AI routing policy** section of `docs/routing.md`, which still described the pre-#290 LLM-based policy generation. The generator became a deterministic evidence-based engine in #290:

- `server/src/routing/aiPolicy.js:14` — "v3: deterministic evidence-based engine (capability gates + traffic-informed expected cost)."
- `server/src/routing/aiPolicy.js:307-311` — "The policy is DECIDED here, not by an LLM … The LLM no longer chooses; ties are broken deterministically."
- `server/src/routing/aiPolicy.js:456` — `generatorModel: "deterministic-scorer"`.

Two statements in the doc were stale against that code:

1. "Click **Regenerate** — uses the default model to produce the map" implied an LLM produces the map.
2. A `::: warning Gemini thinking models` block warning that a thinking model "can fail JSON generation … when generating the AI routing policy" — generation makes no LLM call, so the warning no longer applies.

The section now describes the deterministic capability-gate + expected-cost scoring, clarifies that only per-request task **classification** is AI (policy *generation* is deterministic), and links the existing `docs/ai-routing.md` deep-dive.

Linking `ai-routing.md` also fixes a small navigation gap: that page is built and in the local search index but was not reachable from the sidebar or any in-page link. This mirrors how `routing.md` already links `routing-spec.md`.

No code changes; `npm run docs:build` passes with no dead links.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] CI / build

## Checklist

- [x] `npm run docs:build` passes (no dead links; the new `ai-routing.md` link resolves)
- [x] No API keys, `.env` values, or secrets are committed
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Docs updated to match current user-facing behaviour

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDM3aiW7YvYLEQnDSQFwfG)_