### PR TITLE
docs(api-reference): list the `user` cap dimension

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -160,7 +160,7 @@ Create a budget cap.
 }
 ```
 
-`dimension` options: `application`, `provider`, `department`, `workflow`, `model`. Omit for a global cap.
+`dimension` options: `application`, `provider`, `department`, `workflow`, `model`, `user`. Omit for a global cap.
 `action` options: `alert`, `downgrade`, `block`.
 
 ### `PATCH /api/caps/:id`


### PR DESCRIPTION
## What does this PR do?

Adds the missing `user` option to the `POST /api/caps` **`dimension`** list in `docs/api-reference.md`.

The route accepts six dimensions:

```js
// server/src/api/routes/caps.js:25
const allowed = ["application", "provider", "department", "workflow", "model", "user"];
```

…but the docs listed only five (`application`, `provider`, `department`, `workflow`, `model`). This aligns the documented set with the values the endpoint actually accepts.

> Note (not addressed here, flagged for maintainers): the `Cap.metric` field (`"spend" | "requests"`, #259) is enforced by `routing/capEngine.js` but is not read by `POST`/`PATCH /api/caps` nor set anywhere from user input, so a request-count cap can't currently be created through the API or UI. That's a code-behaviour question rather than a docs fix, so it's intentionally left out of this PR.

## Type of change

- [x] Documentation

## Checklist

- [x] No API keys, `.env` values, or secrets are committed
- [x] Commits follow Conventional Commits format
- [x] Docs-only change; no user-facing behaviour affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ouu8akfrv4QgVhknMqf5M

---
_Generated by [Claude Code](https://claude.ai/code/session_011ouu8akfrv4QgVhknMqf5M)_