### PR TITLE
Multiple API keys per provider, selectable in routing

### DIFF
--- a/server/src/analytics/aggregate.js
+++ b/server/src/analytics/aggregate.js
@@ -20,7 +20,7 @@ function buildMatch(filter = {}) {
     if (filter.from) m.timestamp.$gte = new Date(filter.from);
     if (filter.to) m.timestamp.$lte = new Date(filter.to);
   }
-  for (const f of ["application", "workflow", "department", "model", "provider", "taskType", "userId", "status"]) {
+  for (const f of ["application", "workflow", "department", "model", "provider", "credentialAlias", "taskType", "userId", "status"]) {
     if (filter[f]) m[f] = filter[f];
   }
   if (filter.requestId) m.requestId = filter.requestId;

--- a/server/src/api/routes/appConfigs.js
+++ b/server/src/api/routes/appConfigs.js
@@ -7,13 +7,33 @@ const { toRouterConfig, getRouter } = require("../../providers/router");
 const Settings = require("../../models/Settings");
 const { config, KNOWN_PROVIDERS } = require("../../config");
 const { requireFeature } = require("../../cloud/entitlements");
+const { invalidateAppConfig } = require("../../gateway/handler");
 
 const router = express.Router();
 
 // ── Per-application config (kill switch, model opt-out, AI policy override) ──
 const ApplicationConfig = require("../../models/ApplicationConfig");
 
-const DEFAULT_APP_CONFIG = { killSwitchEnabled: false, killSwitchMessage: null, modelOptOut: [], aiPolicyAssignments: null };
+const DEFAULT_APP_CONFIG = { killSwitchEnabled: false, killSwitchMessage: null, modelOptOut: [], aiPolicyAssignments: null, credentialAliases: null };
+
+// { providerId: alias } for this application's provider keys.
+//
+// This value ends up in a $set on a Mixed field, so it is sanitized rather than trusted:
+// only known provider ids, only non-empty string aliases, and no key that could be read as
+// an operator or a dotted path. An empty result becomes null, which is what "inherit the
+// global default" means everywhere else in this document.
+function sanitizeCredentialAliases(raw) {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const out = {};
+  for (const [provider, alias] of Object.entries(raw)) {
+    if (!KNOWN_PROVIDERS.includes(provider)) continue;
+    if (provider.includes("$") || provider.includes(".")) continue;
+    const v = String(alias ?? "").trim().toLowerCase();
+    if (!v || !/^[a-z0-9][a-z0-9._-]{0,39}$/.test(v)) continue;
+    out[provider] = v;
+  }
+  return Object.keys(out).length ? out : null;
+}
 
 router.get("/app-configs", async (_req, res, next) => {
   try {
@@ -37,11 +57,15 @@ router.put("/app-configs/:app", requireRole("operator"), async (req, res, next) 
     if ("killSwitchMessage" in req.body) update.killSwitchMessage = killSwitchMessage ? String(killSwitchMessage).trim() : null;
     if (Array.isArray(modelOptOut)) update.modelOptOut = modelOptOut.filter(Boolean);
     if ("aiPolicyAssignments" in req.body) update.aiPolicyAssignments = aiPolicyAssignments || null;
+    if ("credentialAliases" in req.body) update.credentialAliases = sanitizeCredentialAliases(req.body.credentialAliases);
     const cfg = await ApplicationConfig.findOneAndUpdate(
       { applicationName: req.params.app },
       { $set: update },
       { new: true, upsert: true }
     ).lean();
+    // getAppConfig caches for 30s. Leaving a key change to expire on its own means up to
+    // half a minute of traffic still on the old key, which is too long for this control.
+    invalidateAppConfig(req.params.app);
     setImmediate(() => logAction("appConfig.update", "appConfig", req.params.app, update, req.user));
     res.json(cfg);
   } catch (e) { next(e); }

--- a/server/src/api/routes/connections.js
+++ b/server/src/api/routes/connections.js
@@ -7,6 +7,9 @@ const { toRouterConfig, getRouter } = require("../../providers/router");
 const { internalComplete } = require("../../internal/complete");
 const secretResolver = require("../../security/secretResolver");
 const { PROVIDERS } = require("../../config");
+const { logAction } = require("../auditLogger");
+const Rule = require("../../models/Rule");
+const ApplicationConfig = require("../../models/ApplicationConfig");
 
 const router = express.Router();
 
@@ -48,15 +51,92 @@ router.put("/default-model", requireRole("administrator"), async (req, res, next
   } catch (e) { res.status(400).json({ error: "bad_request", message: String(e.message || e) }); }
 });
 
-// Live "test" — make a tiny real call with the effective key for one provider.
+// ── individual provider keys (aliases) ──
+//
+// The four routes above are the pre-multi-key surface and keep their exact meaning:
+// PUT writes the alias "default", DELETE disconnects the provider entirely. These operate
+// on one key at a time.
+
+// Add or replace one named key. Body: { alias, makeDefault?, ...credential fields }.
+router.post("/connections/:provider/keys", requireRole("administrator"), async (req, res) => {
+  try {
+    const { alias, makeDefault, ...credential } = req.body || {};
+    // Required here, unlike setCredential's default. Silently falling back to "default"
+    // would let a request that forgot the name overwrite the provider's existing key.
+    if (alias == null || String(alias).trim() === "") {
+      return res.status(400).json({ error: "bad_request", message: "alias is required" });
+    }
+    await connections.setCredential(req.params.provider, credential, { alias, makeDefault: !!makeDefault });
+    setImmediate(() => logAction("connection.keyAdd", "providerCredential", req.params.provider,
+      { alias: String(alias || "").toLowerCase(), makeDefault: !!makeDefault }, req.user));
+    res.json(await connections.statuses());
+  } catch (e) { res.status(400).json({ error: "bad_request", message: String(e.message || e) }); }
+});
+
+router.put("/connections/:provider/keys/:alias", requireRole("administrator"), async (req, res) => {
+  try {
+    const { makeDefault, ...credential } = req.body || {};
+    await connections.setCredential(req.params.provider, credential,
+      { alias: req.params.alias, makeDefault: !!makeDefault });
+    setImmediate(() => logAction("connection.keyUpdate", "providerCredential", req.params.provider,
+      { alias: req.params.alias }, req.user));
+    res.json(await connections.statuses());
+  } catch (e) { res.status(400).json({ error: "bad_request", message: String(e.message || e) }); }
+});
+
+// Removing a key that a rule or an application still pins would silently redirect that
+// traffic to the default key. Refuse, name what is pinning it, and make the operator opt in.
+router.delete("/connections/:provider/keys/:alias", requireRole("administrator"), async (req, res, next) => {
+  try {
+    const { provider, alias } = req.params;
+    if (req.query.force !== "1") {
+      const [rules, apps] = await Promise.all([
+        Rule.find({ "target.provider": provider, "target.credentialAlias": alias }).lean(),
+        ApplicationConfig.find({ [`credentialAliases.${provider}`]: alias }).lean(),
+      ]);
+      if (rules.length || apps.length) {
+        return res.status(409).json({
+          error: "alias_in_use",
+          message:
+            `Key "${alias}" is pinned by ${rules.length} rule(s) and ${apps.length} application(s). ` +
+            "They will fall back to this provider's default key if you remove it.",
+          rules: rules.map((r) => ({ id: String(r._id), condition: r.condition, model: r.target?.model })),
+          applications: apps.map((a) => a.applicationName),
+        });
+      }
+    }
+    await connections.removeCredential(provider, alias);
+    setImmediate(() => logAction("connection.keyRemove", "providerCredential", provider,
+      { alias, forced: req.query.force === "1" }, req.user));
+    res.json(await connections.statuses());
+  } catch (e) { res.status(400).json({ error: "bad_request", message: String(e.message || e) }); }
+});
+
+// Promote a key to the provider's default. An env credential still outranks it, so the
+// response says which key is actually effective rather than implying the change took hold.
+router.put("/connections/:provider/keys/:alias/default", requireRole("administrator"), async (req, res) => {
+  try {
+    const out = await connections.setDefaultCredential(req.params.provider, req.params.alias);
+    setImmediate(() => logAction("connection.keySetDefault", "providerCredential", req.params.provider,
+      { alias: out.alias, effectiveDefault: out.effectiveDefault }, req.user));
+    res.json({ ...(await connections.statuses()), effectiveDefault: out.effectiveDefault });
+  } catch (e) { res.status(400).json({ error: "bad_request", message: String(e.message || e) }); }
+});
+
+// Live "test" — make a tiny real call with one provider's key. ?alias= tests a specific
+// key, so an operator can prove a key works BEFORE pinning traffic to it.
 router.post("/connections/:provider/test", requireRole("administrator"), async (req, res) => {
   try {
     const provider = req.params.provider;
     const eff = await connections.effective();
     const p = eff.providers[provider];
     if (!p) return res.status(400).json({ ok: false, message: "provider not configured" });
+    const resolved = connections.credentialFor(eff, provider, req.query.alias || null);
+    if (req.query.alias && resolved.fellBack) {
+      return res.json({ ok: false, message: `no key "${req.query.alias}" for provider "${provider}"` });
+    }
     const r = createRouter({
-      providers: { [provider]: toRouterConfig(provider, p) },
+      providers: { [provider]: toRouterConfig(provider, { ...p, credential: resolved.credential }) },
       defaultProvider: provider,
     });
     // Generous budget so "thinking" models (e.g. Gemini 2.5) have room to answer.

--- a/server/src/api/routes/requests.js
+++ b/server/src/api/routes/requests.js
@@ -27,7 +27,7 @@ router.get("/requests/export", async (req, res, next) => {
     const match = analytics.buildMatch(req.query);
     const COLS = [
       "timestamp", "requestId", "application", "workflow", "department", "userId",
-      "taskType", "model", "modelRequested", "provider", "routingDecision", "classifiedBy",
+      "taskType", "model", "modelRequested", "provider", "credentialAlias", "routingDecision", "classifiedBy",
       "promptTokens", "completionTokens", "totalTokens", "totalCost",
       "latencyMs", "status", "cacheHit", "difficulty", "difficultyScore",
     ];

--- a/server/src/api/routes/rules.js
+++ b/server/src/api/routes/rules.js
@@ -23,8 +23,20 @@ async function withHealth(rules) {
     health: ruleEngine.ruleTargetHealth(r.target, {
       liveIds: eff.liveIds,
       modelEntry: pricing.getModel(r.target?.model),
+      aliases: Object.keys(eff.providers[r.target?.provider]?.credentials || {}),
     }),
   }));
+}
+
+// Normalize target.credentialAlias. An alias that no provider has is NOT rejected — the
+// rule still routes, on the provider's default key, and withHealth() flags it. Rejecting
+// here would make deleting a key retroactively invalidate rules that reference it.
+function normalizeTargetAlias(target) {
+  const raw = target?.credentialAlias;
+  if (raw == null || String(raw).trim() === "") return null;
+  const alias = String(raw).trim().toLowerCase();
+  if (alias === connections.ENV_ALIAS) return alias; // reserved, but a legitimate pin
+  return /^[a-z0-9][a-z0-9._-]{0,39}$/.test(alias) ? alias : null;
 }
 
 // ── rules ──
@@ -44,7 +56,15 @@ router.post("/rules", requireRole("operator"), async (req, res, next) => {
         application: condition.application || null,
         workflow: condition.workflow || null,
       },
-      target, enabled: !!enabled, note,
+      // Build the target explicitly. Passing the client's object straight through used to
+      // be safe only because Mongoose strict dropped anything unknown; credentialAlias is
+      // now a real field, so an unvalidated value would be persisted verbatim.
+      target: {
+        provider: target.provider,
+        model: target.model,
+        credentialAlias: normalizeTargetAlias(target),
+      },
+      enabled: !!enabled, note,
       priority: Number.isFinite(+priority) ? Math.trunc(+priority) : 0,
       qualityGate: "ungated", // manual rules have no eval proof
     });
@@ -61,6 +81,11 @@ router.patch("/rules/:id", requireRole("operator"), async (req, res, next) => {
     if (typeof req.body.enabled === "boolean") update.enabled = req.body.enabled;
     if (req.body.note != null) update.note = req.body.note;
     if (req.body.priority != null && Number.isFinite(+req.body.priority)) update.priority = Math.trunc(+req.body.priority);
+    // The only editable part of a target: which key it uses. Provider and model stay
+    // immutable (delete and recreate), so this does not reopen that decision.
+    if ("credentialAlias" in (req.body.target || {})) {
+      update["target.credentialAlias"] = normalizeTargetAlias(req.body.target);
+    }
     const rule = await Rule.findByIdAndUpdate(req.params.id, update, { new: true });
     if (!rule) return res.status(404).json({ error: "not found" });
     ruleEngine.invalidate();

--- a/server/src/gateway/core.js
+++ b/server/src/gateway/core.js
@@ -9,6 +9,7 @@ const {
   invokeWithFallback,
   buildFallbackOrder,
   getAppConfig,
+  applyCredentialAlias,
 } = require("./handler");
 
 // Standard gateway tracing headers (set before JSON or SSE responses).
@@ -25,5 +26,6 @@ module.exports = {
   invokeWithFallback,
   buildFallbackOrder,
   getAppConfig,
+  applyCredentialAlias,
   setGatewayHeaders,
 };

--- a/server/src/gateway/embeddings.js
+++ b/server/src/gateway/embeddings.js
@@ -171,7 +171,10 @@ async function handleEmbeddings(req, res) {
     });
   }
 
-  const cred      = eff.providers[provider].credential;
+  // The provider's default key. This endpoint infers its provider from the model-id prefix
+  // rather than running resolveRoute, so there is no rule or application pin to honor here
+  // — a per-application embedding key would need the pin resolved from req.apiKey.application.
+  const cred      = connections.credentialFor(eff, provider, null).credential;
   const _llmStart = Date.now();
   let embeddings, promptTokens;
 

--- a/server/src/gateway/handler.js
+++ b/server/src/gateway/handler.js
@@ -7,7 +7,8 @@
 //      → the router decides: cache → rules → automated routing → default
 //   + fallback to another live provider on a provider error.
 const { v4: uuidv4 } = require("uuid");
-const { getRouter } = require("../providers/router");
+const { getRouter, credentialOverrideFor } = require("../providers/router");
+const { credentialFor } = require("../providers/connections");
 const { config } = require("../config");
 const pricing = require("../pricing/registry");
 const { classifyTask } = require("../classify/classifier");
@@ -56,6 +57,22 @@ async function getAppConfig(appName) {
   // map is bounded, doing so no longer trades a DB problem for a memory one.
   _appConfigCache.set(key, cfg);
   return cfg;
+}
+
+// Drop one application's cached config so an admin edit takes effect on the next request
+// instead of up to 30s later. Scoped to the current connection's database, matching how
+// getAppConfig builds its key.
+function invalidateAppConfig(appName) {
+  if (!appName) return;
+  _appConfigCache.delete(`${currentConnection().name}:${String(appName)}`);
+}
+
+// The key actually exercised by an invocation. invokeWithFallback can end up on a DIFFERENT
+// provider than the one routing chose, and the pinned key belongs to the original provider
+// only — a fallback ran on the new provider's default key. Attributing the pinned alias to
+// it would put spend against a key that never served the request.
+function servedAlias(served, resultProviderId) {
+  return resultProviderId === served.provider ? (served.credentialAlias || null) : null;
 }
 
 // Interpret the client's model field. Returns one of:
@@ -138,7 +155,7 @@ function buildFallbackOrder(provider, model, liveIds, defaultModels, scope = "sa
 // can never serve a model the app is restricted from, a text model for an image
 // request, or an unpriced model. The primary (index 0) is kept as-is — it was already
 // validated by resolveRoute.
-async function invokeWithFallback(router, eff, { provider, model, messages, temperature, maxTokens }, governance = null) {
+async function invokeWithFallback(router, eff, { provider, model, messages, temperature, maxTokens, credentialAlias }, governance = null) {
   const full = buildFallbackOrder(
     provider,
     model,
@@ -149,6 +166,9 @@ async function invokeWithFallback(router, eff, { provider, model, messages, temp
   const order = governance
     ? [full[0], ...full.slice(1).filter((c) => checkModel(c.model, { ...governance, requirePriced: true }).ok)]
     : full;
+  // A pinned key was chosen for THIS provider. buildFallbackOrder can cross providers, so
+  // the override is computed per candidate and comes back null for anything but the pinned
+  // provider — belt and braces with the same guard inside router.complete().
   let lastErr;
   for (let i = 0; i < order.length; i++) {
     const { provider: p, model: m } = order[i];
@@ -159,6 +179,7 @@ async function invokeWithFallback(router, eff, { provider, model, messages, temp
         modelOverride: m,
         temperature,
         maxTokens,
+        credentialOverride: p === provider ? credentialOverrideFor(eff, p, credentialAlias) : null,
       });
       return { result, usedFallback: i > 0 };
     } catch (err) {
@@ -236,6 +257,9 @@ async function resolveRoute(body, { router, eff, application, workflow, userId =
   const explain = { basis: null, classificationUsed: false };
 
   let served, routingDecision;
+  // A key pinned by the matched rule, and the provider it was pinned for. Resolved at the
+  // very end, once every override has had its say about which provider actually serves.
+  let ruleCredentialAlias = null, ruleProvider = null;
   if (explicit) {
     served = explicit;
     routingDecision = "explicit";
@@ -256,6 +280,10 @@ async function resolveRoute(body, { router, eff, application, workflow, userId =
     const route = await ruleEngine.findRoute({ taskType, application, workflow, eff });
     if (route) {
       served = { provider: route.provider, model: route.model };
+      // Remembered, not applied yet. A later override (canary, opt-out, budget) can move
+      // us to a different provider, and this key belongs to route.provider alone.
+      ruleCredentialAlias = route.credentialAlias || null;
+      ruleProvider = route.provider;
       routingDecision = "rule";
       explain.basis = "rule";
       explain.rule = {
@@ -378,10 +406,44 @@ async function resolveRoute(body, { router, eff, application, workflow, userId =
     qualityGate = "passed"; // canaries require a passed offline eval before activation
   }
 
+  // Credential pin, resolved LAST — canary, allowed-models and opt-out above can all move
+  // `served` to a different provider, and a key is only meaningful for the provider that
+  // actually ends up serving. Rule beats application; neither can outrank an explicit pin,
+  // which never consulted a rule in the first place.
+  applyCredentialAlias(served, {
+    eff, explain,
+    rulePin: (routingDecision === "rule" && served.provider === ruleProvider) ? ruleCredentialAlias : null,
+    appDbConfig,
+  });
+
   return {
     served, routingDecision, taskType, classifiedBy,
     difficulty, difficultyScore, confidence, explain, qualityGate,
   };
+}
+
+// Choose which of the provider's keys serves this request and record the choice on `served`
+// (for dispatch) and `explain` (for the request drawer). Mutates both.
+//
+// Also called again after a budget downgrade, which can change served.provider AFTER
+// resolveRoute has returned — otherwise a key pinned for one provider follows the
+// downgraded model to another.
+function applyCredentialAlias(served, { eff, explain, rulePin, appDbConfig }) {
+  const appPin = appDbConfig?.credentialAliases?.[served.provider] || null;
+  const pinned = rulePin || appPin;
+  const resolved = credentialFor(eff, served.provider, pinned);
+  served.credentialAlias = resolved ? resolved.alias : null;
+  if (pinned && explain) {
+    explain.credential = {
+      requested: pinned,
+      used: served.credentialAlias,
+      source: rulePin ? "rule" : "app",
+      fellBack: !!resolved?.fellBack,
+    };
+  } else if (explain) {
+    delete explain.credential; // a downgrade may have moved us off the pinned provider
+  }
+  return served.credentialAlias;
 }
 
 async function handleChat(req, res) {
@@ -502,7 +564,7 @@ async function handleChat(req, res) {
       setImmediate(() =>
         logger.write({
           requestId, timestamp, ...meta,
-          provider: served.provider, model: served.model, modelRequested,
+          provider: served.provider, credentialAlias: served.credentialAlias, model: served.model, modelRequested,
           taskType, classifiedBy, latencyMs: 0, status: "blocked",
           routingDecision: "budget", cacheHit: false, routingExplain: explain,
         })
@@ -522,7 +584,12 @@ async function handleChat(req, res) {
     if (target && checkModel(target.model, gov).ok) {
       pushOverride(explain, { type: "budget", action: "downgrade", from: served.model, to: target.model,
         cap: { scope: capEngine.describeScope(enf.cap), period: enf.cap.period, limit: enf.cap.limit } });
+      const prevProvider = served.provider, prevAlias = served.credentialAlias;
       served = { provider: target.provider, model: target.model };
+      // The downgrade can cross providers. Same provider: keep the key that was pinned.
+      // Different provider: that key does not belong there, so re-resolve from scratch.
+      if (target.provider === prevProvider) served.credentialAlias = prevAlias;
+      else applyCredentialAlias(served, { eff, explain, rulePin: null, appDbConfig: appCfg });
       routingDecision = "budget";
       qualityGate = null; // budget override is not eval-gated
     }
@@ -647,6 +714,7 @@ async function handleChat(req, res) {
     invocation = await invokeWithFallback(router, eff, {
       provider: served.provider,
       model: served.model,
+      credentialAlias: served.credentialAlias,
       messages: body.messages,
       temperature: body.temperature,
       maxTokens: body.maxTokens,
@@ -656,7 +724,7 @@ async function handleChat(req, res) {
     setImmediate(() =>
       logger.write({
         requestId, timestamp, ...meta,
-        provider: served.provider, model: served.model, modelRequested,
+        provider: served.provider, credentialAlias: served.credentialAlias, model: served.model, modelRequested,
         taskType, classifiedBy, latencyMs: 0, status: "failure", routingDecision,
         errorMessage, routingExplain: explain,
       })
@@ -678,7 +746,7 @@ async function handleChat(req, res) {
       setImmediate(() =>
         logger.write({
           requestId, timestamp, ...meta,
-          provider: result.providerId, model: result.modelId, modelRequested,
+          provider: result.providerId, credentialAlias: servedAlias(served, result.providerId), model: result.modelId, modelRequested,
           taskType, classifiedBy, latencyMs: result.latencyMs,
           status: "blocked", routingDecision, cacheHit: false,
           errorMessage: `guardrail_violation: ${ruleName}`,
@@ -735,7 +803,7 @@ async function handleChat(req, res) {
     }
     logger.write({
       requestId, timestamp, ...meta,
-      provider: result.providerId, model: result.modelId, modelRequested,
+      provider: result.providerId, credentialAlias: servedAlias(served, result.providerId), model: result.modelId, modelRequested,
       taskType, classifiedBy, difficulty, difficultyScore, confidence, routingExplain: explain,
       promptTokens: result.usage?.inputTokens || 0,
       completionTokens: result.usage?.outputTokens || 0,
@@ -759,9 +827,11 @@ module.exports = {
   handleChat,
   resolveRoute,
   resolveExplicit, // pure, exported for tests
+  applyCredentialAlias,
   invokeWithFallback,
   buildFallbackOrder,
   getAppConfig,
+  invalidateAppConfig,
   hasVisionContent, // re-exported from routing/guards for existing tests
   isVisionCapable,
 };

--- a/server/src/gateway/openaiCompat.js
+++ b/server/src/gateway/openaiCompat.js
@@ -3,17 +3,17 @@
 // Routing uses the same precedence logic as /v1/chat; response format is OpenAI-shaped.
 // Streaming (stream: true) uses SSE: "data: {...}\n\n" chunks, ending with "data: [DONE]\n\n".
 const { v4: uuidv4 } = require("uuid");
-const { getRouter } = require("../providers/router");
+const { getRouter, credentialOverrideFor } = require("../providers/router");
 const { extractFinishReason } = require("../providers/llm-router");
 const { normalizeMessages } = require("./normalizeMessages");
 const {
-  resolveRoute, invokeWithFallback, getAppConfig, setGatewayHeaders,
+  resolveRoute, invokeWithFallback, getAppConfig, setGatewayHeaders, applyCredentialAlias,
 } = require("./core");
 const capEngine = require("../routing/capEngine");
 const pricing = require("../pricing/registry");
 const logger = require("../logging/logger");
 const { maybeShadowEval } = require("../eval/shadow");
-const { resolveBaseURL } = require("../providers/connections");
+const { resolveBaseURL, credentialFor } = require("../providers/connections");
 const Settings = require("../models/Settings");
 const outputGuardrail = require("./outputGuardrail");
 const promptInjection = require("./promptInjection");
@@ -66,6 +66,14 @@ function openAICompatBaseURL(providerId, eff) {
     return base ? base.replace(/\/+$/, "") : null;
   }
   return null;
+}
+
+// The key actually exercised by an invocation. invokeWithFallback can end up on a DIFFERENT
+// provider than the one routing chose, and the pinned key belongs to the original provider
+// only — a fallback ran on the new provider's default key. Attributing the pinned alias to
+// it would put spend against a key that never served the request.
+function servedAlias(served, resultProviderId) {
+  return resultProviderId === served.provider ? (served.credentialAlias || null) : null;
 }
 
 const DEMO_503 = {
@@ -159,7 +167,10 @@ async function proxyOpenAICompat(ctx) {
     settings, _reqStart,
   } = ctx;
 
-  const apiKey = eff.providers[served.provider]?.credential?.apiKey || "none";
+  // Honors a rule- or application-pinned key; falls back to the provider default when the
+  // pinned alias no longer exists (resolveRoute has already recorded that it fell back).
+  const apiKey =
+    credentialFor(eff, served.provider, served.credentialAlias)?.credential?.apiKey || "none";
   const url = `${baseURL}/chat/completions`;
   const upstreamBody = { ...body, model: served.model };
   const start = Date.now();
@@ -169,7 +180,7 @@ async function proxyOpenAICompat(ctx) {
     setImmediate(() =>
       logger.write({
         requestId, timestamp, ...meta,
-        provider: served.provider, model: served.model, modelRequested,
+        provider: served.provider, credentialAlias: served.credentialAlias, model: served.model, modelRequested,
         taskType, classifiedBy, difficulty, difficultyScore, confidence, routingDecision, routingExplain, qualityGate: qualityGate || null, cacheHit: false,
         knownPricing: served.knownPricing,
         messages: body.messages,
@@ -423,7 +434,11 @@ async function handleOpenAICompat(req, res) {
     if (target && checkModel(target.model, governanceFor({ appConfig, appDbConfig: appCfg, messages: body.messages })).ok) {
       pushOverride(explain, { type: "budget", action: "downgrade", from: served.model, to: target.model,
         cap: { scope: capEngine.describeScope(enf.cap), period: enf.cap.period, limit: enf.cap.limit } });
+      const prevProvider = served.provider, prevAlias = served.credentialAlias;
       served = { provider: target.provider, model: target.model }; routingDecision = "budget";
+      // Same provider: the pinned key still applies. Crossed providers: it does not.
+      if (target.provider === prevProvider) served.credentialAlias = prevAlias;
+      else applyCredentialAlias(served, { eff, explain, rulePin: null, appDbConfig: appCfg });
       qualityGate = null;
     }
   }
@@ -501,6 +516,9 @@ async function handleOpenAICompat(req, res) {
         modelOverride: served.model,
         temperature: body.temperature,
         maxTokens: body.max_tokens,
+        // Native tool calling bypasses invokeWithFallback entirely, so without this the
+        // pinned key would be silently ignored for every tool-using request.
+        credentialOverride: credentialOverrideFor(eff, served.provider, served.credentialAlias),
       });
       // Turn 1: bind tools. Turn 2 (tool result history, no new tools): plain invoke.
       const boundModel = hasTurnTools ? buildBoundModel(model, body) : model;
@@ -552,7 +570,7 @@ async function handleOpenAICompat(req, res) {
             if (blocked) {
               setImmediate(() => logger.write({
                 requestId, timestamp, ...meta,
-                provider: served.provider, model: served.model, modelRequested,
+                provider: served.provider, credentialAlias: served.credentialAlias, model: served.model, modelRequested,
                 taskType, classifiedBy, latencyMs: Date.now() - start,
                 status: "blocked", routingDecision, routingExplain: explain, qualityGate: qualityGate || null, cacheHit: false,
                 errorMessage: `guardrail_violation: ${ruleName}`,
@@ -592,7 +610,7 @@ async function handleOpenAICompat(req, res) {
           if (blocked) {
             setImmediate(() => logger.write({
               requestId, timestamp, ...meta,
-              provider: served.provider, model: served.model, modelRequested,
+              provider: served.provider, credentialAlias: served.credentialAlias, model: served.model, modelRequested,
               taskType, classifiedBy, latencyMs: Date.now() - start,
               status: "blocked", routingDecision, routingExplain: explain, qualityGate: qualityGate || null, cacheHit: false,
               errorMessage: `guardrail_violation: ${ruleName}`,
@@ -622,7 +640,7 @@ async function handleOpenAICompat(req, res) {
       setImmediate(() =>
         logger.write({
           requestId, timestamp, ...meta,
-          provider: served.provider, model: served.model, modelRequested,
+          provider: served.provider, credentialAlias: served.credentialAlias, model: served.model, modelRequested,
           taskType, classifiedBy, difficulty, difficultyScore, confidence,
           promptTokens, completionTokens, totalTokens, cachedReadTokens, cacheWriteTokens,
           latencyMs: Date.now() - start, gatewayOverheadMs: start - _reqStart, status: "success", routingDecision, routingExplain: explain, qualityGate: qualityGate || null, cacheHit: false,
@@ -635,7 +653,7 @@ async function handleOpenAICompat(req, res) {
       setImmediate(() =>
         logger.write({
           requestId, timestamp, ...meta,
-          provider: served.provider, model: served.model, modelRequested,
+          provider: served.provider, credentialAlias: served.credentialAlias, model: served.model, modelRequested,
           taskType, classifiedBy, latencyMs: Date.now() - start,
           status: "failure", routingDecision, routingExplain: explain, qualityGate: qualityGate || null, cacheHit: false, errorMessage,
         })
@@ -681,6 +699,7 @@ async function handleOpenAICompat(req, res) {
       invocation = await invokeWithFallback(router, eff, {
         provider: served.provider,
         model: served.model,
+        credentialAlias: served.credentialAlias,
         messages: body.messages,
         temperature: body.temperature,
         maxTokens: body.max_tokens,
@@ -692,7 +711,7 @@ async function handleOpenAICompat(req, res) {
       setImmediate(() =>
         logger.write({
           requestId, timestamp, ...meta,
-          provider: served.provider, model: served.model, modelRequested,
+          provider: served.provider, credentialAlias: served.credentialAlias, model: served.model, modelRequested,
           taskType, classifiedBy, latencyMs: Date.now() - start,
           status: "failure", routingDecision, routingExplain: explain, qualityGate: qualityGate || null, cacheHit: false, errorMessage,
         })
@@ -715,7 +734,7 @@ async function handleOpenAICompat(req, res) {
       if (blocked) {
         setImmediate(() => logger.write({
           requestId, timestamp, ...meta,
-          provider: result.providerId, model: result.modelId, modelRequested,
+          provider: result.providerId, credentialAlias: servedAlias(served, result.providerId), model: result.modelId, modelRequested,
           taskType, classifiedBy, latencyMs: Date.now() - start,
           status: "blocked", routingDecision, routingExplain: explain, qualityGate: qualityGate || null, cacheHit: false,
           errorMessage: `guardrail_violation: ${ruleName}`,
@@ -759,7 +778,7 @@ async function handleOpenAICompat(req, res) {
     setImmediate(() =>
       logger.write({
         requestId, timestamp, ...meta,
-        provider: result.providerId, model: result.modelId, modelRequested,
+        provider: result.providerId, credentialAlias: servedAlias(served, result.providerId), model: result.modelId, modelRequested,
         taskType, classifiedBy, difficulty, difficultyScore, confidence,
         promptTokens, completionTokens, totalTokens, cachedReadTokens, cacheWriteTokens,
         latencyMs: Date.now() - start, gatewayOverheadMs: start - _reqStart, status: "success", routingDecision, routingExplain: explain, qualityGate: qualityGate || null, cacheHit: false,
@@ -779,6 +798,7 @@ async function handleOpenAICompat(req, res) {
     invocation = await invokeWithFallback(router, eff, {
       provider: served.provider,
       model: served.model,
+      credentialAlias: served.credentialAlias,
       messages: body.messages,
       temperature: body.temperature,
       maxTokens: body.max_tokens,
@@ -788,7 +808,7 @@ async function handleOpenAICompat(req, res) {
     setImmediate(() =>
       logger.write({
         requestId, timestamp, ...meta,
-        provider: served.provider, model: served.model, modelRequested,
+        provider: served.provider, credentialAlias: served.credentialAlias, model: served.model, modelRequested,
         taskType, classifiedBy, latencyMs: 0, status: "failure", routingDecision, qualityGate: qualityGate || null,
         errorMessage, routingExplain: explain, qualityGate: qualityGate || null,
       })
@@ -806,7 +826,7 @@ async function handleOpenAICompat(req, res) {
     if (blocked) {
       setImmediate(() => logger.write({
         requestId, timestamp, ...meta,
-        provider: result.providerId, model: result.modelId, modelRequested,
+        provider: result.providerId, credentialAlias: servedAlias(served, result.providerId), model: result.modelId, modelRequested,
         taskType, classifiedBy, latencyMs: result.latencyMs,
         status: "blocked", routingDecision, routingExplain: explain, qualityGate: qualityGate || null, cacheHit: false,
         errorMessage: `guardrail_violation: ${ruleName}`,
@@ -836,7 +856,7 @@ async function handleOpenAICompat(req, res) {
   setImmediate(() => {
     logger.write({
       requestId, timestamp, ...meta,
-      provider: result.providerId, model: result.modelId, modelRequested,
+      provider: result.providerId, credentialAlias: servedAlias(served, result.providerId), model: result.modelId, modelRequested,
       taskType, classifiedBy, difficulty, difficultyScore, confidence,
       promptTokens:     result.usage?.inputTokens  || 0,
       completionTokens: result.usage?.outputTokens || 0,

--- a/server/src/gateway/realtimeProxy.js
+++ b/server/src/gateway/realtimeProxy.js
@@ -39,7 +39,9 @@ async function handleRealtimeSession(req, clientWs) {
   let cred;
   try {
     const eff = await connections.effective();
-    cred = eff.providers[provider]?.credential;
+    // Default key: the realtime path resolves its provider from the model, not resolveRoute,
+    // so there is no pin to apply (same known gap as /v1/embeddings).
+    cred = connections.credentialFor(eff, provider, null)?.credential;
   } catch (err) {
     clientWs.close(1013, "Gateway error resolving provider credentials.");
     return;

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -22,6 +22,7 @@ const { handleIngest } = require("./gateway/ingest");
 const { handleUpgrade, closeAll: closeRealtimeSessions } = require("./gateway/wsAuth");
 const { purgeOldRecords } = require("./maintenance/purge");
 const { backfillInternalKind } = require("./maintenance/backfillInternalKind");
+const { migrateCredentialAliases } = require("./maintenance/migrateCredentialAliases");
 const errorAlertMonitor = require("./routing/errorAlertMonitor");
 const canaryMonitor = require("./routing/canaryMonitor");
 const evalWorker = require("./eval/worker");
@@ -73,6 +74,7 @@ async function start() {
   await mongoose.connect(config.mongoUri);
   await registry.init(); // seed ModelEntry if empty + warm in-memory cache
   await backfillInternalKind(); // idempotent; no-op after the first run
+  await migrateCredentialAliases(); // idempotent; drops the pre-multi-key unique provider index
   telemetry.init(); // OTLP trace export — a no-op unless ARBR_OTEL_ENABLED is set
   require("./currency/fx").startAutoRefresh(); // live USD→display-currency rate (no-op for USD)
 

--- a/server/src/maintenance/migrateCredentialAliases.js
+++ b/server/src/maintenance/migrateCredentialAliases.js
@@ -1,0 +1,86 @@
+// One-off migration to the multi-key provider-credential layout.
+//
+// Before: `provider` carried a UNIQUE index, so a provider had exactly one credential.
+// After:  the unique index is {provider, alias}, so a provider can hold several keys and a
+//         routing rule can pin one of them.
+//
+// Two things have to happen, and Mongoose does neither on its own. It will happily declare the
+// new compound index while leaving the old unique `provider_1` in place — and that stale index
+// is what rejects the SECOND key for a provider with a duplicate-key error, long after this code
+// appeared to succeed.
+//
+// Safe to run on every boot:
+//   • idempotent — the backfill predicate stops matching, and the drop is skipped once gone
+//   • matches nothing on a fresh install (the collection does not exist yet)
+//   • concurrent replicas race harmlessly (the loser gets IndexNotFound)
+//
+// Unlike backfillInternalKind, failure here is NOT swallowed quietly. A failed relabel is
+// cosmetic; a failed index drop silently blocks every second key an operator tries to add. It
+// still must not block boot: single-key deploys keep working exactly as they do today.
+const ProviderCredential = require("../models/ProviderCredential");
+
+const LEGACY_INDEX_KEY = JSON.stringify({ provider: 1 });
+const NAMESPACE_NOT_FOUND = 26;
+const INDEX_NOT_FOUND = 27;
+
+async function migrateCredentialAliases() {
+  const out = { backfilled: 0, droppedLegacyIndex: false, error: null };
+  try {
+    // 1. Rows written before `alias` existed are the provider's default key.
+    const { modifiedCount } = await ProviderCredential.updateMany(
+      { $or: [{ alias: { $exists: false } }, { alias: null }, { alias: "" }] },
+      { $set: { alias: "default", isDefault: true } }
+    );
+    out.backfilled = modifiedCount || 0;
+
+    // 2. Drop the legacy single-field unique index.
+    const coll = ProviderCredential.collection;
+    let indexes;
+    try {
+      indexes = await coll.indexes();
+    } catch (err) {
+      // Fresh install: the collection has never been written to, so there is no legacy index
+      // and nothing to backfill. Just make sure the new index exists.
+      if (err.code === NAMESPACE_NOT_FOUND || err.codeName === "NamespaceNotFound") {
+        await ProviderCredential.createIndexes();
+        return out;
+      }
+      throw err;
+    }
+
+    // Match on SHAPE (unique + exactly {provider:1}), not on the name `provider_1`. A
+    // deliberately re-added NON-unique index on provider is legitimate and must survive.
+    const legacy = indexes.find((i) => i.unique && JSON.stringify(i.key) === LEGACY_INDEX_KEY);
+    if (legacy) {
+      try {
+        await coll.dropIndex(legacy.name);
+        out.droppedLegacyIndex = true;
+      } catch (err) {
+        // Another replica dropped it first between our read and our write. Benign.
+        if (err.code !== INDEX_NOT_FOUND && err.codeName !== "IndexNotFound") throw err;
+      }
+    }
+
+    // 3. Build {provider, alias} now rather than waiting on a later autoIndex pass, so the
+    //    very next setCredential() can write a second alias.
+    await ProviderCredential.createIndexes();
+
+    if (out.backfilled || out.droppedLegacyIndex) {
+      console.log(
+        `[migrate] provider credentials: ${out.backfilled} row(s) given alias "default"` +
+        `${out.droppedLegacyIndex ? ", legacy unique provider index dropped" : ""}`
+      );
+    }
+    return out;
+  } catch (err) {
+    console.error(
+      "[migrate] provider-credential alias migration FAILED. Existing credentials keep working, " +
+      "but adding a SECOND key for a provider will fail with a duplicate-key error until this " +
+      "succeeds. Restart to retry. Cause:", err.message
+    );
+    out.error = err.message;
+    return out;
+  }
+}
+
+module.exports = { migrateCredentialAliases };

--- a/server/src/models/ApplicationConfig.js
+++ b/server/src/models/ApplicationConfig.js
@@ -7,6 +7,10 @@ const schema = new mongoose.Schema({
   killSwitchMessage: { type: String, default: null },
   modelOptOut: { type: [String], default: [] },
   aiPolicyAssignments: { type: mongoose.Schema.Types.Mixed, default: null }, // null = use global
+  // { [providerId]: alias } — which provider key this application's traffic uses when no
+  // routing rule pins one. null (or a missing provider) = the provider's default key.
+  // Mixed, like aiPolicyAssignments above, because the keys are dynamic provider ids.
+  credentialAliases: { type: mongoose.Schema.Types.Mixed, default: null },
 }, { collection: "applicationconfigs", timestamps: true });
 
 module.exports = defineModel("ApplicationConfig", schema);

--- a/server/src/models/ProviderCredential.js
+++ b/server/src/models/ProviderCredential.js
@@ -1,13 +1,28 @@
 // A provider credential entered via the dashboard, stored encrypted at rest.
-// One document per provider. The ciphertext holds a JSON credential object
-// ({ apiKey } for apiKey providers; { accessKeyId, secretAccessKey, region } for
-// AWS providers). Secrets never leave the server.
+// MANY documents per provider, one per alias — an operator can hold a prod key and a
+// staging key for the same provider and pin either from a routing rule. The ciphertext
+// holds a JSON credential object ({ apiKey } for apiKey providers; { accessKeyId,
+// secretAccessKey, region } for AWS providers). Secrets never leave the server.
 const mongoose = require("mongoose");
 const { defineModel } = require("../db/context");
 
 const providerCredentialSchema = new mongoose.Schema(
   {
-    provider: { type: String, required: true, unique: true, index: true }, // openai | anthropic | gemini | bedrock-nova
+    // NOT unique and NOT independently indexed: the compound index below is unique on
+    // {provider, alias} and serves a bare find({provider}) as its prefix. Declaring
+    // `index: true` here would ask for a NON-unique `provider_1` while the pre-multi-key
+    // UNIQUE `provider_1` may still exist on disk, and Mongo rejects the pair with
+    // IndexOptionsConflict (85) — surfaced only as an async model `error` event, leaving
+    // every index unbuilt. maintenance/migrateCredentialAliases.js drops the legacy one.
+    provider: { type: String, required: true }, // openai | anthropic | gemini | bedrock-nova
+    // Operator-facing name for this key. Defaults to "default" so pre-multi-key callers
+    // (and the two tests that construct a credential directly) keep working untouched.
+    // "env" is reserved for the credential resolved from environment variables.
+    alias: { type: String, required: true, default: "default", trim: true },
+    // At most one true per provider. Enforced in setDefaultCredential rather than by a
+    // partial unique index: a duplicate degrades harmlessly because compute() sorts
+    // deterministically, and a second index is one more thing to migrate around.
+    isDefault: { type: Boolean, default: false },
     ciphertext: { type: String, required: true },
     iv: { type: String, required: true },
     tag: { type: String, required: true },
@@ -16,5 +31,7 @@ const providerCredentialSchema = new mongoose.Schema(
   },
   { collection: "provider_credentials", timestamps: true }
 );
+
+providerCredentialSchema.index({ provider: 1, alias: 1 }, { unique: true });
 
 module.exports = defineModel("ProviderCredential", providerCredentialSchema);

--- a/server/src/models/RequestRecord.js
+++ b/server/src/models/RequestRecord.js
@@ -30,7 +30,11 @@ const requestRecordSchema = new mongoose.Schema(
     department: { type: String, index: true },
 
     // model — requested vs actually served
-    provider: { type: String, index: true }, // provider served
+    provider: { type: String, index: true },
+    // Which of the provider's keys served this request. Indexed (not tucked into
+    // routingExplain) so spend can be grouped and filtered per key — per-key cost
+    // attribution is usually the reason an operator runs more than one key at all.
+    credentialAlias: { type: String, default: null, index: true }, // provider served
     model: { type: String, index: true },     // model served
     modelRequested: { type: String, index: true },
     taskType: { type: String, index: true },

--- a/server/src/models/Rule.js
+++ b/server/src/models/Rule.js
@@ -15,6 +15,10 @@ const ruleSchema = new mongoose.Schema(
     target: {
       provider: { type: String, required: true },
       model: { type: String, required: true },
+      // Which of the provider's keys to use. null = the provider's default key.
+      // A pin naming a key that has since been deleted is NOT an error: the gateway
+      // falls back to the default key and records that it did.
+      credentialAlias: { type: String, default: null },
     },
     enabled: { type: Boolean, default: false, index: true },
     // Higher priority wins when more than one enabled rule matches a request. Ties

--- a/server/src/providers/connections.js
+++ b/server/src/providers/connections.js
@@ -82,6 +82,49 @@ function resolveBaseURL(providerId, entry) {
   return url ? url.replace(/\/+$/, "") : null;
 }
 
+// Reserved alias for the credential resolved from environment variables. It is never
+// stored, never editable, and always the provider's default when present.
+const ENV_ALIAS = "env";
+const ALIAS_RE = /^[a-z0-9][a-z0-9._-]{0,39}$/;
+
+// Normalize an operator-supplied alias, or throw with a message worth showing.
+//
+// Lowercasing is not cosmetic: MongoDB's unique index compares bytes, so "Prod-EU" and
+// "prod-eu" would happily coexist as two different keys that read identically in the UI
+// and in a rule's target.
+function normalizeAlias(raw) {
+  const alias = String(raw ?? "").trim().toLowerCase();
+  if (!alias) throw new Error("alias is required");
+  if (alias === ENV_ALIAS) {
+    throw new Error(`"${ENV_ALIAS}" is reserved for the credential read from environment variables`);
+  }
+  if (!ALIAS_RE.test(alias)) {
+    throw new Error(
+      "alias must start with a letter or digit and contain only letters, digits, dots, " +
+      "dashes or underscores (max 40 characters)"
+    );
+  }
+  return alias;
+}
+
+// Resolve one provider's credential by alias, against an effective() snapshot.
+//
+// An absent alias asks for the default. An UNKNOWN alias also gets the default, flagged
+// with fellBack — a rule pinning a key that was since deleted or renamed then degrades to
+// exactly today's behaviour instead of failing the request. Callers surface fellBack so the
+// degradation is visible rather than silent.
+//
+// Returns null only when the provider itself is not live. Pure; exported for tests.
+function credentialFor(eff, providerId, alias) {
+  const p = eff?.providers?.[providerId];
+  if (!p) return null;
+  if (alias) {
+    const hit = p.credentials?.[alias];
+    if (hit) return { credential: hit.credential, alias, source: hit.source, fellBack: false };
+  }
+  return { credential: p.credential, alias: p.defaultAlias || null, source: p.source, fellBack: !!alias };
+}
+
 // Decrypt a stored credential doc into a credential object. Handles the legacy
 // shape where the ciphertext was a bare API-key string.
 function decodeStored(doc) {
@@ -100,42 +143,107 @@ function isComplete(id, cred) {
   return required.every((f) => cred[f]);
 }
 
+// Apply the provider's default region to an aws credential that lacks one.
+function withRegionDefault(id, cred) {
+  if (PROVIDERS[id].authType !== "aws" || cred.region) return cred;
+  return { ...cred, region: PROVIDERS[id].regionDefault };
+}
+
+// Which stored key is the provider's default, when env has not already claimed it.
+// Deterministic so a row wrongly carrying isDefault (or two that do) still resolves the
+// same way on every replica and every recompute, instead of following cursor order.
+function byDefaultPreference(a, b) {
+  if (!!b.isDefault !== !!a.isDefault) return b.isDefault ? 1 : -1;
+  const aPlain = a.alias === "default", bPlain = b.alias === "default";
+  if (aPlain !== bPlain) return bPlain ? 1 : -1;
+  const at = a.createdAt ? +new Date(a.createdAt) : 0;
+  const bt = b.createdAt ? +new Date(b.createdAt) : 0;
+  if (at !== bt) return at - bt;
+  return String(a._id).localeCompare(String(b._id));
+}
+
 async function compute() {
-  const stored = {};
+  const storedByProvider = {};
   for (const c of await ProviderCredential.find().lean()) {
-    try { stored[c.provider] = decodeStored(c); } catch { /* skip undecodable */ }
+    try {
+      (storedByProvider[c.provider] ||= []).push({ ...c, cred: decodeStored(c) });
+    } catch { /* skip undecodable */ }
   }
+  for (const rows of Object.values(storedByProvider)) rows.sort(byDefaultPreference);
   const settings = await Settings.get();
 
   const providers = {};
   for (const id of KNOWN_PROVIDERS) {
-    const envCred = envCredentialFor(id);
-    let credential = null, source = null;
-    if (isComplete(id, envCred)) { credential = envCred; source = "env"; }
-    else if (isComplete(id, stored[id])) { credential = stored[id]; source = "stored"; }
-    if (!credential) continue;
-    // Apply region default for aws.
-    if (PROVIDERS[id].authType === "aws" && !credential.region) {
-      credential = { ...credential, region: PROVIDERS[id].regionDefault };
+    const credentials = {};
+    for (const row of storedByProvider[id] || []) {
+      if (!isComplete(id, row.cred)) continue;
+      credentials[row.alias] = {
+        credential: withRegionDefault(id, row.cred),
+        source: "stored",
+        last4: row.last4 || "",
+        region: row.region || null,
+        isDefault: !!row.isDefault,
+        createdAt: row.createdAt || null,
+      };
     }
+
+    // Env is merged LAST and wins unconditionally, exactly as it did before multi-key:
+    // a deploy that sets OPENAI_API_KEY keeps serving that key for unpinned traffic no
+    // matter what is in the database. Merging last also means a legacy row that somehow
+    // holds the reserved alias "env" cannot displace the real environment credential.
+    const envCred = envCredentialFor(id);
+    if (isComplete(id, envCred)) {
+      credentials[ENV_ALIAS] = {
+        credential: withRegionDefault(id, envCred),
+        source: "env",
+        last4: (envCred[primaryField(id)] || "").slice(-4),
+        region: envCred.region || null,
+        isDefault: true,
+        createdAt: null,
+      };
+    }
+
+    const aliases = Object.keys(credentials);
+    if (!aliases.length) continue; // provider not configured at all
+    const defaultAlias = credentials[ENV_ALIAS]
+      ? ENV_ALIAS
+      : (storedByProvider[id] || []).find((r) => credentials[r.alias])?.alias || aliases[0];
+
     providers[id] = {
-      credential,
+      // The DEFAULT key. Every pre-multi-key reader (`eff.providers[x].credential`) keeps
+      // resolving to exactly what it resolved to before, which is what holds this change
+      // to a handful of call sites instead of the whole dispatch layer.
+      credential: credentials[defaultAlias].credential,
       defaultModel: DEFAULT_MODELS[id],
       authType: PROVIDERS[id].authType,
-      source,
+      source: credentials[defaultAlias].source,
+      defaultAlias,
+      credentials,
     };
   }
 
   // Merge user-added custom providers (OpenAI-compat endpoints stored in MongoDB).
+  //
+  // A custom row shadowing a built-in id REPLACES it wholesale, aliases included — it does
+  // not inherit the built-in's keys. That is providerShadowing.test.js's defect at alias
+  // granularity: pinning an alias that only exists on the built-in would pair the built-in's
+  // key with this row's baseURL and post the operator's key to the wrong host. An alias pin
+  // against a shadowed provider resolves to nothing and falls back to this row's own key.
   for (const cp of await CustomProvider.find({ enabled: true }).lean()) {
     try {
       const apiKey = secrets.decrypt(cp);
+      const credential = { apiKey };
       providers[cp.id] = {
-        credential: { apiKey },
+        credential,
         defaultModel: null,
         authType: "apiKey",
         source: "stored",
         baseURL: cp.baseURL,
+        defaultAlias: "default",
+        credentials: {
+          default: { credential, source: "stored", last4: cp.last4 || "", region: null, isDefault: true, createdAt: cp.createdAt || null },
+        },
+        shadowsBuiltin: KNOWN_PROVIDERS.includes(cp.id),
       };
     } catch { /* skip undecodable */ }
   }
@@ -175,27 +283,41 @@ async function effective() {
 
 // Per-provider status for the Settings page (never returns secrets).
 async function statuses() {
-  const storedDocs = {};
-  for (const c of await ProviderCredential.find().lean()) storedDocs[c.provider] = c;
   const settings = await Settings.get();
   const eff = await effective();
 
   const list = KNOWN_PROVIDERS.map((id) => {
     const spec = PROVIDERS[id];
     const live = eff.providers[id];
-    let source = live ? live.source : null;
-    let last4 = "", region = null;
-    if (source === "env") {
-      const envCred = envCredentialFor(id);
-      last4 = (envCred?.[primaryField(id)] || "").slice(-4);
-      region = envCred?.region || null;
-      // Surface that this credential came from a managed secret store —
-      // never the reference itself, just the boolean.
-      if (secretResolver.wasSecretRef(spec.env[primaryField(id)])) source = "secret-manager";
-    } else if (source === "stored") {
-      last4 = storedDocs[id]?.last4 || "";
-      region = storedDocs[id]?.region || null;
-    }
+    // Whether the env credential came from a managed secret store — the boolean only,
+    // never the reference itself.
+    const envIsSecretRef = secretResolver.wasSecretRef(spec.env[primaryField(id)]);
+    const sourceLabel = (s) => (s === "env" && envIsSecretRef ? "secret-manager" : s);
+
+    // One row per key. Env sorts first (it is always the default and cannot be removed),
+    // then stored keys by the same deterministic order compute() used.
+    const entries = Object.entries(live?.credentials || {});
+    const keys = entries
+      .map(([alias, e]) => ({
+        alias,
+        source: sourceLabel(e.source),
+        last4: e.last4 || "",
+        region: e.region || null,
+        isDefault: alias === live.defaultAlias,
+        editable: e.source !== "env",
+        createdAt: e.createdAt || null,
+      }))
+      .sort((a, b) => {
+        if (a.editable !== b.editable) return a.editable ? 1 : -1;
+        if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;
+        return a.alias.localeCompare(b.alias);
+      });
+
+    // These five keep describing the DEFAULT key, byte-identically to pre-multi-key, so
+    // existing console code and any script reading this endpoint is unaffected.
+    const defaultKey = keys.find((k) => k.isDefault) || null;
+    const source = live ? sourceLabel(live.source) : null;
+
     return {
       provider: id,
       label: spec.label,
@@ -203,11 +325,15 @@ async function statuses() {
       fields: spec.fields,
       defaultModel: spec.defaultModel,
       regionDefault: spec.regionDefault || null,
-      configured: !!source,
+      configured: !!live,
       source,
-      editable: source !== "env",
-      last4,
-      region,
+      editable: live ? live.source !== "env" : true,
+      last4: defaultKey?.last4 || "",
+      region: defaultKey?.region || null,
+      // New: the full key list, and whether a custom provider has shadowed this id (in
+      // which case these aliases are inert — see the shadowing note in compute()).
+      keys,
+      shadowedByCustom: !!live?.shadowsBuiltin,
     };
   });
 
@@ -223,11 +349,25 @@ async function statuses() {
   };
 }
 
+// The boot migration (maintenance/migrateCredentialAliases) runs only on the connection that
+// was current at boot. A tenant database provisioned later would never get its legacy unique
+// index dropped, and its second key would fail with an unreadable E11000. Run it once per
+// connection, lazily, on the first write.
+const _migrated = perConnCache();
+async function ensureMigrated() {
+  if (_migrated.get()) return;
+  const { migrateCredentialAliases } = require("../maintenance/migrateCredentialAliases");
+  await migrateCredentialAliases();
+  _migrated.set(true);
+}
+
 // credential: object whose shape depends on the provider's authType.
-async function setCredential(provider, credential) {
+// opts.alias defaults to "default", so the pre-multi-key two-argument call is unchanged.
+async function setCredential(provider, credential, opts = {}) {
   const spec = PROVIDERS[provider];
   if (!spec) throw new Error(`unknown provider "${provider}"`);
   if (!credential || typeof credential !== "object") throw new Error("credential is required");
+  const alias = opts.alias == null ? "default" : normalizeAlias(opts.alias);
 
   const cred = {};
   for (const f of spec.fields) {
@@ -238,18 +378,67 @@ async function setCredential(provider, credential) {
   if (missing.length) throw new Error(`missing fields: ${missing.join(", ")}`);
   if (spec.authType === "aws" && !cred.region) cred.region = spec.regionDefault;
 
+  await ensureMigrated();
+
+  // The provider's first stored key is its default, or the caller asked for it explicitly.
+  const existing = await ProviderCredential.countDocuments({ provider });
+  const makeDefault = !!opts.makeDefault || existing === 0;
+
   const enc = secrets.encrypt(JSON.stringify(cred));
-  await ProviderCredential.findOneAndUpdate(
-    { provider },
-    { $set: { ...enc, last4: (cred[primaryField(provider)] || "").slice(-4), region: cred.region || null } },
-    { upsert: true, new: true, setDefaultsOnInsert: true }
-  );
+  try {
+    if (makeDefault) await ProviderCredential.updateMany({ provider }, { $set: { isDefault: false } });
+    await ProviderCredential.findOneAndUpdate(
+      { provider, alias },
+      { $set: { ...enc, last4: (cred[primaryField(provider)] || "").slice(-4), region: cred.region || null, ...(makeDefault ? { isDefault: true } : {}) } },
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+  } catch (err) {
+    // A duplicate-key error on {provider} rather than {provider, alias} means the legacy
+    // unique index is still on disk. Raw E11000 text is unintelligible here.
+    if (err?.code === 11000) {
+      throw new Error(
+        "Could not save this key: the provider-credential index migration has not completed, " +
+        "so this provider still allows only one key. Restart the server and try again."
+      );
+    }
+    throw err;
+  }
   invalidate();
 }
 
-async function removeCredential(provider) {
-  await ProviderCredential.deleteOne({ provider });
+// No alias removes EVERY stored key for the provider, preserving what
+// DELETE /api/connections/:provider has always meant ("disconnect this provider"). Removing
+// only the default would leave the provider live on a key the operator believed was gone.
+async function removeCredential(provider, alias) {
+  if (alias == null) {
+    await ProviderCredential.deleteMany({ provider });
+    invalidate();
+    return;
+  }
+  const target = await ProviderCredential.findOne({ provider, alias }).lean();
+  if (!target) throw new Error(`no key "${alias}" for provider "${provider}"`);
+  await ProviderCredential.deleteOne({ _id: target._id });
+  // Promote a successor so the provider does not go dark just because its default was removed.
+  if (target.isDefault) {
+    const rest = await ProviderCredential.find({ provider }).lean();
+    const next = rest.sort(byDefaultPreference)[0];
+    if (next) await ProviderCredential.updateOne({ _id: next._id }, { $set: { isDefault: true } });
+  }
   invalidate();
+}
+
+// Mark a stored key as the provider's default. Because an env credential outranks anything
+// in the database, this can succeed while changing nothing that serves traffic — the return
+// value says which key is actually effective so the caller can be honest about it.
+async function setDefaultCredential(provider, alias) {
+  const normalized = normalizeAlias(alias);
+  const target = await ProviderCredential.findOne({ provider, alias: normalized }).lean();
+  if (!target) throw new Error(`no key "${normalized}" for provider "${provider}"`);
+  await ProviderCredential.updateMany({ provider }, { $set: { isDefault: false } });
+  await ProviderCredential.updateOne({ _id: target._id }, { $set: { isDefault: true } });
+  invalidate();
+  const eff = await effective();
+  return { alias: normalized, effectiveDefault: eff.providers[provider]?.defaultAlias || normalized };
 }
 
 async function setDefaultProvider(provider) {
@@ -288,8 +477,12 @@ async function setDefaultModel(model) {
 }
 
 module.exports = {
-  effective, statuses, setCredential, removeCredential, setDefaultProvider, setDefaultModel, invalidate,
+  effective, statuses, setCredential, removeCredential, setDefaultCredential,
+  setDefaultProvider, setDefaultModel, invalidate,
   KNOWN: KNOWN_PROVIDERS,
+  ENV_ALIAS,
   decideDefaultModel, // pure, exported for tests
   resolveBaseURL,     // pure, exported for tests
+  credentialFor,      // pure, exported for tests
+  normalizeAlias,     // pure, exported for tests
 };

--- a/server/src/providers/llm-router/index.js
+++ b/server/src/providers/llm-router/index.js
@@ -43,13 +43,20 @@ function createRouter(options) {
     }
   }
 
-  function getModel({ providerOverride, modelOverride, temperature, maxTokens } = {}) {
+  // credentialOverride swaps in a different key for the SAME provider (a routing rule or an
+  // application pinning one of several keys). It is a partial provider config — {apiKey} or
+  // {region, credentials} — built by providers/router.js so the shape logic lives in one place.
+  function getModel({ providerOverride, modelOverride, temperature, maxTokens, credentialOverride } = {}) {
     const providerId = providerOverride || defaultProvider;
     const cfg = providers[providerId];
     if (!cfg) {
       throw new Error(`getModel: provider "${providerId}" is not configured`);
     }
-    const effectiveCfg = modelOverride ? { ...cfg, model: modelOverride } : cfg;
+    const effectiveCfg = {
+      ...cfg,
+      ...(modelOverride ? { model: modelOverride } : {}),
+      ...(credentialOverride || {}),
+    };
     return loadProviderModel(providerId, effectiveCfg, { temperature, maxTokens });
   }
 
@@ -65,7 +72,15 @@ function createRouter(options) {
     for (const providerId of order) {
       if (!providers[providerId]) continue;
       const baseCfg = providers[providerId];
-      const cfg = args.modelOverride ? { ...baseCfg, model: args.modelOverride } : baseCfg;
+      // A pinned credential belongs to ONE provider. Carrying it down the fallback chain
+      // would post an OpenAI key to Anthropic, so it applies only to the provider the
+      // caller explicitly asked for.
+      const useCredential = args.credentialOverride && providerId === args.providerOverride;
+      const cfg = {
+        ...baseCfg,
+        ...(args.modelOverride ? { model: args.modelOverride } : {}),
+        ...(useCredential ? args.credentialOverride : {}),
+      };
       const start = Date.now();
       try {
         const model = loadProviderModel(providerId, cfg, {

--- a/server/src/providers/router.js
+++ b/server/src/providers/router.js
@@ -8,9 +8,13 @@ let _router = null;
 let _signature = "";
 
 // A signature of the live provider set + creds, so we rebuild only on change.
+//
+// defaultAlias is part of the signature because the credential tail alone is not enough:
+// promote a different key to default and, if the two keys happen to share their last 12
+// serialized characters, the memoized router keeps serving the old one.
 function signatureOf(eff) {
   return eff.liveIds
-    .map((id) => `${id}:${JSON.stringify(eff.providers[id].credential).slice(-12)}`)
+    .map((id) => `${id}:${eff.providers[id].defaultAlias}:${JSON.stringify(eff.providers[id].credential).slice(-12)}`)
     .sort()
     .join("|") + `#default=${eff.defaultProvider}`;
 }
@@ -28,6 +32,25 @@ function toRouterConfig(id, p) {
     };
   }
   return { apiKey: p.credential.apiKey, model: p.defaultModel, baseURL: connections.resolveBaseURL(id, p) };
+}
+
+// The partial router config that swaps in a pinned key for `providerId`, or null when the
+// pin resolves to the key the router already holds — so unpinned traffic passes undefined
+// and takes a code path identical to before multi-key.
+//
+// Reuses toRouterConfig so the apiKey-vs-aws shape is decided in exactly one place; a second
+// copy of that branching is how a pinned AWS key ends up sent as a bearer token.
+function credentialOverrideFor(eff, providerId, alias) {
+  if (!alias) return null;
+  const entry = eff?.providers?.[providerId];
+  if (!entry) return null;
+  const resolved = connections.credentialFor(eff, providerId, alias);
+  if (!resolved || resolved.alias === entry.defaultAlias) return null;
+  const cfg = toRouterConfig(providerId, { ...entry, credential: resolved.credential });
+  // Only the credential fields — model and baseURL still come from the router's own config.
+  return entry.authType === "aws"
+    ? { region: cfg.region, credentials: cfg.credentials }
+    : { apiKey: cfg.apiKey };
 }
 
 // Returns { router, eff } or { router: null, eff } in demo mode.
@@ -52,4 +75,4 @@ async function getRouter() {
   return { router: _router, eff };
 }
 
-module.exports = { getRouter, toRouterConfig };
+module.exports = { getRouter, toRouterConfig, credentialOverrideFor, signatureOf };

--- a/server/src/routing/explainRoute.js
+++ b/server/src/routing/explainRoute.js
@@ -50,6 +50,7 @@ async function explainRoute(input, { eff, appConfig = {}, appDbConfig = null } =
   return {
     model: r.served.model,
     provider: r.served.provider,
+    credentialAlias: r.served.credentialAlias || null,
     routingDecision: r.routingDecision,
     taskType: r.taskType,
     classifiedBy: r.classifiedBy,

--- a/server/src/routing/ruleEngine.js
+++ b/server/src/routing/ruleEngine.js
@@ -66,10 +66,15 @@ function targetServable(rule, eff) {
 //   warn  — model unknown to the registry (served as pass-through, cost logs $0) or
 //           unpriced (same); works, but attribution/enforcement is blind.
 //   ok    — target is live and priced.
-function ruleTargetHealth(target, { liveIds = [], modelEntry = null } = {}) {
-  const { provider, model } = target || {};
+function ruleTargetHealth(target, { liveIds = [], modelEntry = null, aliases = null } = {}) {
+  const { provider, model, credentialAlias } = target || {};
   if (!liveIds.includes(provider)) {
     return { level: "error", reason: "provider-offline", detail: `Provider "${provider}" is not connected; this rule is skipped at request time.` };
+  }
+  // A pinned key that no longer exists is a warning, not an error: the rule still routes,
+  // just on the provider's default key. Silently doing that is the part worth surfacing.
+  if (credentialAlias && aliases && !aliases.includes(credentialAlias)) {
+    return { level: "warn", reason: "alias-unknown", detail: `Provider "${provider}" has no key "${credentialAlias}"; this rule routes on the provider's default key instead.` };
   }
   if (!modelEntry) {
     return { level: "warn", reason: "model-unknown", detail: `Model "${model}" is not in the registry; it is served as a pass-through and its cost logs as $0.` };
@@ -115,6 +120,9 @@ async function findRoute(ctx) {
     return {
       provider: rule.target.provider,
       model: rule.target.model,
+      // An unknown alias deliberately does NOT make the rule unservable — the gateway
+      // falls back to the provider's default key rather than dead-ending the request.
+      credentialAlias: rule.target.credentialAlias || null,
       ruleId: rule._id,
       condition: rule.condition,
       note: rule.note,

--- a/server/src/telemetry/attributes.js
+++ b/server/src/telemetry/attributes.js
@@ -90,6 +90,7 @@ function attributesFor(record, { captureContent = false, contentMaxChars = 8192 
   // status has three values (success|failure|blocked); OTel status has two, so keep it.
   set(a, "arbr.status", record.status);
   set(a, "arbr.internal_kind", record.internalKind);
+  set(a, "arbr.credential_alias", record.credentialAlias);
   set(a, "arbr.source", record.source);
 
   // routingExplain (a Mixed field) flattened to scalars.
@@ -98,6 +99,7 @@ function attributesFor(record, { captureContent = false, contentMaxChars = 8192 
     set(a, "arbr.routing.basis", ex.basis);
     if (ex.rule && ex.rule.note) set(a, "arbr.routing.rule", ex.rule.note);
     if (ex.override && ex.override.type) set(a, "arbr.routing.override_type", ex.override.type);
+    if (ex.credential) set(a, "arbr.routing.credential_source", ex.credential.source);
   }
 
   // Content — opt-in, clamped small. Collectors drop oversized spans, so one long

--- a/server/src/utils/boundedTtlCache.js
+++ b/server/src/utils/boundedTtlCache.js
@@ -52,11 +52,17 @@ function createBoundedTtlCache({ ttlMs, maxEntries }) {
     return value;
   }
 
+  // Drop one key, for an explicit invalidation (an admin edited the thing we cached).
+  // Named `del` because `delete` is a reserved word; exposed under both names.
+  function del(key) {
+    return store.delete(key);
+  }
+
   function clear() {
     store.clear();
   }
 
-  return { getEntry, get, has, set, clear, get size() { return store.size; } };
+  return { getEntry, get, has, set, del, delete: del, clear, get size() { return store.size; } };
 }
 
 module.exports = { createBoundedTtlCache };

--- a/server/test/integration/credentialAliasMigration.test.js
+++ b/server/test/integration/credentialAliasMigration.test.js
@@ -1,0 +1,130 @@
+"use strict";
+// Integration: migrating provider_credentials from one-key-per-provider to many.
+//
+// This is the test that matters most in the multi-key change. Mongoose declares the new
+// {provider, alias} unique index but never drops the old unique {provider} one, and the
+// stale index is what rejects the SECOND key for a provider — with an E11000 that surfaces
+// long after the deploy looked successful. So the assertions here are: the legacy index is
+// gone, a second alias is actually insertable, and running twice changes nothing.
+// Uses MongoMemoryServer; skips cleanly if it cannot start.
+const { test, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const mongoose = require("mongoose");
+
+let mongod, skip = false;
+let ProviderCredential, migrateCredentialAliases, secrets;
+
+const COLL = "provider_credentials";
+
+before(async () => {
+  try {
+    const { MongoMemoryServer } = require("mongodb-memory-server");
+    mongod = await MongoMemoryServer.create();
+    await mongoose.connect(mongod.getUri());
+  } catch (err) {
+    skip = true;
+    console.warn("[credentialAliasMigration] skipping — no in-memory Mongo:", err.message);
+    return;
+  }
+  ProviderCredential = require("../../src/models/ProviderCredential");
+  ({ migrateCredentialAliases } = require("../../src/maintenance/migrateCredentialAliases"));
+  secrets = require("../../src/security/secrets");
+});
+
+after(async () => {
+  if (mongod) { await mongoose.disconnect(); await mongod.stop(); }
+});
+
+// Recreate the pre-multi-key world: a unique index on {provider} alone, and a row with no
+// alias field at all.
+async function seedLegacy() {
+  const db = mongoose.connection.db;
+  await db.collection(COLL).drop().catch(() => {});
+  await db.collection(COLL).createIndex({ provider: 1 }, { unique: true, name: "provider_1" });
+  const enc = secrets.encrypt(JSON.stringify({ apiKey: "sk-legacy" }));
+  await db.collection(COLL).insertOne({
+    provider: "openai", ...enc, last4: "gacy", region: null,
+    createdAt: new Date(), updatedAt: new Date(),
+  });
+}
+
+const indexNames = async () =>
+  (await mongoose.connection.db.collection(COLL).indexes()).map((i) => i.name);
+
+test("backfills alias and drops the legacy unique index", async (t) => {
+  if (skip) return t.skip("no in-memory Mongo");
+  await seedLegacy();
+  assert.ok((await indexNames()).includes("provider_1"), "precondition: legacy index exists");
+
+  const out = await migrateCredentialAliases();
+
+  assert.equal(out.error, null);
+  assert.equal(out.backfilled, 1);
+  assert.equal(out.droppedLegacyIndex, true);
+
+  const row = await ProviderCredential.findOne({ provider: "openai" }).lean();
+  assert.equal(row.alias, "default", "a pre-multi-key row is the provider's default key");
+  assert.equal(row.isDefault, true);
+
+  const names = await indexNames();
+  assert.ok(!names.includes("provider_1"), "the legacy unique index must be gone");
+  assert.ok(names.includes("provider_1_alias_1"), "the compound unique index must exist");
+});
+
+test("a second key for the same provider is insertable afterwards", async (t) => {
+  if (skip) return t.skip("no in-memory Mongo");
+  // The whole point of the migration. Before it, this throws E11000.
+  const enc = secrets.encrypt(JSON.stringify({ apiKey: "sk-second" }));
+  await ProviderCredential.create({ provider: "openai", alias: "staging", ...enc, last4: "cond" });
+  const rows = await ProviderCredential.find({ provider: "openai" }).lean();
+  assert.equal(rows.length, 2);
+  assert.deepEqual(rows.map((r) => r.alias).sort(), ["default", "staging"]);
+});
+
+test("the same alias twice on one provider is still rejected", async (t) => {
+  if (skip) return t.skip("no in-memory Mongo");
+  const enc = secrets.encrypt(JSON.stringify({ apiKey: "sk-dupe" }));
+  await assert.rejects(
+    () => ProviderCredential.create({ provider: "openai", alias: "staging", ...enc }),
+    (err) => err.code === 11000,
+    "the compound index must still enforce uniqueness per (provider, alias)"
+  );
+});
+
+test("the same alias on a DIFFERENT provider is allowed", async (t) => {
+  if (skip) return t.skip("no in-memory Mongo");
+  const enc = secrets.encrypt(JSON.stringify({ apiKey: "sk-ant" }));
+  await ProviderCredential.create({ provider: "anthropic", alias: "staging", ...enc });
+  assert.equal(await ProviderCredential.countDocuments({ alias: "staging" }), 2);
+});
+
+test("a second run is a clean no-op", async (t) => {
+  if (skip) return t.skip("no in-memory Mongo");
+  const before = await ProviderCredential.find().lean();
+  const out = await migrateCredentialAliases();
+  assert.equal(out.error, null);
+  assert.equal(out.backfilled, 0, "nothing left to backfill");
+  assert.equal(out.droppedLegacyIndex, false, "nothing left to drop");
+  const after = await ProviderCredential.find().lean();
+  assert.equal(after.length, before.length);
+  assert.ok((await indexNames()).includes("provider_1_alias_1"));
+});
+
+test("runs cleanly on a fresh install with no collection", async (t) => {
+  if (skip) return t.skip("no in-memory Mongo");
+  await mongoose.connection.db.collection(COLL).drop().catch(() => {});
+  const out = await migrateCredentialAliases();
+  assert.equal(out.error, null, "a missing collection must not be treated as a failure");
+  assert.equal(out.backfilled, 0);
+  assert.equal(out.droppedLegacyIndex, false);
+});
+
+test("a row already carrying an alias is left alone", async (t) => {
+  if (skip) return t.skip("no in-memory Mongo");
+  const enc = secrets.encrypt(JSON.stringify({ apiKey: "sk-keep" }));
+  await ProviderCredential.create({ provider: "gemini", alias: "prod-eu", isDefault: true, ...enc });
+  const out = await migrateCredentialAliases();
+  assert.equal(out.backfilled, 0);
+  const row = await ProviderCredential.findOne({ provider: "gemini" }).lean();
+  assert.equal(row.alias, "prod-eu", "the migration must never rename an existing alias");
+});

--- a/server/test/integration/credentialAliases.test.js
+++ b/server/test/integration/credentialAliases.test.js
@@ -1,0 +1,239 @@
+"use strict";
+// Integration: the named-provider-key API surface.
+//
+// Covers the two things most likely to go wrong operationally: a secret leaking into a
+// response (these routes are the only ones that accept raw credentials), and deleting a key
+// that routing still points at.
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+const mongoose = require("mongoose");
+const express = require("express");
+const supertest = require("supertest");
+
+process.env.ARBR_ADMIN_KEY = "";
+
+const ProviderCredential = require("../../src/models/ProviderCredential");
+const Rule = require("../../src/models/Rule");
+const ApplicationConfig = require("../../src/models/ApplicationConfig");
+const connections = require("../../src/providers/connections");
+const apiRoutes = require("../../src/api/routes");
+
+let mongod, agent;
+
+const stubAdmin = (req, _res, next) => { req.user = { id: "t", email: "t@test", role: "administrator" }; next(); };
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(stubAdmin);
+  app.use("/api", apiRoutes);
+  return app;
+}
+
+// The provider used throughout. Deliberately NOT one with an env credential set in the
+// test environment, so `stored` keys are the ones under test.
+const P = "openai";
+const openaiOf = (body) => body.providers.find((p) => p.provider === P);
+
+before(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  agent = supertest(buildApp());
+});
+
+after(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+beforeEach(async () => {
+  // The developer .env (loaded by dotenv during the requires above) may set OPENAI_API_KEY,
+  // which would add an always-default "env" key to every assertion. Stored keys are what
+  // most of these tests are about; env precedence has its own tests at the bottom, which
+  // set the variable deliberately.
+  delete process.env.OPENAI_API_KEY;
+  await Promise.all([
+    ProviderCredential.deleteMany({}), Rule.deleteMany({}), ApplicationConfig.deleteMany({}),
+  ]);
+  connections.invalidate();
+});
+
+test("the pre-multi-key PUT still writes the alias 'default'", async () => {
+  // Back-compat: existing callers and scripts must keep working untouched.
+  const res = await agent.put(`/api/connections/${P}`).send({ apiKey: "sk-aaaa1111" });
+  assert.equal(res.status, 200);
+  const rows = await ProviderCredential.find({ provider: P }).lean();
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].alias, "default");
+  assert.equal(rows[0].isDefault, true, "the first key is the provider's default");
+});
+
+test("a second key can be added under its own name", async () => {
+  await agent.put(`/api/connections/${P}`).send({ apiKey: "sk-aaaa1111" });
+  const res = await agent.post(`/api/connections/${P}/keys`).send({ alias: "Staging", apiKey: "sk-bbbb2222" });
+  assert.equal(res.status, 200);
+
+  const keys = openaiOf(res.body).keys;
+  assert.deepEqual(keys.map((k) => k.alias).sort(), ["default", "staging"], "aliases are lowercased");
+  assert.equal(keys.find((k) => k.alias === "default").isDefault, true,
+    "adding a key must not silently move the default");
+});
+
+test("no response ever contains a secret, only last4", async () => {
+  await agent.put(`/api/connections/${P}`).send({ apiKey: "sk-fixture-not-a-real-key-9999" });
+  await agent.post(`/api/connections/${P}/keys`).send({ alias: "batch", apiKey: "sk-fixture-not-a-real-key-8888" });
+  const res = await agent.get("/api/connections");
+  const body = JSON.stringify(res.body);
+  assert.ok(!body.includes("sk-fixture-not-a-real-key-9999"), "the stored secret leaked into a response");
+  assert.ok(!body.includes("sk-fixture-not-a-real-key-8888"), "the stored secret leaked into a response");
+  const keys = openaiOf(res.body).keys;
+  assert.deepEqual(keys.map((k) => k.last4).sort(), ["8888", "9999"]);
+});
+
+test("'env' is reserved and rejected as a key name", async () => {
+  const res = await agent.post(`/api/connections/${P}/keys`).send({ alias: "env", apiKey: "sk-x" });
+  assert.equal(res.status, 400);
+  assert.match(res.body.message, /reserved/);
+});
+
+test("a malformed key name is rejected", async () => {
+  for (const alias of ["has space", "-leading", "a/b", ""]) {
+    const res = await agent.post(`/api/connections/${P}/keys`).send({ alias, apiKey: "sk-x" });
+    assert.equal(res.status, 400, `alias ${JSON.stringify(alias)} should be rejected`);
+  }
+});
+
+test("a key can be promoted to default", async () => {
+  await agent.put(`/api/connections/${P}`).send({ apiKey: "sk-aaaa1111" });
+  await agent.post(`/api/connections/${P}/keys`).send({ alias: "batch", apiKey: "sk-bbbb2222" });
+  const res = await agent.put(`/api/connections/${P}/keys/batch/default`);
+  assert.equal(res.status, 200);
+  const keys = openaiOf(res.body).keys;
+  assert.equal(keys.find((k) => k.alias === "batch").isDefault, true);
+  assert.equal(keys.find((k) => k.alias === "default").isDefault, false, "exactly one default");
+});
+
+test("deleting a key a RULE pins is refused, and names the rule", async () => {
+  await agent.put(`/api/connections/${P}`).send({ apiKey: "sk-aaaa1111" });
+  await agent.post(`/api/connections/${P}/keys`).send({ alias: "batch", apiKey: "sk-bbbb2222" });
+  await Rule.create({
+    condition: { taskType: "coding" },
+    target: { provider: P, model: "gpt-4o", credentialAlias: "batch" },
+    enabled: true,
+  });
+
+  const res = await agent.delete(`/api/connections/${P}/keys/batch`);
+  assert.equal(res.status, 409);
+  assert.equal(res.body.error, "alias_in_use");
+  assert.equal(res.body.rules.length, 1);
+  assert.equal(await ProviderCredential.countDocuments({ provider: P, alias: "batch" }), 1,
+    "the key must still exist after a refused delete");
+});
+
+test("deleting a key an APPLICATION pins is refused, and names the application", async () => {
+  await agent.put(`/api/connections/${P}`).send({ apiKey: "sk-aaaa1111" });
+  await agent.post(`/api/connections/${P}/keys`).send({ alias: "batch", apiKey: "sk-bbbb2222" });
+  await ApplicationConfig.create({ applicationName: "billing", credentialAliases: { [P]: "batch" } });
+
+  const res = await agent.delete(`/api/connections/${P}/keys/batch`);
+  assert.equal(res.status, 409);
+  assert.deepEqual(res.body.applications, ["billing"]);
+});
+
+test("force removes a pinned key", async () => {
+  await agent.put(`/api/connections/${P}`).send({ apiKey: "sk-aaaa1111" });
+  await agent.post(`/api/connections/${P}/keys`).send({ alias: "batch", apiKey: "sk-bbbb2222" });
+  await Rule.create({
+    condition: { taskType: "coding" },
+    target: { provider: P, model: "gpt-4o", credentialAlias: "batch" }, enabled: true,
+  });
+  const res = await agent.delete(`/api/connections/${P}/keys/batch?force=1`);
+  assert.equal(res.status, 200);
+  assert.equal(await ProviderCredential.countDocuments({ provider: P, alias: "batch" }), 0);
+});
+
+test("an unpinned key deletes without a confirmation step", async () => {
+  await agent.put(`/api/connections/${P}`).send({ apiKey: "sk-aaaa1111" });
+  await agent.post(`/api/connections/${P}/keys`).send({ alias: "batch", apiKey: "sk-bbbb2222" });
+  const res = await agent.delete(`/api/connections/${P}/keys/batch`);
+  assert.equal(res.status, 200);
+  assert.deepEqual(openaiOf(res.body).keys.map((k) => k.alias), ["default"]);
+});
+
+test("removing the default key promotes a successor rather than going dark", async () => {
+  await agent.put(`/api/connections/${P}`).send({ apiKey: "sk-aaaa1111" });
+  await agent.post(`/api/connections/${P}/keys`).send({ alias: "batch", apiKey: "sk-bbbb2222" });
+  const res = await agent.delete(`/api/connections/${P}/keys/default`);
+  assert.equal(res.status, 200);
+  const keys = openaiOf(res.body).keys;
+  assert.equal(keys.length, 1);
+  assert.equal(keys[0].alias, "batch");
+  assert.equal(keys[0].isDefault, true, "the surviving key must become the default");
+});
+
+test("the pre-multi-key DELETE still disconnects the whole provider", async () => {
+  await agent.put(`/api/connections/${P}`).send({ apiKey: "sk-aaaa1111" });
+  await agent.post(`/api/connections/${P}/keys`).send({ alias: "batch", apiKey: "sk-bbbb2222" });
+  const res = await agent.delete(`/api/connections/${P}`);
+  assert.equal(res.status, 200);
+  assert.equal(await ProviderCredential.countDocuments({ provider: P }), 0,
+    "DELETE /connections/:provider must remove every key, not just the default");
+});
+
+test("replacing a key's secret keeps its name and its pins", async () => {
+  await agent.put(`/api/connections/${P}`).send({ apiKey: "sk-aaaa1111" });
+  await agent.post(`/api/connections/${P}/keys`).send({ alias: "batch", apiKey: "sk-bbbb2222" });
+  const res = await agent.put(`/api/connections/${P}/keys/batch`).send({ apiKey: "sk-cccc3333" });
+  assert.equal(res.status, 200);
+  const key = openaiOf(res.body).keys.find((k) => k.alias === "batch");
+  assert.equal(key.last4, "3333");
+  assert.equal(await ProviderCredential.countDocuments({ provider: P }), 2, "no duplicate row");
+});
+
+// ── env precedence ───────────────────────────────────────────────────────────
+//
+// An environment credential stays the provider's default no matter what is stored, so an
+// existing env-based deploy keeps serving exactly the key it served before multi-key.
+// Stored keys sit alongside it and can be pinned explicitly.
+
+test("an env credential is listed as a reserved, non-editable, always-default key", async () => {
+  process.env.OPENAI_API_KEY = "sk-from-env-7777";
+  connections.invalidate();
+  try {
+    await agent.put(`/api/connections/${P}`).send({ apiKey: "sk-stored-1111" });
+    connections.invalidate();
+    const res = await agent.get("/api/connections");
+    const p = openaiOf(res.body);
+
+    const env = p.keys.find((k) => k.alias === "env");
+    assert.ok(env, "the environment credential should appear as a key");
+    assert.equal(env.isDefault, true, "env outranks anything stored");
+    assert.equal(env.editable, false, "an env key cannot be edited or removed from the console");
+    assert.equal(env.last4, "7777");
+    assert.ok(p.keys.some((k) => k.alias === "default"), "the stored key is still selectable");
+    assert.ok(!JSON.stringify(res.body).includes("sk-from-env-7777"));
+  } finally {
+    delete process.env.OPENAI_API_KEY;
+    connections.invalidate();
+  }
+});
+
+test("promoting a stored key while env is set reports which key is actually effective", async () => {
+  process.env.OPENAI_API_KEY = "sk-from-env-7777";
+  connections.invalidate();
+  try {
+    await agent.put(`/api/connections/${P}`).send({ apiKey: "sk-stored-1111" });
+    await agent.post(`/api/connections/${P}/keys`).send({ alias: "batch", apiKey: "sk-bbbb2222" });
+    // effective() memoizes for 3s. Under load an earlier compute can still be live, so force
+    // a recompute rather than depending on the writes above having invalidated recently.
+    connections.invalidate();
+    const res = await agent.put(`/api/connections/${P}/keys/batch/default`);
+    assert.equal(res.status, 200);
+    // The write succeeded, but env still wins. Saying so is the point — silently accepting
+    // would leave the operator believing traffic had moved.
+    assert.equal(res.body.effectiveDefault, "env");
+  } finally {
+    delete process.env.OPENAI_API_KEY;
+    connections.invalidate();
+  }
+});

--- a/server/test/integration/requestsExport.test.js
+++ b/server/test/integration/requestsExport.test.js
@@ -94,12 +94,13 @@ test("Content-Disposition header is set for attachment download", async () => {
   assert.match(res.headers["content-disposition"], /requests\.csv/);
 });
 
-test("header row contains the expected 21 columns", async () => {
+test("header row contains the expected 22 columns", async () => {
   const res = await agent.get("/api/requests/export");
   const header = res.text.split("\n")[0];
   const cols = header.split(",");
-  assert.equal(cols.length, 21, "21 columns in header");
+  assert.equal(cols.length, 22, "22 columns in header");
   assert.ok(cols.includes("timestamp"), "timestamp column present");
   assert.ok(cols.includes("requestId"), "requestId column present");
   assert.ok(cols.includes("totalCost"), "totalCost column present");
+  assert.ok(cols.includes("credentialAlias"), "credentialAlias column present (which provider key served the request)");
 });

--- a/server/test/integration/routeExplain.test.js
+++ b/server/test/integration/routeExplain.test.js
@@ -91,3 +91,88 @@ test("preview never makes a billable classification (classifiedBy is not 'ai')",
   assert.notEqual(r.classifiedBy, "ai", "dry-run must not invoke the LLM classifier");
   await ruleEngine.setRoutingMode("off");
 });
+
+// ── credential pinning (multi-key) ───────────────────────────────────────────
+//
+// Which of a provider's API keys serves a request: a rule's pin beats an application's,
+// and a pin naming a key that no longer exists degrades to the provider's default key
+// rather than failing the request.
+
+// An eff snapshot carrying two openai keys, shaped as connections.compute() builds it.
+const multiKeyEff = () => ({
+  liveIds: ["openai"], defaultProvider: "openai", defaultModel: "gpt-4o-mini",
+  providers: {
+    openai: {
+      credential: { apiKey: "sk-default" },
+      defaultModel: "gpt-4o-mini", authType: "apiKey", source: "stored",
+      defaultAlias: "default",
+      credentials: {
+        default: { credential: { apiKey: "sk-default" }, source: "stored" },
+        batch: { credential: { apiKey: "sk-batch" }, source: "stored" },
+      },
+    },
+  },
+});
+
+test("with no pin, the provider's default key is recorded and nothing is explained", async (t) => {
+  if (skip) return t.skip("no mongo");
+  const r = await explainRoute({ model: "auto", application: "billing" }, { eff: multiKeyEff() });
+  assert.equal(r.credentialAlias, "default");
+  assert.equal(r.routingExplain.credential, undefined, "no pin means nothing worth narrating");
+});
+
+test("an application-level pin selects that key", async (t) => {
+  if (skip) return t.skip("no mongo");
+  const r = await explainRoute(
+    { model: "auto", application: "billing" },
+    { eff: multiKeyEff(), appDbConfig: { credentialAliases: { openai: "batch" } } }
+  );
+  assert.equal(r.credentialAlias, "batch");
+  assert.equal(r.routingExplain.credential.source, "app");
+  assert.equal(r.routingExplain.credential.fellBack, false);
+});
+
+test("a rule pin beats an application pin", async (t) => {
+  if (skip) return t.skip("no mongo");
+  await Rule.create({
+    condition: { application: "billing" },
+    target: { provider: "openai", model: "gpt-4o", credentialAlias: "default" },
+    enabled: true, priority: 0,
+  });
+  ruleEngine.invalidate();
+  const r = await explainRoute(
+    { model: "auto", application: "billing" },
+    { eff: multiKeyEff(), appDbConfig: { credentialAliases: { openai: "batch" } } }
+  );
+  assert.equal(r.routingDecision, "rule");
+  assert.equal(r.credentialAlias, "default", "the rule's key wins over the application's");
+  assert.equal(r.routingExplain.credential.source, "rule");
+  await Rule.deleteMany({});
+  ruleEngine.invalidate();
+});
+
+test("a pin naming a deleted key falls back to the default and says so", async (t) => {
+  if (skip) return t.skip("no mongo");
+  await Rule.create({
+    condition: { application: "billing" },
+    target: { provider: "openai", model: "gpt-4o", credentialAlias: "deleted-key" },
+    enabled: true, priority: 0,
+  });
+  ruleEngine.invalidate();
+  const r = await explainRoute({ model: "auto", application: "billing" }, { eff: multiKeyEff() });
+  // The request still routes — a deleted key must not take the rule down with it.
+  assert.equal(r.routingDecision, "rule");
+  assert.equal(r.model, "gpt-4o");
+  assert.equal(r.credentialAlias, "default");
+  assert.equal(r.routingExplain.credential.requested, "deleted-key");
+  assert.equal(r.routingExplain.credential.used, "default");
+  assert.equal(r.routingExplain.credential.fellBack, true);
+  await Rule.deleteMany({});
+  ruleEngine.invalidate();
+});
+
+test("an eff with no credentials map (older snapshot) does not throw", async (t) => {
+  if (skip) return t.skip("no mongo");
+  const r = await explainRoute({ model: "auto", application: "billing" }, { eff });
+  assert.equal(r.credentialAlias, null);
+});

--- a/server/test/unit/credentialAlias.test.js
+++ b/server/test/unit/credentialAlias.test.js
@@ -1,0 +1,106 @@
+"use strict";
+// Unit tests for multi-key credential resolution.
+//
+// The property that matters most here is what happens to a pin that no longer resolves.
+// Rules and application configs reference a key by NAME, and a name can be deleted at any
+// time from a different screen. If that dead-ended the request, deleting a key would take
+// down every rule that mentioned it. Instead it falls back to the provider's default key
+// and says so, which is what `fellBack` is for.
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { credentialFor, normalizeAlias } = require("../../src/providers/connections");
+
+// An effective() snapshot as compute() shapes it.
+const eff = {
+  providers: {
+    openai: {
+      credential: { apiKey: "sk-env" }, // == credentials.env, the default
+      defaultModel: "gpt-4o-mini",
+      authType: "apiKey",
+      source: "env",
+      defaultAlias: "env",
+      credentials: {
+        "prod-eu": { credential: { apiKey: "sk-prod" }, source: "stored", last4: "prod" },
+        batch: { credential: { apiKey: "sk-batch" }, source: "stored", last4: "atch" },
+        env: { credential: { apiKey: "sk-env" }, source: "env", last4: "-env" },
+      },
+    },
+    anthropic: {
+      credential: { apiKey: "sk-ant-a" },
+      defaultModel: "claude", authType: "apiKey", source: "stored",
+      defaultAlias: "a",
+      credentials: { a: { credential: { apiKey: "sk-ant-a" }, source: "stored" } },
+    },
+  },
+};
+
+test("an exact alias resolves to that key", () => {
+  const r = credentialFor(eff, "openai", "prod-eu");
+  assert.equal(r.credential.apiKey, "sk-prod");
+  assert.equal(r.alias, "prod-eu");
+  assert.equal(r.fellBack, false);
+});
+
+test("no alias resolves to the provider's default key", () => {
+  const r = credentialFor(eff, "openai", null);
+  assert.equal(r.credential.apiKey, "sk-env");
+  assert.equal(r.alias, "env");
+  // Not a fallback — nothing was asked for, so nothing was missed.
+  assert.equal(r.fellBack, false);
+});
+
+test("an unknown alias falls back to the default key and flags it", () => {
+  const r = credentialFor(eff, "openai", "deleted-last-week");
+  assert.equal(r.credential.apiKey, "sk-env");
+  assert.equal(r.alias, "env");
+  assert.equal(r.fellBack, true, "a dangling pin must be reported, not silently honored");
+});
+
+test("an alias from a DIFFERENT provider does not leak across providers", () => {
+  // "prod-eu" exists on openai but not anthropic. Resolving it against anthropic must
+  // yield anthropic's own key, never openai's.
+  const r = credentialFor(eff, "anthropic", "prod-eu");
+  assert.equal(r.credential.apiKey, "sk-ant-a");
+  assert.equal(r.fellBack, true);
+});
+
+test("a provider that is not live resolves to null", () => {
+  assert.equal(credentialFor(eff, "gemini", "anything"), null);
+  assert.equal(credentialFor(eff, "gemini", null), null);
+});
+
+test("a missing or malformed snapshot does not throw", () => {
+  assert.equal(credentialFor(null, "openai", "x"), null);
+  assert.equal(credentialFor({}, "openai", "x"), null);
+  assert.equal(credentialFor({ providers: {} }, "openai", null), null);
+});
+
+// ── normalizeAlias ───────────────────────────────────────────────────────────
+
+test("aliases are lowercased", () => {
+  // MongoDB's unique index compares bytes, so without this "Prod-EU" and "prod-eu" would
+  // both persist as separate keys that look identical everywhere they are displayed.
+  assert.equal(normalizeAlias("Prod-EU"), "prod-eu");
+  assert.equal(normalizeAlias("  Staging  "), "staging");
+});
+
+test("valid alias shapes are accepted", () => {
+  for (const a of ["default", "prod-eu", "team_1", "v1.2", "a", "0abc"]) {
+    assert.equal(normalizeAlias(a), a);
+  }
+});
+
+test("env is reserved", () => {
+  assert.throws(() => normalizeAlias("env"), /reserved/);
+  assert.throws(() => normalizeAlias("ENV"), /reserved/);
+});
+
+test("invalid aliases are rejected", () => {
+  assert.throws(() => normalizeAlias(""), /required/);
+  assert.throws(() => normalizeAlias(null), /required/);
+  assert.throws(() => normalizeAlias("-leading-dash"), /must start with/);
+  assert.throws(() => normalizeAlias("has space"), /must start with/);
+  assert.throws(() => normalizeAlias("has/slash"), /must start with/);
+  assert.throws(() => normalizeAlias("$ne"), /must start with/);
+  assert.throws(() => normalizeAlias("a".repeat(41)), /must start with/);
+});

--- a/server/test/unit/routerCredentialOverride.test.js
+++ b/server/test/unit/routerCredentialOverride.test.js
@@ -1,0 +1,152 @@
+"use strict";
+// Regression tests for pinning a specific provider key at dispatch time.
+//
+// The failure this guards against: `complete()` walks a fallback chain that can cross
+// providers, so a credentialOverride applied to every candidate would post an OpenAI key
+// to Anthropic. The override must reach the provider it was pinned for and no other.
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { createRouter } = require("../../src/providers/llm-router");
+const { credentialOverrideFor, toRouterConfig } = require("../../src/providers/router");
+
+// ── credentialOverrideFor ────────────────────────────────────────────────────
+
+const eff = {
+  providers: {
+    openai: {
+      credential: { apiKey: "sk-default" },
+      defaultModel: "gpt-4o-mini", authType: "apiKey", source: "stored",
+      defaultAlias: "default",
+      credentials: {
+        default: { credential: { apiKey: "sk-default" }, source: "stored" },
+        batch: { credential: { apiKey: "sk-batch" }, source: "stored" },
+      },
+    },
+    "bedrock-nova": {
+      credential: { accessKeyId: "AKIA-DEF", secretAccessKey: "sec-def", region: "us-east-1" },
+      defaultModel: "us.amazon.nova-lite-v1:0", authType: "aws", source: "stored",
+      defaultAlias: "default",
+      credentials: {
+        default: { credential: { accessKeyId: "AKIA-DEF", secretAccessKey: "sec-def", region: "us-east-1" }, source: "stored" },
+        eu: { credential: { accessKeyId: "AKIA-EU", secretAccessKey: "sec-eu", region: "eu-west-1" }, source: "stored" },
+      },
+    },
+  },
+};
+
+test("no alias produces no override, so unpinned traffic is untouched", () => {
+  assert.equal(credentialOverrideFor(eff, "openai", null), null);
+});
+
+test("pinning the alias that IS the default produces no override", () => {
+  // Passing an override identical to what the router already holds would be harmless but
+  // pointless; returning null keeps the unpinned code path bit-identical.
+  assert.equal(credentialOverrideFor(eff, "openai", "default"), null);
+});
+
+test("a pinned apiKey alias overrides only the key", () => {
+  const o = credentialOverrideFor(eff, "openai", "batch");
+  assert.deepEqual(o, { apiKey: "sk-batch" });
+  // model and baseURL must NOT be in the override — they come from the router's own config,
+  // and overriding the model here would silently defeat modelOverride.
+  assert.equal("model" in o, false);
+  assert.equal("baseURL" in o, false);
+});
+
+test("a pinned aws alias overrides region AND credentials together", () => {
+  // Half-applying this would pair one account's keys with another's region.
+  const o = credentialOverrideFor(eff, "bedrock-nova", "eu");
+  assert.deepEqual(o, {
+    region: "eu-west-1",
+    credentials: { accessKeyId: "AKIA-EU", secretAccessKey: "sec-eu" },
+  });
+});
+
+test("an unknown alias produces no override (falls back to the default key)", () => {
+  assert.equal(credentialOverrideFor(eff, "openai", "no-such-key"), null);
+});
+
+test("an offline provider produces no override", () => {
+  assert.equal(credentialOverrideFor(eff, "gemini", "batch"), null);
+});
+
+// ── complete(): which key actually goes on the wire ──────────────────────────
+//
+// Asserting the Authorization header of each upstream attempt is the only way to prove
+// this. A local server that 400s makes both providers fail, so complete() walks its whole
+// order and we see every key it tried — and rejects fast, with no real network.
+
+const http = require("node:http");
+
+async function withRecordingUpstream(fn) {
+  const seen = [];
+  const server = http.createServer((req, res) => {
+    seen.push(req.headers.authorization || "");
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: { message: "nope", type: "invalid_request_error" } }));
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const base = `http://127.0.0.1:${server.address().port}/v1`;
+  try {
+    // Two OpenAI-wire providers so both take the same ChatOpenAI path and honour baseURL.
+    const router = createRouter({
+      providers: {
+        openai: { apiKey: "sk-openai-default", model: "m1", baseURL: base },
+        deepseek: { apiKey: "sk-deepseek", model: "m2", baseURL: base },
+      },
+      defaultProvider: "openai",
+      fallbackChain: ["deepseek"],
+    });
+    await fn(router, seen);
+  } finally {
+    await new Promise((r) => server.close(r));
+  }
+}
+
+test("a pinned key IS sent for the provider it was pinned for", async () => {
+  await withRecordingUpstream(async (router, seen) => {
+    await assert.rejects(() => router.complete({
+      messages: [{ role: "user", content: "hi" }],
+      providerOverride: "openai",
+      credentialOverride: { apiKey: "sk-PINNED" },
+    }));
+    assert.ok(seen.length > 0, "the upstream should have been called");
+    assert.ok(seen.every((h) => h === "Bearer sk-PINNED"),
+      `expected only the pinned key on the wire, saw ${JSON.stringify(seen)}`);
+  });
+});
+
+test("a pinned key is NOT sent to any provider it was not pinned for", async () => {
+  await withRecordingUpstream(async (router, seen) => {
+    // No providerOverride: complete() walks [default, ...fallbackChain]. The guard
+    // (providerId === args.providerOverride) must keep the override off every one of them
+    // — otherwise a fallback to a different provider ships the wrong vendor's key.
+    await assert.rejects(() => router.complete({
+      messages: [{ role: "user", content: "hi" }],
+      credentialOverride: { apiKey: "sk-PINNED" },
+    }));
+    assert.ok(seen.length >= 2, `expected the fallback chain to be walked, saw ${seen.length} call(s)`);
+    assert.ok(!seen.includes("Bearer sk-PINNED"),
+      `the pinned key leaked to an unpinned provider: ${JSON.stringify(seen)}`);
+    assert.ok(seen.includes("Bearer sk-openai-default"));
+    assert.ok(seen.includes("Bearer sk-deepseek"));
+  });
+});
+
+test("an aws override never carries an apiKey field", () => {
+  // Half-shaped overrides are how an AWS credential ends up sent as a bearer token.
+  const openaiOverride = credentialOverrideFor(eff, "openai", "batch");
+  const bedrockOverride = credentialOverrideFor(eff, "bedrock-nova", "eu");
+  assert.ok("apiKey" in openaiOverride);
+  assert.ok(!("apiKey" in bedrockOverride));
+  assert.ok("credentials" in bedrockOverride);
+});
+
+test("toRouterConfig still reads entry.credential (the default key)", () => {
+  // providerShadowing.test.js depends on this. If toRouterConfig ever starts reading
+  // `credentials` instead, a custom provider shadowing a built-in id can pair one record's
+  // key with another's baseURL again.
+  const cfg = toRouterConfig("openai", eff.providers.openai);
+  assert.equal(cfg.apiKey, "sk-default");
+  assert.equal(cfg.model, "gpt-4o-mini");
+});

--- a/server/test/unit/ruleEngine.test.js
+++ b/server/test/unit/ruleEngine.test.js
@@ -86,3 +86,43 @@ test("ruleTargetHealth: live + priced target is ok", () => {
   const h = ruleTargetHealth({ provider: "openai", model: "gpt-4o" }, { liveIds: ["openai"], modelEntry: { id: "gpt-4o", inputPer1M: 2.5 } });
   assert.equal(h.level, "ok");
 });
+
+// ── credential alias health (multi-key) ──────────────────────────────────────
+
+test("ruleTargetHealth warns when a rule pins a key the provider does not have", () => {
+  // A warn, not an error: the rule still routes, on the provider's default key. Silently
+  // doing that is the part worth surfacing in the console.
+  const h = ruleTargetHealth(
+    { provider: "openai", model: "gpt-4o", credentialAlias: "deleted-key" },
+    { liveIds: ["openai"], modelEntry: { inputPer1M: 1 }, aliases: ["default", "batch"] }
+  );
+  assert.equal(h.level, "warn");
+  assert.equal(h.reason, "alias-unknown");
+});
+
+test("ruleTargetHealth is ok when the pinned key exists", () => {
+  const h = ruleTargetHealth(
+    { provider: "openai", model: "gpt-4o", credentialAlias: "batch" },
+    { liveIds: ["openai"], modelEntry: { inputPer1M: 1 }, aliases: ["default", "batch"] }
+  );
+  assert.equal(h.level, "ok");
+});
+
+test("ruleTargetHealth ignores aliases when the rule pins none", () => {
+  const h = ruleTargetHealth(
+    { provider: "openai", model: "gpt-4o" },
+    { liveIds: ["openai"], modelEntry: { inputPer1M: 1 }, aliases: ["default"] }
+  );
+  assert.equal(h.level, "ok");
+});
+
+test("an offline provider still outranks an unknown alias", () => {
+  // Provider-offline is an error (the rule is skipped entirely); reporting the alias
+  // instead would bury the reason the rule never fires.
+  const h = ruleTargetHealth(
+    { provider: "openai", model: "gpt-4o", credentialAlias: "nope" },
+    { liveIds: [], modelEntry: { inputPer1M: 1 }, aliases: [] }
+  );
+  assert.equal(h.level, "error");
+  assert.equal(h.reason, "provider-offline");
+});

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -214,12 +214,18 @@ export const api = {
   connections: () => req("/connections"),
   setProviderCredential: (provider, credential) => req(`/connections/${provider}`, { method: "PUT", body: JSON.stringify(credential) }),
   removeProviderKey: (provider) => req(`/connections/${provider}`, { method: "DELETE" }),
+  // Named keys. A provider can hold several; routing rules and applications pin one by alias.
+  addProviderKey: (provider, body) => req(`/connections/${provider}/keys`, { method: "POST", body: JSON.stringify(body) }),
+  updateProviderKey: (provider, alias, body) => req(`/connections/${provider}/keys/${encodeURIComponent(alias)}`, { method: "PUT", body: JSON.stringify(body) }),
+  // force skips the "this key is still pinned" check (409) — the caller has seen what uses it.
+  removeProviderKeyAlias: (provider, alias, force) => req(`/connections/${provider}/keys/${encodeURIComponent(alias)}${force ? "?force=1" : ""}`, { method: "DELETE" }),
+  setDefaultProviderKey: (provider, alias) => req(`/connections/${provider}/keys/${encodeURIComponent(alias)}/default`, { method: "PUT" }),
   setDefaultProvider: (provider) => req("/default-provider", { method: "PUT", body: JSON.stringify({ provider }) }),
   setDefaultModel: (model) => req("/default-model", { method: "PUT", body: JSON.stringify({ model }) }),
   getCurrency: () => req("/currency"),
   setCurrencyCode: (currency) => req("/currency", { method: "PUT", body: JSON.stringify({ currency }) }),
   refreshCurrency: () => req("/currency/refresh", { method: "POST" }),
-  testProvider: (provider) => req(`/connections/${provider}/test`, { method: "POST" }),
+  testProvider: (provider, alias) => req(`/connections/${provider}/test${alias ? `?alias=${encodeURIComponent(alias)}` : ""}`, { method: "POST" }),
 
   customProviders: () => req("/custom-providers"),
   addCustomProvider: (body) => req("/custom-providers", { method: "POST", body: JSON.stringify(body) }),

--- a/web/src/components/RequestsTable.jsx
+++ b/web/src/components/RequestsTable.jsx
@@ -68,13 +68,13 @@ function RequestFlow({ r }) {
           : (r.model || "—")}
       />
       <FlowArrow />
-      <FlowNode label="Provider" value={r.provider || "—"} />
+      <FlowNode label="Provider" value={r.provider || "—"} sub={r.credentialAlias} />
       {r.status !== "success" && <span className="shrink-0"><Badge tone="red">{r.status}</Badge></span>}
     </div>
   );
 }
 
-const EMPTY_FILTER = { application: "", workflow: "", department: "", model: "", provider: "", taskType: "", status: "", requestId: "", source: "" };
+const EMPTY_FILTER = { application: "", workflow: "", department: "", model: "", provider: "", credentialAlias: "", taskType: "", status: "", requestId: "", source: "" };
 
 const PERIODS = [
   { label: "Today",    days: 0 },

--- a/web/src/lib/routingNarration.js
+++ b/web/src/lib/routingNarration.js
@@ -40,6 +40,15 @@ export function explainRouting(r) {
       : `No model was pinned and no rule or policy matched, so Arbr served the default model, ${r.model}.`);
   }
 
+  // Which provider key served it, but only when one was actually pinned — saying "used the
+  // default key" on every request would be noise. A pin that fell back is the case worth
+  // reading: the request succeeded, on a different key than the operator asked for.
+  if (x.credential) {
+    lines.push(x.credential.fellBack
+      ? `The ${x.credential.source}-pinned API key "${x.credential.requested}" no longer exists for ${r.provider}, so Arbr used the provider's default key ("${x.credential.used}") instead.`
+      : `The ${x.credential.source} pinned ${r.provider} API key "${x.credential.used}" was used for this request.`);
+  }
+
   // Overrides chain. Older records carry only the single `override`; newer ones
   // carry the whole ordered `overrides`. Narrating every step is what makes a
   // model the caller never asked for traceable back to the rule that picked it.

--- a/web/src/pages/ApplicationDetail.jsx
+++ b/web/src/pages/ApplicationDetail.jsx
@@ -114,8 +114,11 @@ function ModelPicker({ models, excluded, onChange }) {
 // ── Combined routing policy tab ────────────────────────────────────────────────
 // modelOptOut drives both gateway enforcement AND AI generation exclusions.
 
-function RoutingPolicyTab({ appName, initialAssignments, initialModelOptOut, models, onSaved }) {
+function RoutingPolicyTab({ appName, initialAssignments, initialModelOptOut, initialCredentialAliases, models, onSaved }) {
   const [globalPol, setGlobalPol]     = useState(null);
+  const [connections, setConnections] = useState(null);
+  const [aliases, setAliases]         = useState(initialCredentialAliases || {});
+  const [aliasMsg, setAliasMsg]       = useState(null);
   const [assignments, setAssignments] = useState(initialAssignments || null);
   // excluded = opted-out models: blocked at gateway + excluded from AI generation
   const [excluded, setExcluded]       = useState(initialModelOptOut || []);
@@ -131,6 +134,7 @@ function RoutingPolicyTab({ appName, initialAssignments, initialModelOptOut, mod
   const [generatorModel, setGeneratorModel] = useState(null);
 
   useEffect(() => { api.aiPolicy().then(setGlobalPol).catch((e) => setMsg(e.message)); }, []);
+  useEffect(() => { api.connections().then(setConnections).catch(() => setConnections({ providers: [] })); }, []);
 
   if (!globalPol) return <Spinner />;
 
@@ -191,6 +195,29 @@ function RoutingPolicyTab({ appName, initialAssignments, initialModelOptOut, mod
     finally { setBusy(false); }
   };
 
+  const aliasesDirty =
+    JSON.stringify(aliases) !== JSON.stringify(initialCredentialAliases || {});
+
+  const saveAliases = async () => {
+    setBusy(true); setAliasMsg(null);
+    try {
+      await api.setAppConfig(appName, { credentialAliases: aliases });
+      setAliasMsg("Saved"); setTimeout(() => setAliasMsg(null), 1500);
+      onSaved?.();
+    } catch (e) { setAliasMsg(e.message); }
+    finally { setBusy(false); }
+  };
+
+  const setAlias = (provider, alias) => setAliases((a) => {
+    const next = { ...a };
+    if (alias) next[provider] = alias; else delete next[provider];
+    return next;
+  });
+
+  // Only providers holding more than one key are worth showing — everyone else has no choice
+  // to make, and listing them would be a column of disabled dropdowns.
+  const multiKeyProviders = (connections?.providers || []).filter((p) => (p.keys || []).length > 1);
+
   // Generate uses excluded as the exclusion list automatically, optimizing for the chosen goal.
   const generate = async () => {
     setConfirmGen(false);
@@ -244,6 +271,40 @@ function RoutingPolicyTab({ appName, initialAssignments, initialModelOptOut, mod
           {allowedMsg && <span className="text-xs text-gray-500">{allowedMsg}</span>}
         </div>
       </Card>
+
+      {/* ── Section 1b: Provider keys ── */}
+      {multiKeyProviders.length > 0 && (
+        <Card title="Provider keys">
+          <p className="mb-3 text-sm text-gray-500">
+            Which API key this application&rsquo;s traffic uses for each provider. A routing rule that
+            pins a key overrides this; anything left on the default follows the provider&rsquo;s own default key.
+          </p>
+          <div className="space-y-2">
+            {multiKeyProviders.map((p) => (
+              <div key={p.provider} className="flex items-center gap-3">
+                <span className="w-32 shrink-0 text-sm text-arbr-charcoal">{p.label || p.provider}</span>
+                <select
+                  className="input w-64"
+                  value={aliases[p.provider] || ""}
+                  onChange={(e) => setAlias(p.provider, e.target.value)}
+                >
+                  <option value="">(use default)</option>
+                  {(p.keys || []).map((k) => (
+                    <option key={k.alias} value={k.alias}>{k.alias}{k.isDefault ? " (default)" : ""}</option>
+                  ))}
+                </select>
+              </div>
+            ))}
+          </div>
+          <div className="mt-3 flex items-center gap-3">
+            <button className="btn-secondary text-xs" disabled={busy || !aliasesDirty} onClick={saveAliases}>
+              {busy ? "Saving…" : "Save provider keys"}
+            </button>
+            {aliasesDirty && <span className="text-xs text-amber-600">Unsaved changes</span>}
+            {aliasMsg && <span className="text-xs text-gray-500">{aliasMsg}</span>}
+          </div>
+        </Card>
+      )}
 
       {/* ── Section 2: Routing policy ── */}
       <Card title="Routing policy">
@@ -595,6 +656,7 @@ export default function ApplicationDetail() {
             appName={appName}
             initialAssignments={config.aiPolicyAssignments}
             initialModelOptOut={config.modelOptOut || []}
+            initialCredentialAliases={config.credentialAliases || {}}
             models={models}
             onSaved={loadConfig}
           />

--- a/web/src/pages/Models.jsx
+++ b/web/src/pages/Models.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { api, fmt } from "../api.js";
-import { Badge, Card, Spinner } from "../components/ui.jsx";
+import { Badge, Card, Spinner, Table } from "../components/ui.jsx";
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -584,10 +584,18 @@ function ModelList({ providerId, models, onRefresh }) {
 
 // ── ProviderConfigureForm ─────────────────────────────────────────────────────
 
-function ProviderConfigureForm({ provider, onSaved, onCancel }) {
+// mode "add"     — a new named key; the alias is editable.
+// mode "replace" — a new secret for an existing alias; the alias is fixed. There is no
+//                  rename, because renaming would orphan every rule and app pinning it.
+function ProviderConfigureForm({ provider, mode = "add", alias: fixedAlias, onSaved, onCancel }) {
   const isAws = provider.authType === "aws";
+  const storedKeys = (provider.keys || []).filter((k) => k.editable);
   const [form, setForm] = useState({
     apiKey: "", accessKeyId: "", secretAccessKey: "", region: provider.region || "us-east-1",
+    // The provider's first key is called "default" — an operator adding one key should not
+    // have to invent a name for it.
+    alias: fixedAlias || (storedKeys.length ? "" : "default"),
+    makeDefault: storedKeys.length === 0,
   });
   const [saving, setSaving] = useState(false);
   const [err, setErr]       = useState("");
@@ -599,7 +607,11 @@ function ProviderConfigureForm({ provider, onSaved, onCancel }) {
       const cred = isAws
         ? { accessKeyId: form.accessKeyId, secretAccessKey: form.secretAccessKey, region: form.region }
         : { apiKey: form.apiKey };
-      await api.setProviderCredential(provider.provider, cred);
+      if (mode === "replace") {
+        await api.updateProviderKey(provider.provider, fixedAlias, cred);
+      } else {
+        await api.addProviderKey(provider.provider, { ...cred, alias: form.alias, makeDefault: form.makeDefault });
+      }
       onSaved();
     } catch (e) { setErr(e.message); }
     finally { setSaving(false); }
@@ -609,6 +621,26 @@ function ProviderConfigureForm({ provider, onSaved, onCancel }) {
 
   return (
     <form onSubmit={submit} className="space-y-3 p-4 bg-gray-50 rounded-lg border border-gray-200">
+      {mode === "replace" ? (
+        <p className="text-sm text-gray-500">
+          Replacing the secret for key <span className="font-medium text-arbr-charcoal">{fixedAlias}</span>.
+          Rules and applications pinning it keep working.
+        </p>
+      ) : (
+        <Field label="Key name">
+          <input
+            className={INPUT}
+            placeholder="e.g. prod-eu, staging, batch"
+            value={form.alias}
+            onChange={s("alias")}
+            required
+          />
+          <p className="mt-1 text-xs text-gray-400">
+            Lowercase letters, digits, dots, dashes and underscores. Routing rules pin a key by
+            this name, and it cannot be changed later.
+          </p>
+        </Field>
+      )}
       {isAws ? (
         <>
           <Field label="Access Key ID">
@@ -626,6 +658,13 @@ function ProviderConfigureForm({ provider, onSaved, onCancel }) {
           <input type="password" className={INPUT} placeholder="••••••••" value={form.apiKey} onChange={s("apiKey")} required />
         </Field>
       )}
+      {mode === "add" && storedKeys.length > 0 && (
+        <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-600">
+          <input type="checkbox" checked={form.makeDefault}
+            onChange={(e) => setForm({ ...form, makeDefault: e.target.checked })} />
+          Make this the provider&rsquo;s default key
+        </label>
+      )}
       {err && <p className="text-sm text-red-600">{err}</p>}
       <div className="flex gap-2">
         <button type="submit" disabled={saving} className={BTN_PRIMARY}>{saving ? "Saving…" : "Save"}</button>
@@ -639,20 +678,56 @@ function ProviderConfigureForm({ provider, onSaved, onCancel }) {
 
 function BuiltinProviderDetail({ provider, models, onRefresh }) {
   const [configuring, setConfiguring]     = useState(false);
+  const [replacing, setReplacing]         = useState(null); // alias being re-keyed
   const [testResult, setTestResult]       = useState(null);
-  const [testing, setTesting]             = useState(false);
+  const [testing, setTesting]             = useState(null); // alias under test
+  const [busyAlias, setBusyAlias]         = useState(null);
 
-  async function testConn() {
-    setTesting(true); setTestResult(null);
+  const keys = provider.keys || [];
+
+  async function testConn(alias) {
+    setTesting(alias || "__default__"); setTestResult(null);
     try {
-      const r = await api.testProvider(provider.provider);
-      setTestResult(r);
-    } catch { setTestResult({ ok: false, message: "Request failed" }); }
-    finally { setTesting(false); }
+      const r = await api.testProvider(provider.provider, alias);
+      setTestResult({ ...r, alias });
+    } catch { setTestResult({ ok: false, message: "Request failed", alias }); }
+    finally { setTesting(null); }
   }
 
-  async function removeKey() {
-    if (!window.confirm("Remove this credential? Requests to this provider will fail until a new key is added.")) return;
+  async function makeDefault(alias) {
+    setBusyAlias(alias);
+    try {
+      const r = await api.setDefaultProviderKey(provider.provider, alias);
+      // An env credential outranks anything stored, so saying "done" without saying this
+      // would leave the operator believing traffic moved when it did not.
+      if (r?.effectiveDefault && r.effectiveDefault !== alias) {
+        alert(`Saved, but the credential from the environment still takes precedence, so "${r.effectiveDefault}" remains the key actually in use.`);
+      }
+      onRefresh();
+    } catch (e) { alert(e.message); }
+    finally { setBusyAlias(null); }
+  }
+
+  // Two-step delete: the server refuses (409) while a rule or application still pins the
+  // key, and names them, so "delete anyway" is an informed choice rather than a surprise.
+  async function removeKeyAlias(alias) {
+    if (!window.confirm(`Remove key "${alias}"?`)) return;
+    setBusyAlias(alias);
+    try {
+      await api.removeProviderKeyAlias(provider.provider, alias);
+      onRefresh();
+    } catch (e) {
+      if (e.status === 409) {
+        if (window.confirm(`${e.message}\n\nRemove it anyway?`)) {
+          try { await api.removeProviderKeyAlias(provider.provider, alias, true); onRefresh(); }
+          catch (e2) { alert(e2.message); }
+        }
+      } else alert(e.message);
+    } finally { setBusyAlias(null); }
+  }
+
+  async function disconnect() {
+    if (!window.confirm("Remove every stored key for this provider? Requests will fail until a new key is added.")) return;
     try { await api.removeProviderKey(provider.provider); onRefresh(); }
     catch (e) { alert(e.message); }
   }
@@ -669,34 +744,82 @@ function BuiltinProviderDetail({ provider, models, onRefresh }) {
             <StatusDot live={isLive} />
             <span className="text-sm text-gray-500">
               {isLive
-                ? provider.authType === "aws"
-                  ? `AWS · ${provider.region || "us-east-1"}`
-                  : `API key ····${provider.last4}`
+                ? `${keys.length} key${keys.length === 1 ? "" : "s"}${provider.authType === "aws" ? ` · AWS ${provider.region || "us-east-1"}` : ""}`
                 : "Not configured"}
             </span>
           </div>
         </div>
         <div className="flex items-center gap-2">
-          {isLive && !configuring && (
-            <>
-              <button onClick={testConn} disabled={testing} className={BTN_GHOST}>
-                {testing ? "Testing…" : "Test connection"}
-              </button>
-              {provider.editable && (
-                <button onClick={removeKey} className={`${BTN} text-red-600 border border-red-200 hover:bg-red-50`}>Remove key</button>
-              )}
-            </>
+          {isLive && provider.editable && !configuring && (
+            <button onClick={disconnect} className={`${BTN} text-red-600 border border-red-200 hover:bg-red-50`}>Disconnect</button>
           )}
           {!configuring && (
-            <button onClick={() => setConfiguring(true)} className={BTN_PRIMARY}>
-              {isLive ? "Reconfigure" : "Configure"}
+            <button onClick={() => { setReplacing(null); setConfiguring(true); }} className={BTN_PRIMARY}>
+              {isLive ? "Add key" : "Configure"}
             </button>
           )}
         </div>
       </div>
 
+      {provider.shadowedByCustom && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          A custom provider is using the id <span className="font-medium">{provider.provider}</span> and takes
+          precedence, so the keys below are not in use. Remove the custom provider to restore them.
+        </div>
+      )}
+
+      {isLive && (
+        <div>
+          <div className="mb-2 flex items-baseline justify-between">
+            <h3 className="text-sm font-medium text-arbr-charcoal">Keys</h3>
+            <p className="text-xs text-gray-400">Routing rules and applications can pin any of these by name.</p>
+          </div>
+          <Table
+            columns={[
+              { key: "alias", header: "Name", render: (k) => (
+                <span className="flex items-center gap-2">
+                  <span className="font-medium">{k.alias}</span>
+                  {k.isDefault && <Badge tone="green">default</Badge>}
+                </span>
+              ) },
+              { key: "source", header: "Source", render: (k) => (
+                <Badge tone={k.editable ? "charcoal" : "gray"}>{k.source}</Badge>
+              ) },
+              { key: "last4", header: "Secret", render: (k) => (
+                <span className="font-mono text-xs text-gray-500">
+                  {k.last4 ? `····${k.last4}` : "—"}{k.region ? ` · ${k.region}` : ""}
+                </span>
+              ) },
+              { key: "actions", header: "", render: (k) => (
+                <div className="flex items-center justify-end gap-2">
+                  <button onClick={() => testConn(k.alias)} disabled={testing === k.alias} className={BTN_GHOST}>
+                    {testing === k.alias ? "Testing…" : "Test"}
+                  </button>
+                  {k.editable && !k.isDefault && (
+                    <button onClick={() => makeDefault(k.alias)} disabled={busyAlias === k.alias} className={BTN_GHOST}>
+                      Make default
+                    </button>
+                  )}
+                  {k.editable && (
+                    <>
+                      <button onClick={() => { setReplacing(k.alias); setConfiguring(true); }} className={BTN_GHOST}>Replace</button>
+                      <button onClick={() => removeKeyAlias(k.alias)} disabled={busyAlias === k.alias}
+                        className={`${BTN} text-red-600 hover:bg-red-50`}>Remove</button>
+                    </>
+                  )}
+                  {!k.editable && <span className="text-xs text-gray-400">from environment · always default</span>}
+                </div>
+              ) },
+            ]}
+            rows={keys}
+            empty="No keys yet."
+          />
+        </div>
+      )}
+
       {testResult && (
         <div className={`text-sm rounded-lg px-4 py-3 ${testResult.ok ? "bg-arbr-accent-50 text-arbr-accent-800 border border-arbr-accent-200" : "bg-red-50 text-red-700 border border-red-200"}`}>
+          {testResult.alias ? <span className="font-medium">{testResult.alias}: </span> : null}
           {testResult.ok ? `✓ Connected · model: ${testResult.model}${testResult.sample ? ` · "${testResult.sample}"` : ""}` : `✗ ${testResult.message}`}
         </div>
       )}
@@ -704,8 +827,10 @@ function BuiltinProviderDetail({ provider, models, onRefresh }) {
       {configuring && (
         <ProviderConfigureForm
           provider={provider}
-          onSaved={() => { setConfiguring(false); onRefresh(); }}
-          onCancel={() => setConfiguring(false)}
+          mode={replacing ? "replace" : "add"}
+          alias={replacing}
+          onSaved={() => { setConfiguring(false); setReplacing(null); onRefresh(); }}
+          onCancel={() => { setConfiguring(false); setReplacing(null); }}
         />
       )}
 

--- a/web/src/pages/Routing.jsx
+++ b/web/src/pages/Routing.jsx
@@ -142,11 +142,12 @@ function RouteTester() {
   );
 }
 
-function CreateRuleForm({ models, onCreated }) {
+function CreateRuleForm({ models, providerKeys, onCreated }) {
   const [field, setField] = useState("taskType");
   const [value, setValue] = useState("");
   const [provider, setProvider] = useState("");
   const [model, setModel] = useState("");
+  const [credentialAlias, setCredentialAlias] = useState("");
   const [enabled, setEnabled] = useState(true);
   const [priority, setPriority] = useState(0);
   const [busy, setBusy] = useState(false);
@@ -156,8 +157,12 @@ function CreateRuleForm({ models, onCreated }) {
   const providers = [...new Set(models.map((m) => m.provider))];
   const providerModels = models.filter((m) => m.provider === provider);
 
+  // Keys belong to a provider, so switching provider invalidates the chosen key.
+  const keys = providerKeys?.[provider] || [];
+
   useEffect(() => { if (!provider && providers.length) setProvider(providers[0]); }, [models]);
   useEffect(() => { if (providerModels.length) setModel(providerModels[0].id); }, [provider]);
+  useEffect(() => { setCredentialAlias(""); }, [provider]);
 
   const submit = async () => {
     setErr(null); setWarn(null);
@@ -167,7 +172,7 @@ function CreateRuleForm({ models, onCreated }) {
     try {
       const created = await api.createRule({
         condition: { [field]: value.trim() },
-        target: { provider, model },
+        target: { provider, model, credentialAlias: credentialAlias || null },
         enabled,
         priority: Number(priority) || 0,
         note: `${field}=${value.trim()} → ${model}`,
@@ -208,6 +213,15 @@ function CreateRuleForm({ models, onCreated }) {
             {providerModels.map((m) => <option key={m.id} value={m.id}>{m.id} ({m.tier})</option>)}
           </select>
         </div>
+        {keys.length > 1 && (
+          <div>
+            <div className="label mb-1" title="Which of this provider's API keys serves matching requests.">Key</div>
+            <select className="input w-40" value={credentialAlias} onChange={(e) => setCredentialAlias(e.target.value)}>
+              <option value="">(default key)</option>
+              {keys.map((k) => <option key={k.alias} value={k.alias}>{k.alias}{k.isDefault ? " (default)" : ""}</option>)}
+            </select>
+          </div>
+        )}
         <div>
           <div className="label mb-1" title="Higher wins when multiple rules match. Ties break by how specific the rule is.">Priority</div>
           <input className="input w-20" type="number" step="1" value={priority} onChange={(e) => setPriority(e.target.value)} />
@@ -644,6 +658,7 @@ export default function Routing({ onChange }) {
   const [models, setModels] = useState([]);
   const [loadingModels, setLoadingModels] = useState(true);
   const [mode, setMode] = useState("off");
+  const [providerKeys, setProviderKeys] = useState({});
   const [cacheMsg, setCacheMsg] = useState(null);
   const [err, setErr] = useState(null);
 
@@ -651,8 +666,13 @@ export default function Routing({ onChange }) {
     // Only connected providers' CHAT-CAPABLE models — a rule/policy targeting an unconnected
     // provider would never route, and a media/embedding model (e.g. Lyria) can't serve chat.
     // (The Models page manages the full registry; routing targets the live, routable ones.)
-    Promise.all([api.rules(), api.routingMode(), api.models({ live: true, routable: true })])
-      .then(([r, rm, m]) => { setRules(r); setMode(rm.routingMode); setModels(m); })
+    Promise.all([api.rules(), api.routingMode(), api.models({ live: true, routable: true }), api.connections()])
+      .then(([r, rm, m, c]) => {
+        setRules(r); setMode(rm.routingMode); setModels(m);
+        // { providerId: keys[] } — only providers that actually have more than one key
+        // need a picker, so the rule form stays a single row for everyone else.
+        setProviderKeys(Object.fromEntries((c.providers || []).map((p) => [p.provider, p.keys || []])));
+      })
       .catch((e) => setErr(e.message))
       .finally(() => setLoadingModels(false));
   useEffect(() => { load(); }, []);
@@ -692,7 +712,7 @@ export default function Routing({ onChange }) {
               <div className="py-4 text-sm text-gray-500">
                 No connected providers yet. Connect one under <span className="font-medium text-arbr-charcoal">Models</span> to create routing rules.
               </div>
-            ) : <CreateRuleForm models={models} onCreated={load} />}
+            ) : <CreateRuleForm models={models} providerKeys={providerKeys} onCreated={load} />}
           </Card>
 
           <Card title="Rules">
@@ -709,12 +729,18 @@ export default function Routing({ onChange }) {
                   { key: "condition", header: "When", render: (r) => cond(r.condition) },
                   { key: "target", header: "Route to", render: (r) => (
                     <div className="flex items-center gap-2">
-                      <Badge tone="charcoal">{r.target.provider} · {r.target.model}</Badge>
+                      <Badge tone="charcoal">
+                        {r.target.provider} · {r.target.model}
+                        {r.target.credentialAlias ? ` · key: ${r.target.credentialAlias}` : ""}
+                      </Badge>
                       {r.health && r.health.level === "error" && (
                         <span title={r.health.detail}><Badge tone="red">offline</Badge></span>
                       )}
                       {r.health && r.health.level === "warn" && (
-                        <span title={r.health.detail}><Badge tone="amber">{r.health.reason === "unpriced" ? "unpriced" : "unknown"}</Badge></span>
+                        <span title={r.health.detail}><Badge tone="amber">
+                          {r.health.reason === "unpriced" ? "unpriced"
+                            : r.health.reason === "alias-unknown" ? "key missing" : "unknown"}
+                        </Badge></span>
                       )}
                     </div>
                   ) },


### PR DESCRIPTION
## What

A provider can now hold several API keys, each with an operator-chosen name, and routing can pin which one serves a request — from a global rule or per application. Anything unpinned uses a default key, so existing deployments behave exactly as they do today.

Resolution order, first match wins:

1. `rule.target.credentialAlias` — the global Routing page
2. `appConfig.credentialAliases[provider]` — the Application page
3. the provider's default key

## Why

`ProviderCredential.provider` carried a `unique` index, so a provider had exactly one key and a rule targeting `{ provider, model }` had no way to say *which*. Operators holding a prod and a staging key, per-team keys for cost attribution, a high-rate-limit batch key, or region-specific keys had to run one key for everything and lose attribution, or run separate ARBR instances.

## Migration — read before deploying

The unique index moves from `{provider}` to `{provider, alias}`. Mongoose declares the new index but **never drops the old one**, and that stale index is what rejects the *second* key for a provider with an `E11000`, long after the deploy looked successful. `maintenance/migrateCredentialAliases` runs on boot to drop it and backfill existing rows to the alias `default`. It is idempotent, no-ops on a fresh install, and races safely between replicas. It logs loudly on failure but never blocks boot, since single-key deploys keep working either way.

`server/test/integration/credentialAliasMigration.test.js` reproduces a pre-migration database and asserts a second key is actually insertable afterwards.

## Behaviour worth reviewing

- **Environment credentials still win.** An env credential stays the provider's default under the reserved alias `env`, so unpinned traffic on an env-based deploy is untouched. Promoting a stored key while env is set succeeds but reports `effectiveDefault: "env"`, and the console says so rather than implying traffic moved.
- **A dangling pin degrades, it does not fail.** A rule pinning a key that was since deleted falls back to the provider's default and records `fellBack`, surfaced in the request drawer and as a warning badge on the rule. Deleting a key would otherwise retroactively break every rule naming it. Deletion is still refused with a 409 listing what pins it, overridable with `?force=1`.
- **A pinned key never reaches another provider.** `complete()` applies the override only to the explicitly requested provider, and `invokeWithFallback` recomputes per candidate. `routerCredentialOverride.test.js` asserts this against the real `Authorization` header rather than against the code's shape.
- **`eff.providers[id].credential` still means the default key**, which is what held this to 9 call sites instead of the whole dispatch layer. `providerShadowing.test.js` depends on `toRouterConfig` continuing to read it.

## Implementation notes

- `credentialOverride` on the router, not pseudo-provider ids (`openai#prod-eu`). Those would fail `createRouter`'s id validation and leak into `liveIds`, `fallbackChain`, budgets and `RequestRecord.provider`, splitting cost attribution — and the optimisation they'd buy doesn't exist, since `loadProviderModel` builds a fresh client per call anyway.
- Four key-injection points, not three: the fourth is the native tool-calling branch at `openaiCompat.js`, which bypasses `invokeWithFallback` entirely and would have silently ignored every pin.
- `credentialAlias` is an indexed field on `RequestRecord` so spend is groupable per key. Post-invocation writes record nothing when a fallback landed elsewhere; cache hits record nothing because no key was exercised.
- Alias is read-only after creation. Renaming would orphan every pin, so rename is delete-and-add.

## Known gaps

`/v1/embeddings` and the realtime proxy resolve their provider from the model id rather than `resolveRoute`, so both use the provider's default key and ignore pins. Both have `req.apiKey.application` available and could consult `credentialAliases` in a follow-up.

## Testing

Unit 456 pass / 1 fail, integration 197 pass / 6 fail. Every failure is pre-existing on `main` (verified by stashing) — the unit one is a local `.env` setting `ARBR_ADMIN_KEY`, the integration ones are demo-fixture and eval-worker tests. 27 tests added. Console builds clean.

Manual check: add a second key on Models, pin it from a rule, send a matching request, and confirm the Requests drawer attributes it to that key; then delete the key and confirm the request still succeeds on the default with the fallback narrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
