### PR TITLE
docs(security): name the gateway API-key surface in Scope

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,6 +24,9 @@ This project is an LLM gateway and control plane. Areas of particular interest:
 
 - The admin API and dashboard authentication (`ARBR_ADMIN_KEY`, and per-user OIDC /
   trusted-header identity and role-based access control)
+- The gateway (data-plane) API keys that authenticate applications to the endpoints
+  above (`ab_…` gateway keys and read-only `ab_read_…` usage tokens), including key
+  rotation and expiry
 - Encryption of provider credentials at rest (`ARBR_ENCRYPTION_KEY`), and resolution of
   credentials held in a cloud secret manager (`gcp-sm://...` references)
 - The OpenAI-compatible and native gateway endpoints


### PR DESCRIPTION
## What does this PR do?

Adds the **gateway (data-plane) API keys** to `SECURITY.md`'s **Scope** section.

The Scope list already names the admin key + dashboard auth (OIDC / trusted-header / RBAC), provider-credential encryption + secret-manager resolution, the gateway endpoints, and the credential-leak paths — but it never named the primary data-plane credential: the `ab_…` gateway keys (and read-only `ab_read_…` usage tokens) that authenticate applications, carry attribution, and support rotation and expiry.

Evidence in code:
- `ab_…` / `ab_read_…` minting and auth — `server/src/api/routes/keys.js`, `server/src/gateway/auth.js`
- Rotation — `server/src/api/keyRotation.js`, `POST /api/keys/:id/rotate`
- Expiry — `expiresAt` on `server/src/models/ApiKey.js`

This is a distinct credential surface from the admin key and belongs in Scope so vulnerability reports are invited to cover it.

## Type of change

- [x] Documentation

## Checklist

- [x] No API keys, `.env` values, or secrets are committed
- [x] Commits follow Conventional Commits format
- [x] Docs-only change; no user-facing behaviour affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ouu8akfrv4QgVhknMqf5M

---
_Generated by [Claude Code](https://claude.ai/code/session_011ouu8akfrv4QgVhknMqf5M)_