### PR TITLE
Filter requests by provider key

### DIFF
--- a/server/src/analytics/aggregate.js
+++ b/server/src/analytics/aggregate.js
@@ -233,7 +233,7 @@ async function spend({ dimension, value, from, to, includeInternal = false } = {
 // value, or the console offers "filter by Arbr's overhead" as if it were an application.
 async function facets() {
   const customer = RequestRecord.CUSTOMER_ONLY;
-  const [applications, workflows, departments, models, providers, taskTypes, users, keyApps] = await Promise.all([
+  const [applications, workflows, departments, models, providers, taskTypes, users, credentialAliases, keyApps] = await Promise.all([
     RequestRecord.distinct("application", customer),
     RequestRecord.distinct("workflow", customer),
     RequestRecord.distinct("department", customer),
@@ -241,12 +241,19 @@ async function facets() {
     RequestRecord.distinct("provider", customer),
     RequestRecord.distinct("taskType", customer),
     RequestRecord.distinct("userId", customer),
+    // Which provider key served the request. Null on records written before multi-key,
+    // and on cache hits (no key was exercised) — dropped, since "All" already covers them
+    // and a blank dropdown entry reads as a bug.
+    RequestRecord.distinct("credentialAlias", customer),
     ApiKey.distinct("application", { enabled: true, revokedAt: null }),
   ]);
   // Apps that have a key but have never made a request — shown as "newly added".
   const appSet = new Set(applications);
   const newApplications = keyApps.filter((a) => a && !appSet.has(a));
-  return { applications, newApplications, workflows, departments, models, providers, taskTypes, users };
+  return {
+    applications, newApplications, workflows, departments, models, providers, taskTypes, users,
+    credentialAliases: credentialAliases.filter(Boolean).sort(),
+  };
 }
 
 // Per-provider health over the last 24h: error rate and average latency.

--- a/server/test/integration/requestsExport.test.js
+++ b/server/test/integration/requestsExport.test.js
@@ -104,3 +104,41 @@ test("header row contains the expected 22 columns", async () => {
   assert.ok(cols.includes("totalCost"), "totalCost column present");
   assert.ok(cols.includes("credentialAlias"), "credentialAlias column present (which provider key served the request)");
 });
+
+// ── filtering by provider key ────────────────────────────────────────────────
+//
+// Which of a provider's API keys served a request is a filterable dimension, so per-key
+// spend can be isolated in the dashboard and the CSV.
+
+test("facets list the provider keys seen in traffic, without a null entry", async () => {
+  await seedRecord({ application: "app-a", credentialAlias: "prod-eu" });
+  await seedRecord({ application: "app-a", credentialAlias: "batch" });
+  await seedRecord({ application: "app-a", credentialAlias: null }); // unpinned / cache hit
+
+  const facets = (await agent.get("/api/analytics/facets").expect(200)).body;
+  assert.deepEqual(facets.credentialAliases, ["batch", "prod-eu"], "sorted, deduped");
+  // A null would render as a blank option in the filter dropdown and read as a bug.
+  assert.ok(!facets.credentialAliases.includes(null));
+  assert.ok(!facets.credentialAliases.includes(""));
+});
+
+test("requests can be filtered to one provider key", async () => {
+  await seedRecord({ application: "app-a", credentialAlias: "prod-eu", totalCost: 0.5 });
+  await seedRecord({ application: "app-a", credentialAlias: "batch", totalCost: 0.25 });
+  await seedRecord({ application: "app-a", credentialAlias: null, totalCost: 0.1 });
+
+  const res = await agent.get("/api/requests?credentialAlias=prod-eu").expect(200);
+  assert.equal(res.body.items.length, 1);
+  assert.equal(res.body.items[0].credentialAlias, "prod-eu");
+});
+
+test("the CSV export honours the provider-key filter", async () => {
+  await seedRecord({ application: "app-a", credentialAlias: "prod-eu" });
+  await seedRecord({ application: "app-a", credentialAlias: "batch" });
+
+  const res = await agent.get("/api/requests/export?credentialAlias=batch").expect(200);
+  const lines = res.text.trim().split("\n");
+  assert.equal(lines.length, 2, "header + the one matching row");
+  assert.ok(lines[1].includes("batch"));
+  assert.ok(!lines[1].includes("prod-eu"));
+});

--- a/web/src/components/RequestsTable.jsx
+++ b/web/src/components/RequestsTable.jsx
@@ -156,6 +156,9 @@ export default function RequestsTable({ fixedFilters = {}, hiddenFilterKeys = []
     ["model",       "Model",       facets?.models],
     ["provider",    "Provider",    facets?.providers],
     ["taskType",    "Task type",   facets?.taskTypes],
+    // "Provider key", not "Key": this product also has inbound gateway API keys, and a bare
+    // "Key" here would be read as those.
+    ["credentialAlias", "Provider key", facets?.credentialAliases],
   ];
   const visibleFilters = ALL_FILTERS.filter(([key]) => !hiddenFilterKeys.includes(key));
 


### PR DESCRIPTION
Follow-up to #316.

That PR made `credentialAlias` an indexed field and passed it through `buildMatch`, so the API and the CSV export could already filter on it. But the Requests page had no control for it, so per-key attribution was invisible in the place people actually look — you could pin a key from a rule or an application and then have no way to confirm it in the dashboard.

## Changes

- `credentialAliases` added to `analytics.facets()`, so the dropdown populates from keys actually seen in traffic.
- A **Provider key** filter on the Requests page.

Named "Provider key" rather than "Key" on purpose: this product also has inbound gateway API keys, and a bare "Key" sitting next to Provider and Model would be read as those.

Nulls are dropped from the facet. Records predating multi-key have none, and so do cache hits, which exercised no key at all — a blank dropdown entry would read as a bug rather than as "unpinned".

## Not included

Grouping by key is still missing: `analytics.byCredentialAlias` and a **By key** dimension tab, so two keys can be compared side by side instead of filtered one at a time. I left it out to keep this reviewable; happy to add it here or separately. Note the null-heavy distribution needs a deliberate label there, the way `byUser` handles unattributed spend.

## Testing

Three integration tests in `requestsExport.test.js`: the facet is sorted and free of nulls, `/api/requests` narrows to one key, and the CSV export honours the filter. Full suite matches main (unit 456 pass / 1 pre-existing fail; integration failures unchanged). Console builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
