### PR TITLE
docs(architecture): add missing server/src modules to the module map

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -84,6 +84,8 @@ server/src/
   index.js          boot: mongo → registry.init() → mount routes → listen; GET /health
                     (liveness) and GET /health/ready (readiness — see health/ below)
   config.js         env-driven config + demo-mode detection
+  db/               context.js — request-scoped Mongo context for in-process multi-tenancy
+  cloud/            entitlements.js — plan/feature entitlement gating (cloud tenancy)
   gateway/          /v1 request handling
     core.js           shared resolveRoute / fallback / headers (both entry points)
     handler.js        native /v1/chat + resolveRoute implementation
@@ -99,6 +101,7 @@ server/src/
                     canaryEngine / canaryMonitor (guarded rollout + auto-rollback) ·
                     semanticCache · errorAlertMonitor · notifier
   classify/         task-type classification (provided / keyword / AI)
+  analytics/        aggregate.js (spend/latency rollups) · savings.js (realised savings)
   recommend/        engine.js (opportunity detection) · stage.js / stageBatch.js (derived
                     lifecycle stage) · outcome.js (realised-vs-projected) ·
                     evidenceReport.js (exportable report)
@@ -120,10 +123,15 @@ server/src/
                         (classification, judging, connection/model tests) — tagged and excluded
                         from customer-facing analytics
   health/readiness.js   pure GET /health/ready decision logic (shutting-down / Mongo state)
+  logging/          logger.js (structured request logging) · piiFilter.js (PII masking)
   telemetry/        OpenTelemetry: otel.js (OTLP export) · attributes.js (span shape,
                     redaction) · runtime.js (dashboard-adjustable sample ratio / on-off) —
                     off by default, wired from the post-response log path (see below)
   maintenance/purge.js  retention purge of old request records
+  currency/         fx.js — live FX rates for display-currency conversion
+  embed/            usageChart.js — embeddable per-user usage iframe widget
+  seed/             seed.js (`npm run seed`) · promptPacks.js — demo/seed data
+  utils/            boundedTtlCache.js · csv.js — shared helpers
   api/routes.js     thin re-export of api/routes/* domain modules (master-key gated)
   api/routes/       status, caps, keys, recommendations, evals, analytics, ops
                     (config export/import, support bundle), …


### PR DESCRIPTION
## What does this PR do?

The "Where things live" module map in `ARCHITECTURE.md` had drifted from the actual `server/src/` tree. Eight real subdirectories — all of which predate the file's last edit (2026-08-16), so this is genuine drift rather than newer-than-doc — were absent from the map:

| Module | Contents | Purpose |
|---|---|---|
| `db/` | `context.js` | request-scoped Mongo context for in-process multi-tenancy |
| `cloud/` | `entitlements.js`, `index.js` | plan/feature entitlement gating (cloud tenancy) |
| `analytics/` | `aggregate.js`, `savings.js` | spend/latency rollups + realised savings |
| `logging/` | `logger.js`, `piiFilter.js` | structured request logging + PII masking |
| `currency/` | `fx.js` | live FX rates for display-currency conversion |
| `embed/` | `usageChart.js` | embeddable per-user usage iframe widget |
| `seed/` | `seed.js`, `promptPacks.js` | seed script + demo/seed data |
| `utils/` | `boundedTtlCache.js`, `csv.js` | shared helpers |

Each new entry matches the existing concise, aligned style of the map. No prose, diagrams, or other content changed — this is a documentation-accuracy fix only.

Found by an automated documentation-accuracy audit comparing `ARCHITECTURE.md` against the live `server/src/` layout.

## Type of change

- [x] Documentation

## Checklist

- [x] No API keys, `.env` values, or secrets are committed
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Docs-only change; each added module was verified to exist on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mdm6hZsmFVwV8VqCjUu1x7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mdm6hZsmFVwV8VqCjUu1x7)_